### PR TITLE
QUIC Address discovery extension

### DIFF
--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -39,9 +39,9 @@ impl TryFrom<VarInt> for Role {
 
     fn try_from(value: VarInt) -> Result<Self, Self::Error> {
         match value.0 {
-            0 => Ok(Role::ProvideReportsOnly),
-            1 => Ok(Role::ReceiveReportsOnly),
-            2 => Ok(Role::Both),
+            0 => Ok(Self::ProvideReportsOnly),
+            1 => Ok(Self::ReceiveReportsOnly),
+            2 => Ok(Self::Both),
             _ => Err(crate::transport_parameters::Error::IllegalValue),
         }
     }
@@ -50,21 +50,21 @@ impl TryFrom<VarInt> for Role {
 impl Role {
     /// Whether address discovery is disabled.
     pub(crate) fn is_disabled(&self) -> bool {
-        matches!(self, Role::Disabled)
+        matches!(self, Self::Disabled)
     }
 
     /// Whether this peer's role allows for address reporting to other peers.
     fn is_reporter(&self) -> bool {
-        matches!(self, Role::ProvideReportsOnly | Role::Both)
+        matches!(self, Self::ProvideReportsOnly | Self::Both)
     }
 
     /// Whether this peer's role allows to receive observed address reports.
     fn receives_reports(&self) -> bool {
-        matches!(self, Role::ReceiveReportsOnly | Role::Both)
+        matches!(self, Self::ReceiveReportsOnly | Self::Both)
     }
 
     /// Whether this peer should report observed addresses to other peers.
-    pub(crate) fn should_report(&self, other: &Role) -> bool {
+    pub(crate) fn should_report(&self, other: &Self) -> bool {
         self.is_reporter() && other.receives_reports()
     }
 
@@ -80,20 +80,20 @@ impl Role {
     /// Enables reporting of observed addresses to other peers.
     fn enable_reports_to_peers(&mut self) {
         match self {
-            Role::ProvideReportsOnly => {} // already enabled
-            Role::ReceiveReportsOnly => *self = Role::Both,
-            Role::Both => {} // already enabled
-            Role::Disabled => *self = Role::ProvideReportsOnly,
+            Self::ProvideReportsOnly => {} // already enabled
+            Self::ReceiveReportsOnly => *self = Self::Both,
+            Self::Both => {} // already enabled
+            Self::Disabled => *self = Self::ProvideReportsOnly,
         }
     }
 
     /// Disables reporting of observed addresses to other peers.
     fn disable_reports_to_peers(&mut self) {
         match self {
-            Role::ProvideReportsOnly => *self = Role::Disabled,
-            Role::ReceiveReportsOnly => {} // already disabled
-            Role::Both => *self = Role::ReceiveReportsOnly,
-            Role::Disabled => {} // already disabled
+            Self::ProvideReportsOnly => *self = Self::Disabled,
+            Self::ReceiveReportsOnly => {} // already disabled
+            Self::Both => *self = Self::ReceiveReportsOnly,
+            Self::Disabled => {} // already disabled
         }
     }
 
@@ -110,20 +110,20 @@ impl Role {
     /// Enables accepting reports of observed addresses from other peers.
     fn enable_receiving_reports_from_peers(&mut self) {
         match self {
-            Role::ProvideReportsOnly => *self = Role::Both,
-            Role::ReceiveReportsOnly => {} // already enabled
-            Role::Both => {}               // already enabled
-            Role::Disabled => *self = Role::ReceiveReportsOnly,
+            Self::ProvideReportsOnly => *self = Self::Both,
+            Self::ReceiveReportsOnly => {} // already enabled
+            Self::Both => {}               // already enabled
+            Self::Disabled => *self = Self::ReceiveReportsOnly,
         }
     }
 
     /// Disables accepting reports of observed addresses from other peers.
     fn disable_receiving_reports_from_peers(&mut self) {
         match self {
-            Role::ProvideReportsOnly => {} // already disabled
-            Role::ReceiveReportsOnly => *self = Role::Disabled,
-            Role::Both => *self = Role::ProvideReportsOnly,
-            Role::Disabled => {} // already disabled
+            Self::ProvideReportsOnly => {} // already disabled
+            Self::ReceiveReportsOnly => *self = Self::Disabled,
+            Self::Both => *self = Self::ProvideReportsOnly,
+            Self::Disabled => {} // already disabled
         }
     }
 }

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -44,6 +44,14 @@ impl TryFrom<VarInt> for Role {
 }
 
 impl Role {
+    pub(crate) fn new(is_observer: bool, is_observee: bool) -> Option<Self> {
+        match (is_observer, is_observee) {
+            (true, true) => Some(Role::Both),
+            (true, false) => Some(Role::Observer),
+            (false, true) => Some(Role::Observee),
+            (false, false) => None,
+        }
+    }
     /// Whether this peer's role allows for address reporting to other peers.
     fn is_reporter(&self) -> bool {
         matches!(self, Role::Observer | Role::Both)

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -1,6 +1,10 @@
 //! Address discovery types from
 //! <https://datatracker.ietf.org/doc/draft-seemann-quic-address-discovery/>
 
+use crate::VarInt;
+
+pub(crate) const TRANSPORT_PARAMETER_CODE: u64 = 0x9f81a174;
+
 /// The role of each participant.
 ///
 /// When enabled, this is reported as a transport parameter.
@@ -14,4 +18,27 @@ pub(crate) enum Role {
     Oservee,
     /// Will both report and receive reports of observed addresses.
     Both,
+}
+
+impl From<Role> for VarInt {
+    fn from(role: Role) -> Self {
+        match role {
+            Role::Observer => VarInt(0),
+            Role::Oservee => VarInt(1),
+            Role::Both => VarInt(2),
+        }
+    }
+}
+
+impl TryFrom<VarInt> for Role {
+    type Error = crate::transport_parameters::Error;
+
+    fn try_from(value: VarInt) -> Result<Self, Self::Error> {
+        match value.0 {
+            0 => Ok(Role::Observer),
+            1 => Ok(Role::Oservee),
+            2 => Ok(Role::Both),
+            _ => Err(crate::transport_parameters::Error::IllegalValue)
+        }
+    }
 }

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -15,7 +15,7 @@ pub(crate) enum Role {
     Observer,
     /// Is interested on reports about its own observed address, but will not report back to other
     /// peers.
-    Oservee,
+    Observee,
     /// Will both report and receive reports of observed addresses.
     Both,
 }
@@ -24,7 +24,7 @@ impl From<Role> for VarInt {
     fn from(role: Role) -> Self {
         match role {
             Role::Observer => VarInt(0),
-            Role::Oservee => VarInt(1),
+            Role::Observee => VarInt(1),
             Role::Both => VarInt(2),
         }
     }
@@ -36,9 +36,9 @@ impl TryFrom<VarInt> for Role {
     fn try_from(value: VarInt) -> Result<Self, Self::Error> {
         match value.0 {
             0 => Ok(Role::Observer),
-            1 => Ok(Role::Oservee),
+            1 => Ok(Role::Observee),
             2 => Ok(Role::Both),
-            _ => Err(crate::transport_parameters::Error::IllegalValue)
+            _ => Err(crate::transport_parameters::Error::IllegalValue),
         }
     }
 }

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -119,10 +119,10 @@ impl Role {
     /// Gives the [`VarInt`] representing this [`Role`] as a transport parameter.
     pub(crate) fn as_transport_parameter(&self) -> Option<VarInt> {
         match self {
-            Role::ProvideOnly => Some(VarInt(0)),
-            Role::ReceivesOnly => Some(VarInt(1)),
-            Role::Both => Some(VarInt(2)),
-            Role::Disabled => None,
+            Self::ProvideOnly => Some(VarInt(0)),
+            Self::ReceivesOnly => Some(VarInt(1)),
+            Self::Both => Some(VarInt(2)),
+            Self::Disabled => None,
         }
     }
 }

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -23,17 +23,6 @@ pub(crate) enum Role {
     Disabled,
 }
 
-impl From<Role> for Option<VarInt> {
-    fn from(role: Role) -> Self {
-        match role {
-            Role::ProvideOnly => Some(VarInt(0)),
-            Role::ReceivesOnly => Some(VarInt(1)),
-            Role::Both => Some(VarInt(2)),
-            Role::Disabled => None,
-        }
-    }
-}
-
 impl TryFrom<VarInt> for Role {
     type Error = crate::transport_parameters::Error;
 
@@ -124,6 +113,16 @@ impl Role {
             Self::ReceivesOnly => *self = Self::Disabled,
             Self::Both => *self = Self::ProvideOnly,
             Self::Disabled => {} // already disabled
+        }
+    }
+
+    /// Gives the [`VarInt`] representing this [`Role`] as a transport parameter.
+    pub(crate) fn as_transport_parameter(&self) -> Option<VarInt> {
+        match self {
+            Role::ProvideOnly => Some(VarInt(0)),
+            Role::ReceivesOnly => Some(VarInt(1)),
+            Role::Both => Some(VarInt(2)),
+            Role::Disabled => None,
         }
     }
 }

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -3,7 +3,7 @@
 
 use crate::VarInt;
 
-pub(crate) const TRANSPORT_PARAMETER_CODE: u64 = 0x9f81a174;
+pub(crate) const TRANSPORT_PARAMETER_CODE: u64 = 0x9f81a175;
 
 /// The role of each participant.
 ///

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -3,7 +3,7 @@
 
 use crate::VarInt;
 
-pub(crate) const TRANSPORT_PARAMETER_CODE: u64 = 0x9f81a175;
+pub(crate) const TRANSPORT_PARAMETER_CODE: u64 = 0x9f81a176;
 
 /// The role of each participant.
 ///

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -8,24 +8,28 @@ pub(crate) const TRANSPORT_PARAMETER_CODE: u64 = 0x9f81a174;
 /// The role of each participant.
 ///
 /// When enabled, this is reported as a transport parameter.
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
 pub(crate) enum Role {
     /// Is able to report observer addresses to other peers, but it's not interested in receiving
     /// reports about its own address.
-    Observer,
+    ProvideReportsOnly,
     /// Is interested on reports about its own observed address, but will not report back to other
     /// peers.
-    Observee,
+    ReceiveReportsOnly,
     /// Will both report and receive reports of observed addresses.
     Both,
+    /// Address discovery is disabled.
+    #[default]
+    Disabled,
 }
 
-impl From<Role> for VarInt {
+impl From<Role> for Option<VarInt> {
     fn from(role: Role) -> Self {
         match role {
-            Role::Observer => VarInt(0),
-            Role::Observee => VarInt(1),
-            Role::Both => VarInt(2),
+            Role::ProvideReportsOnly => Some(VarInt(0)),
+            Role::ReceiveReportsOnly => Some(VarInt(1)),
+            Role::Both => Some(VarInt(2)),
+            Role::Disabled => None,
         }
     }
 }
@@ -35,8 +39,8 @@ impl TryFrom<VarInt> for Role {
 
     fn try_from(value: VarInt) -> Result<Self, Self::Error> {
         match value.0 {
-            0 => Ok(Role::Observer),
-            1 => Ok(Role::Observee),
+            0 => Ok(Role::ProvideReportsOnly),
+            1 => Ok(Role::ReceiveReportsOnly),
             2 => Ok(Role::Both),
             _ => Err(crate::transport_parameters::Error::IllegalValue),
         }
@@ -44,26 +48,82 @@ impl TryFrom<VarInt> for Role {
 }
 
 impl Role {
-    pub(crate) fn new(is_observer: bool, is_observee: bool) -> Option<Self> {
-        match (is_observer, is_observee) {
-            (true, true) => Some(Role::Both),
-            (true, false) => Some(Role::Observer),
-            (false, true) => Some(Role::Observee),
-            (false, false) => None,
-        }
+    /// Whether address discovery is disabled.
+    pub(crate) fn is_disabled(&self) -> bool {
+        matches!(self, Role::Disabled)
     }
+
     /// Whether this peer's role allows for address reporting to other peers.
     fn is_reporter(&self) -> bool {
-        matches!(self, Role::Observer | Role::Both)
+        matches!(self, Role::ProvideReportsOnly | Role::Both)
     }
 
     /// Whether this peer's role allows to receive observed address reports.
     fn receives_reports(&self) -> bool {
-        matches!(self, Role::Observee | Role::Both)
+        matches!(self, Role::ReceiveReportsOnly | Role::Both)
     }
 
-    /// Whether this peer should report observed addresses to other peer.
+    /// Whether this peer should report observed addresses to other peers.
     pub(crate) fn should_report(&self, other: &Role) -> bool {
         self.is_reporter() && other.receives_reports()
+    }
+
+    /// Sets whether this peer should provide observed addresses to other peers.
+    pub(crate) fn provide_reports_to_peers(&mut self, provide: bool) {
+        if provide {
+            self.enable_reports_to_peers()
+        } else {
+            self.disable_reports_to_peers()
+        }
+    }
+
+    /// Enables reporting of observed addresses to other peers.
+    fn enable_reports_to_peers(&mut self) {
+        match self {
+            Role::ProvideReportsOnly => {} // already enabled
+            Role::ReceiveReportsOnly => *self = Role::Both,
+            Role::Both => {} // already enabled
+            Role::Disabled => *self = Role::ProvideReportsOnly,
+        }
+    }
+
+    /// Disables reporting of observed addresses to other peers.
+    fn disable_reports_to_peers(&mut self) {
+        match self {
+            Role::ProvideReportsOnly => *self = Role::Disabled,
+            Role::ReceiveReportsOnly => {} // already disabled
+            Role::Both => *self = Role::ReceiveReportsOnly,
+            Role::Disabled => {} // already disabled
+        }
+    }
+
+    /// Sets whether this peer should accept received reports of observed addresses from other
+    /// peers.
+    pub(crate) fn receive_reports_from_peers(&mut self, receive: bool) {
+        if receive {
+            self.enable_receiving_reports_from_peers()
+        } else {
+            self.disable_receiving_reports_from_peers()
+        }
+    }
+
+    /// Enables accepting reports of observed addresses from other peers.
+    fn enable_receiving_reports_from_peers(&mut self) {
+        match self {
+            Role::ProvideReportsOnly => *self = Role::Both,
+            Role::ReceiveReportsOnly => {} // already enabled
+            Role::Both => {}               // already enabled
+            Role::Disabled => *self = Role::ReceiveReportsOnly,
+        }
+    }
+
+    /// Disables accepting reports of observed addresses from other peers.
+    fn disable_receiving_reports_from_peers(&mut self) {
+        match self {
+            Role::ProvideReportsOnly => {} // already disabled
+            Role::ReceiveReportsOnly => *self = Role::Disabled,
+            Role::Both => *self = Role::ProvideReportsOnly,
+            Role::Disabled => {} // already disabled
+        }
     }
 }

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -60,14 +60,14 @@ impl Role {
     /// Sets whether this peer should provide observed addresses to other peers.
     pub(crate) fn send_reports_to_peers(&mut self, provide: bool) {
         if provide {
-            self.enable_reports_to_peers()
+            self.enable_sending_reports_to_peers()
         } else {
-            self.disable_reports_to_peers()
+            self.disable_sending_reports_to_peers()
         }
     }
 
-    /// Enables reporting of observed addresses to other peers.
-    fn enable_reports_to_peers(&mut self) {
+    /// Enables sending reports of observed addresses to other peers.
+    fn enable_sending_reports_to_peers(&mut self) {
         match self {
             Self::SendOnly => {} // already enabled
             Self::ReceiveOnly => *self = Self::Both,
@@ -76,8 +76,8 @@ impl Role {
         }
     }
 
-    /// Disables reporting of observed addresses to other peers.
-    fn disable_reports_to_peers(&mut self) {
+    /// Disables sending reports of observed addresses to other peers.
+    fn disable_sending_reports_to_peers(&mut self) {
         match self {
             Self::SendOnly => *self = Self::Disabled,
             Self::ReceiveOnly => {} // already disabled
@@ -96,7 +96,7 @@ impl Role {
         }
     }
 
-    /// Enables accepting reports of observed addresses from other peers.
+    /// Enables receiving reports of observed addresses from other peers.
     fn enable_receiving_reports_from_peers(&mut self) {
         match self {
             Self::SendOnly => *self = Self::Both,
@@ -106,7 +106,7 @@ impl Role {
         }
     }
 
-    /// Disables accepting reports of observed addresses from other peers.
+    /// Disables receiving reports of observed addresses from other peers.
     fn disable_receiving_reports_from_peers(&mut self) {
         match self {
             Self::SendOnly => {} // already disabled

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -12,10 +12,10 @@ pub(crate) const TRANSPORT_PARAMETER_CODE: u64 = 0x9f81a175;
 pub(crate) enum Role {
     /// Is able to report observer addresses to other peers, but it's not interested in receiving
     /// reports about its own address.
-    ProvideReportsOnly,
+    ProvideOnly,
     /// Is interested on reports about its own observed address, but will not report back to other
     /// peers.
-    ReceiveReportsOnly,
+    ReceivesOnly,
     /// Will both report and receive reports of observed addresses.
     Both,
     /// Address discovery is disabled.
@@ -26,8 +26,8 @@ pub(crate) enum Role {
 impl From<Role> for Option<VarInt> {
     fn from(role: Role) -> Self {
         match role {
-            Role::ProvideReportsOnly => Some(VarInt(0)),
-            Role::ReceiveReportsOnly => Some(VarInt(1)),
+            Role::ProvideOnly => Some(VarInt(0)),
+            Role::ReceivesOnly => Some(VarInt(1)),
             Role::Both => Some(VarInt(2)),
             Role::Disabled => None,
         }
@@ -39,8 +39,8 @@ impl TryFrom<VarInt> for Role {
 
     fn try_from(value: VarInt) -> Result<Self, Self::Error> {
         match value.0 {
-            0 => Ok(Self::ProvideReportsOnly),
-            1 => Ok(Self::ReceiveReportsOnly),
+            0 => Ok(Self::ProvideOnly),
+            1 => Ok(Self::ReceivesOnly),
             2 => Ok(Self::Both),
             _ => Err(crate::transport_parameters::Error::IllegalValue),
         }
@@ -55,12 +55,12 @@ impl Role {
 
     /// Whether this peer's role allows for address reporting to other peers.
     fn is_reporter(&self) -> bool {
-        matches!(self, Self::ProvideReportsOnly | Self::Both)
+        matches!(self, Self::ProvideOnly | Self::Both)
     }
 
     /// Whether this peer's role allows to receive observed address reports.
     fn receives_reports(&self) -> bool {
-        matches!(self, Self::ReceiveReportsOnly | Self::Both)
+        matches!(self, Self::ReceivesOnly | Self::Both)
     }
 
     /// Whether this peer should report observed addresses to other peers.
@@ -80,19 +80,19 @@ impl Role {
     /// Enables reporting of observed addresses to other peers.
     fn enable_reports_to_peers(&mut self) {
         match self {
-            Self::ProvideReportsOnly => {} // already enabled
-            Self::ReceiveReportsOnly => *self = Self::Both,
+            Self::ProvideOnly => {} // already enabled
+            Self::ReceivesOnly => *self = Self::Both,
             Self::Both => {} // already enabled
-            Self::Disabled => *self = Self::ProvideReportsOnly,
+            Self::Disabled => *self = Self::ProvideOnly,
         }
     }
 
     /// Disables reporting of observed addresses to other peers.
     fn disable_reports_to_peers(&mut self) {
         match self {
-            Self::ProvideReportsOnly => *self = Self::Disabled,
-            Self::ReceiveReportsOnly => {} // already disabled
-            Self::Both => *self = Self::ReceiveReportsOnly,
+            Self::ProvideOnly => *self = Self::Disabled,
+            Self::ReceivesOnly => {} // already disabled
+            Self::Both => *self = Self::ReceivesOnly,
             Self::Disabled => {} // already disabled
         }
     }
@@ -110,19 +110,19 @@ impl Role {
     /// Enables accepting reports of observed addresses from other peers.
     fn enable_receiving_reports_from_peers(&mut self) {
         match self {
-            Self::ProvideReportsOnly => *self = Self::Both,
-            Self::ReceiveReportsOnly => {} // already enabled
-            Self::Both => {}               // already enabled
-            Self::Disabled => *self = Self::ReceiveReportsOnly,
+            Self::ProvideOnly => *self = Self::Both,
+            Self::ReceivesOnly => {} // already enabled
+            Self::Both => {}         // already enabled
+            Self::Disabled => *self = Self::ReceivesOnly,
         }
     }
 
     /// Disables accepting reports of observed addresses from other peers.
     fn disable_receiving_reports_from_peers(&mut self) {
         match self {
-            Self::ProvideReportsOnly => {} // already disabled
-            Self::ReceiveReportsOnly => *self = Self::Disabled,
-            Self::Both => *self = Self::ProvideReportsOnly,
+            Self::ProvideOnly => {} // already disabled
+            Self::ReceivesOnly => *self = Self::Disabled,
+            Self::Both => *self = Self::ProvideOnly,
             Self::Disabled => {} // already disabled
         }
     }

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -1,0 +1,17 @@
+//! Address discovery types from
+//! <https://datatracker.ietf.org/doc/draft-seemann-quic-address-discovery/>
+
+/// The role of each participant.
+///
+/// When enabled, this is reported as a transport parameter.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub(crate) enum Role {
+    /// Is able to report observer addresses to other peers, but it's not interested in receiving
+    /// reports about its own address.
+    Observer,
+    /// Is interested on reports about its own observed address, but will not report back to other
+    /// peers.
+    Oservee,
+    /// Will both report and receive reports of observed addresses.
+    Both,
+}

--- a/quinn-proto/src/address_discovery.rs
+++ b/quinn-proto/src/address_discovery.rs
@@ -42,3 +42,20 @@ impl TryFrom<VarInt> for Role {
         }
     }
 }
+
+impl Role {
+    /// Whether this peer's role allows for address reporting to other peers.
+    fn is_reporter(&self) -> bool {
+        matches!(self, Role::Observer | Role::Both)
+    }
+
+    /// Whether this peer's role allows to receive observed address reports.
+    fn receives_reports(&self) -> bool {
+        matches!(self, Role::Observee | Role::Both)
+    }
+
+    /// Whether this peer should report observed addresses to other peer.
+    pub(crate) fn should_report(&self, other: &Role) -> bool {
+        self.is_reporter() && other.receives_reports()
+    }
+}

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -329,19 +329,18 @@ impl TransportConfig {
     ///
     /// This will aid peers in inferring their reachable address, which in most NATd networks
     /// will not be easily available to them.
-    pub fn report_observed_addresses_to_peers(&mut self, enabled: bool) -> &mut Self {
-        self.address_discovery_role
-            .provide_reports_to_peers(enabled);
+    pub fn send_observed_address_reports(&mut self, enabled: bool) -> &mut Self {
+        self.address_discovery_role.send_reports_to_peers(enabled);
         self
     }
 
-    /// Whether to accept observed address_reports from other peers.
+    /// Whether to receive observed address reports from other peers.
     ///
     /// Peers with the address discovery extension enabled that are willing to provide observed
     /// address reports will do so if this transport parameter is set. In general, observed address
     /// reports cannot be trusted. This, however, can aid the current endpoint in inferring its
     /// reachable address, which in most NATd networks will not be easily available.
-    pub fn accept_observed_address_reports(&mut self, enabled: bool) -> &mut Self {
+    pub fn receive_observed_address_reports(&mut self, enabled: bool) -> &mut Self {
         self.address_discovery_role
             .receive_reports_from_peers(enabled);
         self

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -65,6 +65,7 @@ pub struct TransportConfig {
     pub(crate) congestion_controller_factory: Arc<dyn congestion::ControllerFactory + Send + Sync>,
 
     pub(crate) enable_segmentation_offload: bool,
+    pub(crate) address_discovery_role: Option<crate::address_discovery::Role>,
 }
 
 impl TransportConfig {
@@ -360,6 +361,8 @@ impl Default for TransportConfig {
             congestion_controller_factory: Arc::new(congestion::CubicConfig::default()),
 
             enable_segmentation_offload: true,
+
+            address_discovery_role: None,
         }
     }
 }
@@ -390,6 +393,7 @@ impl fmt::Debug for TransportConfig {
                 deterministic_packet_numbers: _,
             congestion_controller_factory: _,
             enable_segmentation_offload,
+            address_discovery_role,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -416,6 +420,7 @@ impl fmt::Debug for TransportConfig {
             .field("datagram_send_buffer_size", datagram_send_buffer_size)
             .field("congestion_controller_factory", &"[ opaque ]")
             .field("enable_segmentation_offload", enable_segmentation_offload)
+            .field("address_discovery_role", address_discovery_role)
             .finish()
     }
 }

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 #[cfg(feature = "rustls")]
 use crate::crypto::rustls::QuicServerConfig;
 use crate::{
+    address_discovery,
     cid_generator::{ConnectionIdGenerator, HashedConnectionIdGenerator},
     congestion,
     crypto::{self, HandshakeTokenKey, HmacKey},
@@ -66,8 +67,7 @@ pub struct TransportConfig {
 
     pub(crate) enable_segmentation_offload: bool,
 
-    pub(crate) report_observed_addresses: bool,
-    pub(crate) accept_observed_address_reports: bool,
+    pub(crate) address_discovery_role: crate::address_discovery::Role,
 }
 
 impl TransportConfig {
@@ -330,7 +330,8 @@ impl TransportConfig {
     /// This will aid peers in inferring their reachable address, which in most NATd networks
     /// will not be easily available to them.
     pub fn report_observed_addresses_to_peers(&mut self, enabled: bool) -> &mut Self {
-        self.report_observed_addresses = enabled;
+        self.address_discovery_role
+            .provide_reports_to_peers(enabled);
         self
     }
 
@@ -341,7 +342,8 @@ impl TransportConfig {
     /// reports cannot be trusted. This, however, can aid the current endpoint in inferring its
     /// reachable address, which in most NATd networks will not be easily available.
     pub fn accept_observed_address_reports(&mut self, enabled: bool) -> &mut Self {
-        self.accept_observed_address_reports = enabled;
+        self.address_discovery_role
+            .receive_reports_from_peers(enabled);
         self
     }
 }
@@ -384,8 +386,7 @@ impl Default for TransportConfig {
 
             enable_segmentation_offload: true,
 
-            report_observed_addresses: false,
-            accept_observed_address_reports: false,
+            address_discovery_role: address_discovery::Role::default(),
         }
     }
 }
@@ -416,8 +417,7 @@ impl fmt::Debug for TransportConfig {
                 deterministic_packet_numbers: _,
             congestion_controller_factory: _,
             enable_segmentation_offload,
-            report_observed_addresses,
-            accept_observed_address_reports,
+            address_discovery_role,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -444,11 +444,7 @@ impl fmt::Debug for TransportConfig {
             .field("datagram_send_buffer_size", datagram_send_buffer_size)
             .field("congestion_controller_factory", &"[ opaque ]")
             .field("enable_segmentation_offload", enable_segmentation_offload)
-            .field("report_observed_addresses", report_observed_addresses)
-            .field(
-                "accept_observed_address_reports",
-                accept_observed_address_reports,
-            )
+            .field("address_discovery_role", address_discovery_role)
             .finish()
     }
 }

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -65,7 +65,9 @@ pub struct TransportConfig {
     pub(crate) congestion_controller_factory: Arc<dyn congestion::ControllerFactory + Send + Sync>,
 
     pub(crate) enable_segmentation_offload: bool,
-    pub(crate) address_discovery_role: Option<crate::address_discovery::Role>,
+
+    pub(crate) report_observed_addresses: bool,
+    pub(crate) accept_observed_address_reports: bool,
 }
 
 impl TransportConfig {
@@ -322,6 +324,26 @@ impl TransportConfig {
         self.enable_segmentation_offload = enabled;
         self
     }
+
+    /// Whether to send observed address reports to peers.
+    ///
+    /// This will aid peers in inferring their reachable address, which in most NATd networks
+    /// will not be easily available to them.
+    pub fn report_observed_addresses_to_peers(&mut self, enabled: bool) -> &mut Self {
+        self.report_observed_addresses = enabled;
+        self
+    }
+
+    /// Whether to accept observed address_reports from other peers.
+    ///
+    /// Peers with the address discovery extension enabled that are willing to provide observed
+    /// address reports will do so if this transport paramter is set. In general, observed address
+    /// reports cannot be trusted. This, however, can aid the current endpoint in inferring its
+    /// reachable address, which in most NATd networks will not be easily available.
+    pub fn accept_observed_address_reports(&mut self, enabled: bool) -> &mut Self {
+        self.accept_observed_address_reports = enabled;
+        self
+    }
 }
 
 impl Default for TransportConfig {
@@ -362,7 +384,8 @@ impl Default for TransportConfig {
 
             enable_segmentation_offload: true,
 
-            address_discovery_role: None,
+            report_observed_addresses: false,
+            accept_observed_address_reports: false,
         }
     }
 }
@@ -393,7 +416,8 @@ impl fmt::Debug for TransportConfig {
                 deterministic_packet_numbers: _,
             congestion_controller_factory: _,
             enable_segmentation_offload,
-            address_discovery_role,
+            report_observed_addresses,
+            accept_observed_address_reports,
         } = self;
         fmt.debug_struct("TransportConfig")
             .field("max_concurrent_bidi_streams", max_concurrent_bidi_streams)
@@ -420,7 +444,11 @@ impl fmt::Debug for TransportConfig {
             .field("datagram_send_buffer_size", datagram_send_buffer_size)
             .field("congestion_controller_factory", &"[ opaque ]")
             .field("enable_segmentation_offload", enable_segmentation_offload)
-            .field("address_discovery_role", address_discovery_role)
+            .field("report_observed_addresses", report_observed_addresses)
+            .field(
+                "accept_observed_address_reports",
+                accept_observed_address_reports,
+            )
             .finish()
     }
 }

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -338,7 +338,7 @@ impl TransportConfig {
     /// Whether to accept observed address_reports from other peers.
     ///
     /// Peers with the address discovery extension enabled that are willing to provide observed
-    /// address reports will do so if this transport paramter is set. In general, observed address
+    /// address reports will do so if this transport parameter is set. In general, observed address
     /// reports cannot be trusted. This, however, can aid the current endpoint in inferring its
     /// reachable address, which in most NATd networks will not be easily available.
     pub fn accept_observed_address_reports(&mut self, enabled: bool) -> &mut Self {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2887,9 +2887,10 @@ impl Connection {
                         self.discard_space(now, SpaceId::Handshake);
                     }
                 }
-                Frame::ObservedAddr(()) => {
-                    trace!("got observed addr");
+                Frame::ObservedAddr(observed) => {
+                    tracing::info!(?observed, "got observed addr");
                     // TODO(@divma): do things
+                    // TODO(@divma): this is ack eliciting
                 }
             }
         }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3053,7 +3053,7 @@ impl Connection {
                 let observed = frame::ObservedAddr {
                     ip: self.path.remote.ip(),
                     port: self.path.remote.port(),
-                    request_id: VarInt(self.rng.gen_range(0..VarInt::MAX.0)),
+                    seq_no: VarInt(self.rng.gen_range(0..VarInt::MAX.0)),
                 };
                 if buf.len() + observed.size() < max_size {
                     tracing::info!(?observed, "reporting observed addr");

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3096,7 +3096,7 @@ impl Connection {
                     || !self
                         .config
                         .address_discovery_role
-                        .should_report(&self.peer_params.address_discovery_role) 
+                        .should_report(&self.peer_params.address_discovery_role)
                     || (self.path.observed_addr_sent && !unconditional)
                 {
                     return;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2991,6 +2991,7 @@ impl Connection {
                 &self.config,
             )
         };
+        new_path.last_observed_addr_report = self.path.last_observed_addr_report.clone();
         if let Some(report) = observed_addr {
             if let Some(updated) = new_path.update_observed_addr_report(report) {
                 self.events.push_back(Event::ObservedAddr(updated));
@@ -3106,7 +3107,6 @@ impl Connection {
                     frame::ObservedAddr::new(self.path.remote, self.next_observed_addr_seq_no);
 
                 if buf.len() + observed.size() < max_size {
-                    tracing::info!(?observed, "reporting observed addr");
                     observed.write(buf);
 
                     self.next_observed_addr_seq_no =

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2650,7 +2650,7 @@ impl Connection {
                     trace!(len = f.data.len(), "got datagram frame");
                 }
                 f => {
-                    tracing::info!("got frame {:?}", f);
+                    trace!("got frame {:?}", f);
                 }
             }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2888,9 +2888,21 @@ impl Connection {
                     }
                 }
                 Frame::ObservedAddr(observed) => {
-                    tracing::info!(?observed, "got observed addr");
-                    // TODO(@divma): do things
-                    // TODO(@divma): this is ack eliciting
+                    if self
+                        .peer_params
+                        .address_discovery_role
+                        .should_report(&self.config.address_discovery_role)
+                    {
+                        tracing::info!(?observed, "got observed addr");
+                        // TODO(@divma): do thingss
+                        // TODO(@divma): this is ack eliciting
+                    } else {
+                        // TODO(@divma): remove, for comedic debugging purposes
+                        tracing::error!(?observed, our_role=?self.config.address_discovery_role, their_role=?self.peer_params.address_discovery_role, "naughty boy sent observed addr with incompatible roles");
+                        return Err(TransportError::PROTOCOL_VIOLATION(
+                            "received observed address frame when not negotiated",
+                        ));
+                    }
                 }
             }
         }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3048,6 +3048,7 @@ impl Connection {
         let is_0rtt = space_id == SpaceId::Data && space.crypto.is_none();
         space.pending_acks.maybe_ack_non_eliciting();
 
+        // TODO(@divma): inline if this ends up being sent in just one place
         let mut send_observed_address = |buf: &mut Vec<u8>, max_size: usize| {
             if self
                 .config
@@ -3163,6 +3164,10 @@ impl Connection {
                 buf.write(frame::Type::PATH_RESPONSE);
                 buf.write(token);
                 self.stats.frame_tx.path_response += 1;
+
+                if send_observed_address(buf, max_size) {
+                    self.stats.frame_tx.path_challenge += 1;
+                }
             }
         }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3083,7 +3083,6 @@ impl Connection {
 
         // OBSERVED_ADDR
         // must be sent as early as possible
-        // TODO(@divma): we don't want to send this all the time. only for new path and probes
         // TODO(@divma): annoying closure required because of the borrows `populate_packet` does
         // throughout its code
         let mut send_observed_address =

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3098,7 +3098,7 @@ impl Connection {
                     .address_discovery_role
                     .should_report(&self.peer_params.address_discovery_role);
                 let send_required =
-                    space.pending.observed_addr && !self.path.observed_addr_sent || skip_sent_check;
+                    space.pending.observed_addr || !self.path.observed_addr_sent || skip_sent_check;
                 if space_id != SpaceId::Data || !send_allowed || !send_required {
                     return;
                 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2887,6 +2887,10 @@ impl Connection {
                         self.discard_space(now, SpaceId::Handshake);
                     }
                 }
+                Frame::ObservedAddr(()) => {
+                    trace!("got observed addr");
+                    // TODO(@divma): do things
+                }
             }
         }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3072,10 +3072,6 @@ impl Connection {
             // This is just a u8 counter and the frame is typically just sent once
             self.stats.frame_tx.handshake_done =
                 self.stats.frame_tx.handshake_done.saturating_add(1);
-
-            if send_observed_address(buf, max_size) {
-                self.stats.frame_tx.observed_addr += 1;
-            }
         }
 
         // PING

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -230,7 +230,7 @@ pub struct Connection {
     //
     // ObservedAddr
     //
-    /// Sequence number for ther next observed address frame sent to the peer.
+    /// Sequence number for the next observed address frame sent to the peer.
     next_observed_addr_seq_no: VarInt,
 
     streams: StreamsState,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3089,8 +3089,9 @@ impl Connection {
              unconditional: bool // whether the check for sent frames on this path should be
                                  // skipped
              | {
-                // should only be sent within Data space and only if extension negotiation allows
-                // it send is also skipped if the path has already sent an observed address and
+                // should only be sent within Data space and only if allowed by extension
+                // negotiation 
+                // send is also skipped if the path has already sent an observed address and
                 // sending it not unconditional
                 if space_id != SpaceId::Data
                     || !self

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2909,13 +2909,13 @@ impl Connection {
                         .should_report(&self.config.address_discovery_role)
                     {
                         return Err(TransportError::PROTOCOL_VIOLATION(
-                            "received observed address frame when not negotiated",
+                            "received OBSERVED_ADDRESS frame when not negotiated",
                         ));
                     }
                     // must only be sent in data space
                     if packet.header.space() != SpaceId::Data {
                         return Err(TransportError::PROTOCOL_VIOLATION(
-                            "observed address outside data space",
+                            "OBSERVED_ADDRESS frame outside data space",
                         ));
                     }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3090,9 +3090,9 @@ impl Connection {
                                  // skipped
              | {
                 // should only be sent within Data space and only if allowed by extension
-                // negotiation 
+                // negotiation
                 // send is also skipped if the path has already sent an observed address and
-                // sending it not unconditional
+                // sending is not unconditional
                 if space_id != SpaceId::Data
                     || !self
                         .config

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3115,6 +3115,7 @@ impl Connection {
 
                     stats.frame_tx.observed_addr += 1;
                     sent.retransmits.get_or_create().observed_addr = true;
+                    space.pending.observed_addr = false;
                 }
             };
         send_observed_address(

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -231,9 +231,7 @@ pub struct Connection {
     // ObservedAddr
     //
     /// Sequence number for ther next observed address frame sent to the peer.
-    // NOTE: this is encoded as a varint (u62) but _per connection_ up to u16 sent oberved address
-    // frames should be more than enough.
-    next_observed_addr_seq_no: u16,
+    next_observed_addr_seq_no: VarInt,
 
     streams: StreamsState,
     /// Surplus remote CIDs for future use on new paths
@@ -351,7 +349,7 @@ impl Connection {
             receiving_ecn: false,
             total_authed_packets: 0,
 
-            next_observed_addr_seq_no: 0,
+            next_observed_addr_seq_no: 0u32.into(),
 
             streams: StreamsState::new(
                 side,
@@ -3111,7 +3109,8 @@ impl Connection {
                     tracing::info!(?observed, "reporting observed addr");
                     observed.write(buf);
 
-                    self.next_observed_addr_seq_no += 1;
+                    self.next_observed_addr_seq_no =
+                        self.next_observed_addr_seq_no.saturating_add(1u8);
                     self.path.observed_addr_sent = true;
 
                     stats.frame_tx.observed_addr += 1;

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -176,12 +176,14 @@ impl PathData {
                     None
                 } else {
                     let addr = (observed.ip, observed.port).into();
+                    tracing::info!(%addr, "observed addr");
                     self.last_observed_addr_report = Some(observed);
                     Some(addr)
                 }
             }
             None => {
                 let addr = (observed.ip, observed.port).into();
+                tracing::info!(%addr, "observed addr");
                 self.last_observed_addr_report = Some(observed);
                 Some(addr)
             }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -175,15 +175,13 @@ impl PathData {
                     prev.seq_no = observed.seq_no;
                     None
                 } else {
-                    let addr = (observed.ip, observed.port).into();
-                    tracing::info!(%addr, "observed addr");
+                    let addr = observed.socket_addr();
                     self.last_observed_addr_report = Some(observed);
                     Some(addr)
                 }
             }
             None => {
-                let addr = (observed.ip, observed.port).into();
-                tracing::info!(%addr, "observed addr");
+                let addr = observed.socket_addr();
                 self.last_observed_addr_report = Some(observed);
                 Some(addr)
             }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -37,6 +37,9 @@ pub(super) struct PathData {
     /// Used in persistent congestion determination.
     pub(super) first_packet_after_rtt_sample: Option<(SpaceId, u64)>,
     pub(super) in_flight: InFlight,
+    /// Whether this path has had it's remote address reported back to the peer. This only happens
+    /// if both peers agree to so based on their transport paramteres.
+    pub(super) observed_addr_sent: bool,
     /// Number of the first packet sent on this path
     ///
     /// Used to determine whether a packet was sent on an earlier path. Insufficient to determine if
@@ -90,10 +93,14 @@ impl PathData {
                 ),
             first_packet_after_rtt_sample: None,
             in_flight: InFlight::new(),
+            observed_addr_sent: false,
             first_packet: None,
         }
     }
 
+    /// Create a new path from a previous one.
+    ///
+    /// This should only be called when migrating paths.
     pub(super) fn from_previous(remote: SocketAddr, prev: &Self, now: Instant) -> Self {
         let congestion = prev.congestion.clone_box();
         let smoothed_rtt = prev.rtt.get();
@@ -111,6 +118,7 @@ impl PathData {
             mtud: prev.mtud.clone(),
             first_packet_after_rtt_sample: prev.first_packet_after_rtt_sample,
             in_flight: InFlight::new(),
+            observed_addr_sent: false,
             first_packet: None,
         }
     }

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -310,6 +310,7 @@ pub struct Retransmits {
     pub(super) retire_cids: Vec<u64>,
     pub(super) ack_frequency: bool,
     pub(super) handshake_done: bool,
+    pub(super) observed_addr: Vec<frame::ObservedAddr>,
 }
 
 impl Retransmits {
@@ -327,6 +328,7 @@ impl Retransmits {
             && self.retire_cids.is_empty()
             && !self.ack_frequency
             && !self.handshake_done
+            && self.observed_addr.is_empty()
     }
 }
 
@@ -348,6 +350,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
         self.retire_cids.extend(rhs.retire_cids);
         self.ack_frequency |= rhs.ack_frequency;
         self.handshake_done |= rhs.handshake_done;
+        self.observed_addr.extend(rhs.observed_addr);
     }
 }
 

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -310,7 +310,7 @@ pub struct Retransmits {
     pub(super) retire_cids: Vec<u64>,
     pub(super) ack_frequency: bool,
     pub(super) handshake_done: bool,
-    pub(super) observed_addr: Vec<frame::ObservedAddr>,
+    pub(super) observed_addr: bool,
 }
 
 impl Retransmits {
@@ -328,7 +328,7 @@ impl Retransmits {
             && self.retire_cids.is_empty()
             && !self.ack_frequency
             && !self.handshake_done
-            && self.observed_addr.is_empty()
+            && !self.observed_addr
     }
 }
 
@@ -350,7 +350,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
         self.retire_cids.extend(rhs.retire_cids);
         self.ack_frequency |= rhs.ack_frequency;
         self.handshake_done |= rhs.handshake_done;
-        self.observed_addr.extend(rhs.observed_addr);
+        self.observed_addr |= rhs.observed_addr;
     }
 }
 

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -54,6 +54,8 @@ pub struct FrameStats {
     pub streams_blocked_uni: u64,
     pub stop_sending: u64,
     pub stream: u64,
+    // TODO(@divma): record type of addr?
+    pub observed_addr: u64,
 }
 
 impl FrameStats {
@@ -94,6 +96,7 @@ impl FrameStats {
             Frame::AckFrequency(_) => self.ack_frequency += 1,
             Frame::ImmediateAck => self.immediate_ack += 1,
             Frame::HandshakeDone => self.handshake_done = self.handshake_done.saturating_add(1),
+            Frame::ObservedAddr(()) => self.observed_addr += 1,
         }
     }
 }

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -54,7 +54,6 @@ pub struct FrameStats {
     pub streams_blocked_uni: u64,
     pub stop_sending: u64,
     pub stream: u64,
-    // TODO(@divma): record type of addr?
     pub observed_addr: u64,
 }
 
@@ -96,7 +95,7 @@ impl FrameStats {
             Frame::AckFrequency(_) => self.ack_frequency += 1,
             Frame::ImmediateAck => self.immediate_ack += 1,
             Frame::HandshakeDone => self.handshake_done = self.handshake_done.saturating_add(1),
-            Frame::ObservedAddr(()) => self.observed_addr += 1,
+            Frame::ObservedAddr(_) => self.observed_addr += 1,
         }
     }
 }

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -135,8 +135,8 @@ frame_types! {
     IMMEDIATE_ACK = 0x1f,
     // DATAGRAM
     // ADDRESS DISCOVERY REPORT
-    OBSERVED_IPV4_ADDR = 0x9f81a2,
-    OBSERVED_IPV6_ADDR = 0x9f81a3,
+    OBSERVED_IPV4_ADDR = 0x9f81a4,
+    OBSERVED_IPV6_ADDR = 0x9f81a5,
 }
 
 const STREAM_TYS: RangeInclusive<u64> = RangeInclusive::new(0x08, 0x0f);

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -141,6 +141,8 @@ frame_types! {
 const STREAM_TYS: RangeInclusive<u64> = RangeInclusive::new(0x08, 0x0f);
 const DATAGRAM_TYS: RangeInclusive<u64> = RangeInclusive::new(0x30, 0x31);
 
+type ObservedAddr = ();
+
 #[derive(Debug)]
 pub(crate) enum Frame {
     Padding,
@@ -166,6 +168,7 @@ pub(crate) enum Frame {
     AckFrequency(AckFrequency),
     ImmediateAck,
     HandshakeDone,
+    ObservedAddr(ObservedAddr),
 }
 
 impl Frame {
@@ -207,6 +210,8 @@ impl Frame {
             AckFrequency(_) => Type::ACK_FREQUENCY,
             ImmediateAck => Type::IMMEDIATE_ACK,
             HandshakeDone => Type::HANDSHAKE_DONE,
+            ObservedAddr(()) => Type::OBSERVED_IPV4_ADDR, // TODO(@divma): modify when addding both
+                                                          // types
         }
     }
 

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::{self, Write},
     io, mem,
-    net::IpAddr,
+    net::{IpAddr, SocketAddr},
     ops::{Range, RangeInclusive},
 };
 
@@ -1008,6 +1008,11 @@ impl ObservedAddr {
         };
         let port = bytes.get()?;
         Ok(Self { seq_no, ip, port })
+    }
+
+    /// Gives the [`SocketAddr`] reported in the frame.
+    pub(crate) fn socket_addr(&self) -> SocketAddr {
+        (self.ip, self.port).into()
     }
 }
 

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -954,6 +954,14 @@ pub(crate) struct ObservedAddr {
 }
 
 impl ObservedAddr {
+    pub(crate) fn new<N: Into<VarInt>>(remote: std::net::SocketAddr, seq_no: N) -> Self {
+        Self {
+            ip: remote.ip(),
+            port: remote.port(),
+            seq_no: seq_no.into(),
+        }
+    }
+
     /// Get the [`Type`] for this frame.
     pub(crate) fn get_type(&self) -> Type {
         if self.ip.is_ipv6() {

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -1000,18 +1000,14 @@ impl ObservedAddr {
     /// Should only be called when the fram type has been identified as
     /// [`Type::OBSERVED_IPV4_ADDR`] or [`Type::OBSERVED_IPV6_ADDR`].
     pub(crate) fn read<R: Buf>(bytes: &mut R, is_ipv6: bool) -> coding::Result<Self> {
-        let request_id = bytes.get()?;
+        let seq_no = bytes.get()?;
         let ip = if is_ipv6 {
             IpAddr::V6(bytes.get()?)
         } else {
             IpAddr::V4(bytes.get()?)
         };
         let port = bytes.get()?;
-        Ok(Self {
-            seq_no: request_id,
-            ip,
-            port,
-        })
+        Ok(Self { seq_no, ip, port })
     }
 }
 

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -133,6 +133,9 @@ frame_types! {
     ACK_FREQUENCY = 0xaf,
     IMMEDIATE_ACK = 0x1f,
     // DATAGRAM
+    // ADDRESS DISCOVERY REPORT
+    OBSERVED_IPV4_ADDR = 0x9f81a2,
+    OBSERVED_IPV6_ADDR = 0x9f81a3,
 }
 
 const STREAM_TYS: RangeInclusive<u64> = RangeInclusive::new(0x08, 0x0f);

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{self, Write},
     io, mem,
+    net::{Ipv4Addr, Ipv6Addr},
     ops::{Range, RangeInclusive},
 };
 
@@ -694,6 +695,8 @@ impl Iter {
                 reordering_threshold: self.bytes.get()?,
             }),
             Type::IMMEDIATE_ACK => Frame::ImmediateAck,
+            Type::OBSERVED_IPV4_ADDR => todo!(),
+            Type::OBSERVED_IPV6_ADDR => todo!(),
             _ => {
                 if let Some(s) = ty.stream() {
                     Frame::Stream(Stream {
@@ -934,6 +937,24 @@ impl AckFrequency {
         buf.write(self.request_max_ack_delay);
         buf.write(self.reordering_threshold);
     }
+}
+
+/// Frame for an observed ipv4 address.
+///
+/// This corresponds to [`Type::OBSERVED_IPV4_ADDR`].
+pub(crate) struct ObservedIpV4Addr {
+    request_id: u64, // TODO(@divma): this doesn't seem to be defined anywhere
+    ip: Ipv4Addr,
+    port: u16,
+}
+
+/// Frame for an observed ipv6 address.
+///
+/// This corresponds to [`Type::OBSERVED_IPV6_ADDR`].
+pub(crate) struct ObservedIpV6Addr {
+    request_id: u64, // TODO(@divma): this doesn't seem to be defined anywhere
+    ip: Ipv6Addr,
+    port: u16,
 }
 
 #[cfg(test)]

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -943,7 +943,7 @@ impl AckFrequency {
 
 /// Conjuction of the information contained in the address discovery frames
 /// ([`Type::OBSERVED_IPV4_ADDR`], [`Type::OBSERVED_IPV6_ADDR`]).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub(crate) struct ObservedAddr {
     /// Monotonically increasing integer within the same connection.
     pub(crate) seq_no: VarInt,

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -941,8 +941,8 @@ impl AckFrequency {
 
 /* Address Discovery https://datatracker.ietf.org/doc/draft-seemann-quic-address-discovery/ */
 
-/// Conjuction of the information contained in the address discovery frames ([`ObservedIpV4Addr`],
-/// [`ObservedIpV6Addr`]).
+/// Conjuction of the information contained in the address discovery frames
+/// ([`Type::OBSERVED_IPV4_ADDR`], [`Type::OBSERVED_IPV6_ADDR`]).
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct ObservedAddr {
     /// Random request id for debugging.

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -135,8 +135,8 @@ frame_types! {
     IMMEDIATE_ACK = 0x1f,
     // DATAGRAM
     // ADDRESS DISCOVERY REPORT
-    OBSERVED_IPV4_ADDR = 0x9f81a4,
-    OBSERVED_IPV6_ADDR = 0x9f81a5,
+    OBSERVED_IPV4_ADDR = 0x9f81a6,
+    OBSERVED_IPV6_ADDR = 0x9f81a7,
 }
 
 const STREAM_TYS: RangeInclusive<u64> = RangeInclusive::new(0x08, 0x0f);

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -86,6 +86,8 @@ pub use crate::cid_generator::{
 mod token;
 use token::{ResetToken, RetryToken};
 
+mod address_discovery;
+
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -3311,7 +3311,7 @@ fn address_discovery_zero_rtt_rejection() {
     };
     let alt_server_cfg = ServerConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::ProvideOnly,
+            address_discovery_role: crate::address_discovery::Role::SendOnly,
             ..TransportConfig::default()
         }),
         ..server_cfg.clone()
@@ -3367,6 +3367,42 @@ fn address_discovery_zero_rtt_rejection() {
 
 #[test]
 fn address_discovery_retransmission() {
+    let _guard = subscribe();
+
+    let server = ServerConfig {
+        transport: Arc::new(TransportConfig {
+            address_discovery_role: crate::address_discovery::Role::Both,
+            ..TransportConfig::default()
+        }),
+        ..server_config()
+    };
+    let mut pair = Pair::new(Default::default(), server);
+    let client_config = ClientConfig {
+        transport: Arc::new(TransportConfig {
+            address_discovery_role: crate::address_discovery::Role::Both,
+            ..TransportConfig::default()
+        }),
+        ..client_config()
+    };
+    let client_ch = pair.begin_connect(client_config);
+    pair.step();
+
+    // lose the last packet
+    pair.client.inbound.pop_back().unwrap();
+    pair.step();
+    let conn = pair.client_conn_mut(client_ch);
+    assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
+    assert_matches!(conn.poll(), Some(Event::Connected));
+    assert_matches!(conn.poll(), None);
+
+    pair.drive();
+    let conn = pair.client_conn_mut(client_ch);
+    assert_matches!(conn.poll(),
+        Some(Event::ObservedAddr(addr)) if addr == pair.client.addr);
+}
+
+#[test]
+fn address_discovery_rebind_retransmission() {
     let _guard = subscribe();
 
     let server = ServerConfig {

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -3348,7 +3348,7 @@ fn address_discovery_zero_rtt_rejection() {
     pair.client.connections.clear();
     pair.server.connections.clear();
 
-    // Changing addres discovery configurations makes the client close the connection
+    // Changing address discovery configurations makes the client close the connection
     pair.server
         .set_server_config(Some(Arc::new(alt_server_cfg)));
     info!("resuming session");

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -528,7 +528,7 @@ mod test {
             }),
             grease_quic_bit: true,
             min_ack_delay: Some(2_000u32.into()),
-            address_discovery_role: address_discovery::Role::ProvideOnly,
+            address_discovery_role: address_discovery::Role::SendOnly,
             ..TransportParameters::default()
         };
         params.write(&mut buf);

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -184,10 +184,12 @@ impl TransportParameters {
             || cached.grease_quic_bit && !self.grease_quic_bit
             || cached.address_discovery_role != self.address_discovery_role
         {
+            tracing::info!(cached=?cached.address_discovery_role, new=?self.address_discovery_role, "0rtt rejected!");
             return Err(TransportError::PROTOCOL_VIOLATION(
                 "0-RTT accepted with incompatible transport parameters",
             ));
         }
+        tracing::info!(cached=?cached.address_discovery_role, new=?self.address_discovery_role, "0rtt accepted!");
         Ok(())
     }
 

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -430,8 +430,6 @@ impl TransportParameters {
                 address_discovery::TRANSPORT_PARAMETER_CODE => {
                     if !params.address_discovery_role.is_disabled() {
                         // duplicate parameter
-                        // NOTE: this depends on the default being Disabled, which is reasonable. Is
-                        // this handled in a better way somewhere?
                         return Err(Error::Malformed);
                     }
                     let value: VarInt = r.get()?;

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -531,7 +531,7 @@ mod test {
             }),
             grease_quic_bit: true,
             min_ack_delay: Some(2_000u32.into()),
-            address_discovery_role: address_discovery::Role::ProvideReportsOnly,
+            address_discovery_role: address_discovery::Role::ProvideOnly,
             ..TransportParameters::default()
         };
         params.write(&mut buf);

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -165,7 +165,10 @@ impl TransportParameters {
             min_ack_delay: Some(
                 VarInt::from_u64(u64::try_from(TIMER_GRANULARITY.as_micros()).unwrap()).unwrap(),
             ),
-            address_discovery_role: config.address_discovery_role,
+            address_discovery_role: address_discovery::Role::new(
+                config.report_observed_addresses,
+                config.accept_observed_address_reports,
+            ),
             ..Self::default()
         }
     }
@@ -440,6 +443,10 @@ impl TransportParameters {
                         return Err(Error::Malformed);
                     }
                     params.address_discovery_role = Some(value.try_into()?);
+                    tracing::info!(
+                        role = ?params.address_discovery_role,
+                        "address discovery enabled for peer"
+                    );
                 }
                 _ => {
                     macro_rules! parse {

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -436,7 +436,7 @@ impl TransportParameters {
                         return Err(Error::Malformed);
                     }
                     params.address_discovery_role = value.try_into()?;
-                    tracing::info!(
+                    tracing::debug!(
                         role = ?params.address_discovery_role,
                         "address discovery enabled for peer"
                     );

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -184,12 +184,10 @@ impl TransportParameters {
             || cached.grease_quic_bit && !self.grease_quic_bit
             || cached.address_discovery_role != self.address_discovery_role
         {
-            tracing::info!(cached=?cached.address_discovery_role, new=?self.address_discovery_role, "0rtt rejected!");
             return Err(TransportError::PROTOCOL_VIOLATION(
                 "0-RTT accepted with incompatible transport parameters",
             ));
         }
-        tracing::info!(cached=?cached.address_discovery_role, new=?self.address_discovery_role, "0rtt accepted!");
         Ok(())
     }
 

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -357,8 +357,7 @@ impl TransportParameters {
             w.write(x);
         }
 
-        let maybe_role: Option<VarInt> = self.address_discovery_role.into();
-        if let Some(varint_role) = maybe_role {
+        if let Some(varint_role) = self.address_discovery_role.as_transport_parameter() {
             w.write_var(address_discovery::TRANSPORT_PARAMETER_CODE);
             w.write_var(varint_role.size() as u64);
             w.write(varint_role);

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -531,7 +531,7 @@ mod test {
             }),
             grease_quic_bit: true,
             min_ack_delay: Some(2_000u32.into()),
-            address_discovery_role: Some(address_discovery::Role::Observer),
+            address_discovery_role: address_discovery::Role::ProvideReportsOnly,
             ..TransportParameters::default()
         };
         params.write(&mut buf);

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -99,6 +99,7 @@ macro_rules! make_struct {
             pub(crate) stateless_reset_token: Option<ResetToken>,
             /// The server's preferred address for communication after handshake completion
             pub(crate) preferred_address: Option<PreferredAddress>,
+            pub(crate) address_discovery_role: Option<crate::address_discovery::Role>
         }
 
         // We deliberately don't implement the `Default` trait, since that would be public, and
@@ -120,6 +121,8 @@ macro_rules! make_struct {
                     retry_src_cid: None,
                     stateless_reset_token: None,
                     preferred_address: None,
+
+                    address_discovery_role: None,
                 }
             }
         }

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -50,7 +50,8 @@ impl VarInt {
         self.0
     }
 
-    /// Saturating integer addition. Computes self + rhs, saturating at the numeric bounds instead of overflowing.
+    /// Saturating integer addition. Computes self + rhs, saturating at the numeric bounds instead
+    /// of overflowing.
     pub fn saturating_add(self, rhs: impl Into<Self>) -> Self {
         let rhs = rhs.into();
         let inner = self.0.saturating_add(rhs.0).min(Self::MAX.0);

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -51,7 +51,7 @@ impl VarInt {
     }
 
     /// Saturating integer addition. Computes self + rhs, saturating at the numeric bounds instead of overflowing.
-    pub fn saturating_add(self, rhs: impl Into<VarInt>) -> VarInt {
+    pub fn saturating_add(self, rhs: impl Into<Self>) -> Self {
         let rhs = rhs.into();
         let inner = self.0.saturating_add(rhs.0).min(Self::MAX.0);
         Self(inner)

--- a/quinn-proto/src/varint.rs
+++ b/quinn-proto/src/varint.rs
@@ -50,6 +50,13 @@ impl VarInt {
         self.0
     }
 
+    /// Saturating integer addition. Computes self + rhs, saturating at the numeric bounds instead of overflowing.
+    pub fn saturating_add(self, rhs: impl Into<VarInt>) -> VarInt {
+        let rhs = rhs.into();
+        let inner = self.0.saturating_add(rhs.0).min(Self::MAX.0);
+        Self(inner)
+    }
+
     /// Compute the number of bytes needed to encode this value
     pub(crate) fn size(self) -> usize {
         let x = self.0;
@@ -189,5 +196,21 @@ impl Codec for VarInt {
         } else {
             unreachable!("malformed VarInt")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_saturating_add() {
+        // add within range behaves normally
+        let large: VarInt = u32::MAX.into();
+        let next = u64::from(u32::MAX) + 1;
+        assert_eq!(large.saturating_add(1u8), VarInt::from_u64(next).unwrap());
+
+        // outside range saturates
+        assert_eq!(VarInt::MAX.saturating_add(1u8), VarInt::MAX)
     }
 }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -65,6 +65,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "macros
 tracing-subscriber = { workspace = true }
 tracing-futures = { workspace = true }
 url = { workspace = true }
+tokio-stream = "0.1.15"
 
 [[example]]
 name = "server"

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -14,7 +14,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use iroh_quinn as quinn;
-use proto::crypto::rustls::QuicClientConfig;
+use proto::{crypto::rustls::QuicClientConfig, TransportConfig};
 use rustls::pki_types::CertificateDer;
 use tracing::{error, info};
 use url::Url;
@@ -102,8 +102,13 @@ async fn run(options: Opt) -> Result<()> {
         client_crypto.key_log = Arc::new(rustls::KeyLogFile::new());
     }
 
-    let client_config =
+    let mut transport = TransportConfig::default();
+    transport
+        .report_observed_addresses_to_peers(true)
+        .accept_observed_address_reports(true);
+    let mut client_config =
         quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(client_crypto)?));
+    client_config.transport_config(Arc::new(transport));
     let mut endpoint = quinn::Endpoint::client(options.bind)?;
     endpoint.set_default_client_config(client_config);
 

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -104,8 +104,8 @@ async fn run(options: Opt) -> Result<()> {
 
     let mut transport = TransportConfig::default();
     transport
-        .report_observed_addresses_to_peers(true)
-        .accept_observed_address_reports(true);
+        .send_observed_address_reports(true)
+        .receive_observed_address_reports(true);
     let mut client_config =
         quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(client_crypto)?));
     client_config.transport_config(Arc::new(transport));

--- a/quinn/examples/client.rs
+++ b/quinn/examples/client.rs
@@ -126,7 +126,7 @@ async fn run(options: Opt) -> Result<()> {
     let mut external_addresses = conn.observed_external_addr();
     tokio::spawn(async move {
         loop {
-            if let Some(new_addr) = external_addresses.borrow_and_update().clone() {
+            if let Some(new_addr) = *external_addresses.borrow_and_update() {
                 info!(%new_addr, "new external address report");
             }
             if external_addresses.changed().await.is_err() {

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -128,7 +128,10 @@ async fn run(options: Opt) -> Result<()> {
     let mut server_config =
         quinn::ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(server_crypto)?));
     let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
-    transport_config.max_concurrent_uni_streams(0_u8.into());
+    transport_config
+        .max_concurrent_uni_streams(0_u8.into())
+        .report_observed_addresses_to_peers(true)
+        .accept_observed_address_reports(true);
 
     let root = Arc::<Path>::from(options.root.clone());
     if !root.exists() {

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -130,8 +130,8 @@ async fn run(options: Opt) -> Result<()> {
     let transport_config = Arc::get_mut(&mut server_config.transport).unwrap();
     transport_config
         .max_concurrent_uni_streams(0_u8.into())
-        .report_observed_addresses_to_peers(true)
-        .accept_observed_address_reports(true);
+        .send_observed_address_reports(true)
+        .receive_observed_address_reports(true);
 
     let root = Arc::<Path>::from(options.root.clone());
     if !root.exists() {

--- a/quinn/examples/server.rs
+++ b/quinn/examples/server.rs
@@ -185,7 +185,7 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Incoming) -> Result<()>
     tokio::spawn(
         async move {
             loop {
-                if let Some(new_addr) = external_addresses.borrow_and_update().clone() {
+                if let Some(new_addr) = *external_addresses.borrow_and_update() {
                     info!(%new_addr, "new external address report");
                 }
                 if external_addresses.changed().await.is_err() {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1183,9 +1183,12 @@ impl State {
                     wake_stream(id, &mut self.stopped);
                     wake_stream(id, &mut self.blocked_writers);
                 }
-                ObservedAddr(observed) => self
-                    .observed_external_addr
-                    .send_modify(|addr| *addr = Some(observed)),
+                ObservedAddr(observed) => {
+                    self.observed_external_addr.send_if_modified(|addr| {
+                        let old = addr.replace(observed);
+                        old != *addr
+                    });
+                }
             }
         }
     }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1183,10 +1183,9 @@ impl State {
                     wake_stream(id, &mut self.stopped);
                     wake_stream(id, &mut self.blocked_writers);
                 }
-                ObservedAddr(observed) => self.observed_external_addr.send_modify(|addr| {
-                    tracing::info!(%observed,"updating!");
-                    *addr = Some(observed)
-                }),
+                ObservedAddr(observed) => self
+                    .observed_external_addr
+                    .send_modify(|addr| *addr = Some(observed)),
             }
         }
     }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1183,9 +1183,10 @@ impl State {
                     wake_stream(id, &mut self.stopped);
                     wake_stream(id, &mut self.blocked_writers);
                 }
-                ObservedAddr(observed) => self
-                    .observed_external_addr
-                    .send_modify(|addr| *addr = Some(observed)),
+                ObservedAddr(observed) => self.observed_external_addr.send_modify(|addr| {
+                    tracing::info!(%observed,"updating!");
+                    *addr = Some(observed)
+                }),
             }
         }
     }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -643,11 +643,6 @@ impl Connection {
     }
 
     /// Track changed on our external address as reported by the peer.
-    // NOTE: this is currently leaking an implementation detail, but quinn does not use common deps
-    // like futures, so no access to the Stream future for example. Other utilities are also not
-    // imported, so for the sake of not incurring in bloat, but prevent the impl detail to leak, we
-    // should at least check on alternative implementations that do not use these common libraries
-    // first.
     pub fn observed_external_addr(&self) -> watch::Receiver<Option<SocketAddr>> {
         let conn = self.0.state.lock("external_addr");
         conn.observed_external_addr.subscribe()
@@ -1024,7 +1019,7 @@ pub(crate) struct State {
     send_buffer: Vec<u8>,
     /// We buffer a transmit when the underlying I/O would block
     buffered_transmit: Option<proto::Transmit>,
-    /// our last external address reported by the peer.
+    /// Our last external address reported by the peer.
     pub(crate) observed_external_addr: watch::Sender<Option<SocketAddr>>,
 }
 


### PR DESCRIPTION
PoC for an address discovery extension implementation on quinn.

### Parts and rationale are as follows:

1. Transport parameters: These are how the extension is negotiated between peers. Implemented with tests, can't be changed in 0rtt
2. Frames: Where we actually send the data. Technically two different kind of frames, one for ipv4 and other for ipv6. This is implemented as a single struct with tests.
3. Frame sending, aka "the logic":
  - we store whether a path has reported the observed address to ensure the first path receives an observation.
  - we send with path challenges since those ensure we send the frame when we identify a change in the peer's address. If my understanding is correct this also covers probing.
  - we send with path responses too. This is not required by the spec but technically allowed. I'm fine to remove it if it's an overkill.
4. Retransmission: the spec says retransmission must happen over the same path the original frame was sent. Taking into account that the information we transmit is only of relevance when fresh, and based on the logic used for other data (for example max_data - and many others) I thought the best course is to simply send a fresh frame when retransmission is needed. Maybe we should try to get this clarification into the spec.
5. Info surfacing to the application: Done via events between quinn-proto and quinn, and accessible via a `tokio::watch::Receiver`. As an initial implementation this is a quick way to move the data all the way up without adding more deps.

### What's missing then:
- [x] Tests for sending in quinn-proto
- [x] Tests for resumption behaviour
- [x] Tests for retransmission
- ~~[ ] Better surfacing api that does not expose impl details like `tokio::watch`~~
  This is staying as in, as implementing this by hand to duplicate the existing-and-well-documented functionalities of `watch` is just not really where our efforts should go at this stage

### Notes
This is still a WIP, and has not had a self-review. It's probably still full of `info!` that should be either be `trace!` or be gone, but it works. Run the server and client example, even with rebinding and frames will flow nicely.

### MORE notes
Note how we create an event for every updated frame? now a peer just needs to send many of these frames to fill up a queue. Is this being fixed by some other quic magic? I'm not sure but I think not. The spec does not mention any kind of limit on frame frequency either. This is fine as a PoC and might even be kinda ok in a closed iroh world, but most likely not ok at all anywhere else.

Finally, upstream will maybe not be happy with the extension being always on at compile time but we can deal with that at the very end