### PR TITLE
Also reset the MTU when the network paths has changed

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1306,19 +1306,16 @@ impl Connection {
         self.path.congestion.as_ref()
     }
 
-    /// Resets the congestion controller and round-trip estimator for the current path.
+    /// Resets path-specific settings.
     ///
-    /// This force-resets the congestion controller and round-trip estimator for the current
-    /// path.
-    pub fn reset_congestion_state(&mut self) {
-        let now = Instant::now();
-        self.path.rtt = RttEstimator::new(self.config.initial_rtt);
-        self.path.congestion = self
-            .config
-            .congestion_controller_factory
-            .clone()
-            .build(now, self.config.get_initial_mtu());
-        // TODO: probably needs MTU discovery reset as well.
+    /// This will force-reset several subsystems related to a specific network path.
+    /// Currently this is the congestion controller, round-trip estimator, and the MTU
+    /// discovery.
+    ///
+    /// This is useful when it is know the underlying network path has changed and the old
+    /// state of these subsystems is no longer valid.
+    pub fn network_path_changed(&mut self) {
+        self.path.reset(&self.config);
     }
 
     /// Modify the number of remotely initiated streams that may be concurrently open

--- a/quinn-proto/src/connection/mtud.rs
+++ b/quinn-proto/src/connection/mtud.rs
@@ -56,6 +56,15 @@ impl MtuDiscovery {
         }
     }
 
+    pub(super) fn reset(&mut self, current_mtu: u16, min_mtu: u16) {
+        self.current_mtu = current_mtu;
+        if let Some(state) = self.state.take() {
+            self.state = Some(EnabledMtuDiscovery::new(state.config));
+            self.on_peer_max_udp_payload_size_received(state.peer_max_udp_payload_size);
+        }
+        self.black_hole_detector = BlackHoleDetector::new(min_mtu);
+    }
+
     /// Returns the current MTU
     pub(crate) fn current_mtu(&self) -> u16 {
         self.current_mtu

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -115,6 +115,19 @@ impl PathData {
         }
     }
 
+    /// Resets RTT, congestion control and MTU states.
+    ///
+    /// This is useful when it is known the underlying path has changed.
+    pub(super) fn reset(&mut self, config: &TransportConfig) {
+        let now = Instant::now();
+        self.rtt = RttEstimator::new(config.initial_rtt);
+        self.congestion = config
+            .congestion_controller_factory
+            .clone()
+            .build(now, config.get_initial_mtu());
+        self.mtud.reset(config.get_initial_mtu(), config.min_mtu);
+    }
+
     /// Indicates whether we're a server that hasn't validated the peer's address and hasn't
     /// received enough data from the peer to permit sending `bytes_to_send` additional bytes
     pub(super) fn anti_amplification_blocked(&self, bytes_to_send: u64) -> bool {

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -956,19 +956,24 @@ impl WeakConnectionHandle {
         self.0.upgrade().is_some()
     }
 
-    /// Resets the congestion controller and round-trip estimator for the current path.
+    /// Resets path-specific state.
     ///
-    /// This force-resets the congestion controller and round-trip estimator for the current
-    /// path.
+    /// This resets several subsystems keeping state for a specific network path.  It is
+    /// useful if it is known that the underlying network path changed substantially.
+    ///
+    /// Currently resets:
+    /// - RTT Estimator
+    /// - Congestion Controller
+    /// - MTU Discovery
     ///
     /// # Returns
     ///
     /// `true` if the connection still existed and the congestion controller state was
     /// reset.  `false` otherwise.
-    pub fn reset_congestion_state(&self) -> bool {
+    pub fn network_path_changed(&self) -> bool {
         if let Some(inner) = self.0.upgrade() {
             let mut inner_state = inner.state.lock("reset-congestion-state");
-            inner_state.inner.reset_congestion_state();
+            inner_state.inner.network_path_changed();
             true
         } else {
             false


### PR DESCRIPTION
The existing mechanism to reset the congestion controller and RTT estimator is insufficient: the MTU should also start anew when the path has changed.  This adds this to the same method and renames the functions to make their use clearer.