### PR TITLE
Allow resetting of the congestion controller

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1305,6 +1305,21 @@ impl Connection {
         self.path.congestion.as_ref()
     }
 
+    /// Resets the congestion controller and round-trip estimator for the current path.
+    ///
+    /// This force-resets the congestion controller and round-trip estimator for the current
+    /// path.
+    pub fn reset_congestion_state(&mut self) {
+        let now = Instant::now();
+        self.path.rtt = RttEstimator::new(self.config.initial_rtt);
+        self.path.congestion = self
+            .config
+            .congestion_controller_factory
+            .clone()
+            .build(now, self.config.get_initial_mtu());
+        // TODO: probably needs MTU discovery reset as well.
+    }
+
     /// Modify the number of remotely initiated streams that may be concurrently open
     ///
     /// No streams may be opened by the peer unless fewer than `count` are already open. Large

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -160,7 +160,7 @@ pub struct RttEstimator {
 }
 
 impl RttEstimator {
-    fn new(initial_rtt: Duration) -> Self {
+    pub(super) fn new(initial_rtt: Duration) -> Self {
         Self {
             latest: initial_rtt,
             smoothed: None,

--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -72,7 +72,7 @@ pub use udp;
 
 pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagramError,
-    ZeroRttAccepted,
+    WeakConnectionHandle, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};


### PR DESCRIPTION
This gives access to a low-level handle for a connection which allows resetting of the congestion controller state.  This is helpful when there is out-of-band knowledge about changes to the underlying network path.