### PR TITLE
Merge latest release into 0.11.x

### DIFF
--- a/.github/workflows/rust-android-run-tests-on-emulator.sh
+++ b/.github/workflows/rust-android-run-tests-on-emulator.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+adb wait-for-device
+while [[ -z "$(adb shell getprop sys.boot_completed | tr -d '\r')" ]]; do sleep 1; done
+
+any_failures=0
+for test in $(find target/$TARGET/debug/deps/ -type f -executable ! -name "*.so" -name "*-*"); do
+    adb push "$test" /data/local/tmp/
+    adb shell chmod +x /data/local/tmp/$(basename "$test")
+    adb shell /data/local/tmp/$(basename "$test") || any_failures=1
+done
+
+exit $any_failures

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,3 +99,76 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: EmbarkStudios/cargo-deny-action@v2
+
+  test-android:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-linux-android
+            emulator-arch: x86_64
+            # Note that x86_64 image is only available for API 21+. See
+            # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#configurations.
+            api-level: 26
+          - target: i686-linux-android
+            emulator-arch: x86
+            api-level: 26
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: '21'
+
+    - name: Install Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Install Android NDK
+      run: sdkmanager --install "ndk;25.2.9519653"
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Install cargo-ndk
+      run: cargo install cargo-ndk
+
+    - name: Build unit tests for Android
+      run: cargo ndk -t ${{ matrix.target }} test --no-run
+
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Set up Android Emulator and run tests
+      env:
+        TARGET: ${{ matrix.target }}
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: ${{ matrix.api-level }}
+        arch: ${{ matrix.emulator-arch }}
+        script: .github/workflows/rust-android-run-tests-on-emulator.sh
+
+  features:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      RUSTFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack check --feature-powerset --optional-deps --no-dev-deps --ignore-unknown-features --ignore-private --group-features runtime-async-std,async-io,async-std --group-features runtime-smol,async-io,smol

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['0.10.x']
+    branches: ['0.10.x', '0.11.x']
   pull_request:
 
 jobs:

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn-proto/src/config.rs
+++ b/quinn-proto/src/config.rs
@@ -930,7 +930,7 @@ impl ServerConfig {
     ) -> Result<Self, rustls::Error> {
         Ok(Self::with_crypto(Arc::new(QuicServerConfig::new(
             cert_chain, key,
-        ))))
+        )?)))
     }
 }
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1207,6 +1207,7 @@ impl Connection {
         let mut stats = self.stats;
         stats.path.rtt = self.path.rtt.get();
         stats.path.cwnd = self.path.congestion.window();
+        stats.path.current_mtu = self.path.mtud.current_mtu();
 
         stats
     }

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -152,6 +152,8 @@ pub struct PathStats {
     pub lost_plpmtud_probes: u64,
     /// The number of times a black hole was detected in the path
     pub black_holes_detected: u64,
+    /// Largest UDP payload size the path currently supports
+    pub current_mtu: u16,
 }
 
 /// Connection statistics

--- a/quinn-proto/src/crypto/rustls.rs
+++ b/quinn-proto/src/crypto/rustls.rs
@@ -414,14 +414,14 @@ impl QuicServerConfig {
     pub(crate) fn new(
         cert_chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
-    ) -> Self {
-        let inner = Self::inner(cert_chain, key);
-        Self {
+    ) -> Result<Self, rustls::Error> {
+        let inner = Self::inner(cert_chain, key)?;
+        Ok(Self {
             // We're confident that the *ring* default provider contains TLS13_AES_128_GCM_SHA256
             initial: initial_suite_from_provider(inner.crypto_provider())
                 .expect("no initial cipher suite found"),
             inner: Arc::new(inner),
-        }
+        })
     }
 
     /// Initialize a QUIC-compatible TLS client configuration with a separate initial cipher suite
@@ -445,18 +445,17 @@ impl QuicServerConfig {
     pub(crate) fn inner(
         cert_chain: Vec<CertificateDer<'static>>,
         key: PrivateKeyDer<'static>,
-    ) -> rustls::ServerConfig {
+    ) -> Result<rustls::ServerConfig, rustls::Error> {
         let mut inner = rustls::ServerConfig::builder_with_provider(
             rustls::crypto::ring::default_provider().into(),
         )
         .with_protocol_versions(&[&rustls::version::TLS13])
         .unwrap() // The *ring* default provider supports TLS 1.3
         .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .unwrap();
+        .with_single_cert(cert_chain, key)?;
 
         inner.max_early_data_size = u32::MAX;
-        inner
+        Ok(inner)
     }
 }
 

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-quinn-udp"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -20,7 +20,7 @@ log = ["tracing/log"]
 direct-log = ["dep:log"]
 
 [dependencies]
-libc = "0.2.113"
+libc = "0.2.158"
 log = { workspace = true, optional = true }
 socket2 = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/quinn-udp/src/cmsg/mod.rs
+++ b/quinn-udp/src/cmsg/mod.rs
@@ -42,7 +42,7 @@ impl<'a, M: MsgHdr> Encoder<'a, M> {
     /// # Panics
     /// - If insufficient buffer space remains.
     /// - If `T` has stricter alignment requirements than `M::ControlMessage`
-    pub(crate) fn push<T: Copy + ?Sized>(&mut self, level: c_int, ty: c_int, value: T) {
+    pub(crate) fn push<T: Copy>(&mut self, level: c_int, ty: c_int, value: T) {
         assert!(mem::align_of::<T>() <= mem::align_of::<M::ControlMessage>());
         let space = M::ControlMessage::cmsg_space(mem::size_of_val(&value));
         assert!(

--- a/quinn-udp/src/lib.rs
+++ b/quinn-udp/src/lib.rs
@@ -158,7 +158,7 @@ fn log_sendmsg_error(
     if now.saturating_duration_since(*last_send_error) > IO_ERROR_LOG_INTERVAL {
         *last_send_error = now;
         log::warn!(
-        "sendmsg error: {:?}, Transmit: {{ destination: {:?}, src_ip: {:?}, enc: {:?}, len: {:?}, segment_size: {:?} }}",
+        "sendmsg error: {:?}, Transmit: {{ destination: {:?}, src_ip: {:?}, ecn: {:?}, len: {:?}, segment_size: {:?} }}",
             err, transmit.destination, transmit.src_ip, transmit.ecn, transmit.contents.len(), transmit.segment_size);
     }
 }

--- a/quinn-udp/src/unix.rs
+++ b/quinn-udp/src/unix.rs
@@ -1,4 +1,9 @@
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "openbsd",
+    target_os = "solaris",
+)))]
 use std::ptr;
 use std::{
     io::{self, IoSliceMut},
@@ -62,6 +67,7 @@ impl UdpSocketState {
             || cfg!(target_os = "macos")
             || cfg!(target_os = "ios")
             || cfg!(target_os = "android")
+            || cfg!(target_os = "solaris")
         {
             cmsg_platform_space +=
                 unsafe { libc::CMSG_SPACE(mem::size_of::<libc::in6_pktinfo>() as _) as usize };
@@ -84,7 +90,7 @@ impl UdpSocketState {
 
         // mac and ios do not support IP_RECVTOS on dual-stack sockets :(
         // older macos versions also don't have the flag and will error out if we don't ignore it
-        #[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+        #[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
         if is_ipv4 || !io.only_v6()? {
             if let Err(_err) =
                 set_socket_option(&*io, libc::IPPROTO_IP, libc::IP_RECVTOS, OPTION_ON)
@@ -138,10 +144,11 @@ impl UdpSocketState {
             target_os = "openbsd",
             target_os = "netbsd",
             target_os = "macos",
-            target_os = "ios"
+            target_os = "ios",
+            target_os = "solaris",
         ))]
         // IP_RECVDSTADDR == IP_SENDSRCADDR on FreeBSD
-        // macOS uses only IP_RECVDSTADDR, no IP_SENDSRCADDR on macOS
+        // macOS uses only IP_RECVDSTADDR, no IP_SENDSRCADDR on macOS (the same on Solaris)
         // macOS also supports IP_PKTINFO
         {
             if is_ipv4 {
@@ -367,7 +374,12 @@ fn send(state: &UdpSocketState, io: SockRef<'_>, transmit: &Transmit<'_>) -> io:
     Ok(())
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "openbsd")))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "openbsd",
+    target_os = "solaris",
+)))]
 fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> io::Result<usize> {
     let mut names = [MaybeUninit::<libc::sockaddr_storage>::uninit(); BATCH_SIZE];
     let mut ctrls = [cmsg::Aligned(MaybeUninit::<[u8; CMSG_LEN]>::uninit()); BATCH_SIZE];
@@ -383,10 +395,12 @@ fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> 
     }
     let msg_count = loop {
         let n = unsafe {
-            recvmmsg_with_fallback(
+            libc::recvmmsg(
                 io.as_raw_fd(),
                 hdrs.as_mut_ptr(),
                 bufs.len().min(BATCH_SIZE) as _,
+                0,
+                ptr::null_mut::<libc::timespec>(),
             )
         };
         if n == -1 {
@@ -404,7 +418,12 @@ fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> 
     Ok(msg_count as usize)
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "openbsd",
+    target_os = "solaris",
+))]
 fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> io::Result<usize> {
     let mut name = MaybeUninit::<libc::sockaddr_storage>::uninit();
     let mut ctrl = cmsg::Aligned(MaybeUninit::<[u8; CMSG_LEN]>::uninit());
@@ -426,76 +445,6 @@ fn recv(io: SockRef<'_>, bufs: &mut [IoSliceMut<'_>], meta: &mut [RecvMeta]) -> 
     };
     meta[0] = decode_recv(&name, &hdr, n as usize);
     Ok(1)
-}
-
-/// Implementation of `recvmmsg` with a fallback
-/// to `recvmsg` if syscall is not available.
-///
-/// It uses [`libc::syscall`] instead of [`libc::recvmmsg`]
-/// to avoid linking error on systems where libc does not contain `recvmmsg`.
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "openbsd")))]
-unsafe fn recvmmsg_with_fallback(
-    sockfd: libc::c_int,
-    msgvec: *mut libc::mmsghdr,
-    vlen: libc::c_uint,
-) -> libc::c_int {
-    let flags = 0;
-    let timeout = ptr::null_mut::<libc::timespec>();
-
-    #[cfg(not(any(target_os = "freebsd", target_os = "netbsd")))]
-    {
-        let ret =
-            libc::syscall(libc::SYS_recvmmsg, sockfd, msgvec, vlen, flags, timeout) as libc::c_int;
-        if ret != -1 {
-            return ret;
-        }
-    }
-
-    // libc on FreeBSD and NetBSD implement `recvmmsg` as a high-level abstraction over
-    // `recvmsg`, thus `SYS_recvmmsg` constant and direct system call do not exist
-    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
-    {
-        #[cfg(target_os = "freebsd")]
-        let vlen = vlen as usize;
-        let ret = libc::recvmmsg(sockfd, msgvec, vlen, flags, timeout) as libc::c_int;
-        if ret != -1 {
-            return ret;
-        }
-    }
-
-    let e = io::Error::last_os_error();
-    match e.raw_os_error() {
-        Some(libc::ENOSYS) => {
-            // Fallback to `recvmsg`.
-            recvmmsg_fallback(sockfd, msgvec, vlen)
-        }
-        _ => -1,
-    }
-}
-
-/// Fallback implementation of `recvmmsg` using `recvmsg`
-/// for systems which do not support `recvmmsg`
-/// such as Linux <2.6.33.
-#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "openbsd")))]
-unsafe fn recvmmsg_fallback(
-    sockfd: libc::c_int,
-    msgvec: *mut libc::mmsghdr,
-    vlen: libc::c_uint,
-) -> libc::c_int {
-    let flags = 0;
-    if vlen == 0 {
-        return 0;
-    }
-
-    let n = libc::recvmsg(sockfd, &mut (*msgvec).msg_hdr, flags);
-    if n == -1 {
-        -1
-    } else {
-        // type of `msg_len` field differs on Linux and FreeBSD,
-        // it is up to the compiler to infer and cast `n` to correct type
-        (*msgvec).msg_len = n as _;
-        1
-    }
 }
 
 const CMSG_LEN: usize = 88;
@@ -567,6 +516,7 @@ fn prepare_msg(
                     target_os = "netbsd",
                     target_os = "macos",
                     target_os = "ios",
+                    target_os = "solaris",
                 ))]
                 {
                     if encode_src_ip {
@@ -625,7 +575,7 @@ fn decode_recv(
                 ecn_bits = cmsg::decode::<u8, libc::cmsghdr>(cmsg);
             },
             // FreeBSD uses IP_RECVTOS here, and we can be liberal because cmsgs are opt-in.
-            #[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+            #[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
             (libc::IPPROTO_IP, libc::IP_RECVTOS) => unsafe {
                 ecn_bits = cmsg::decode::<u8, libc::cmsghdr>(cmsg);
             },

--- a/quinn-udp/tests/tests.rs
+++ b/quinn-udp/tests/tests.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::{
     io::IoSliceMut,
@@ -51,7 +51,7 @@ fn ecn_v6() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v4() {
     let send = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
     let recv = Socket::from(UdpSocket::bind("127.0.0.1:0").unwrap());
@@ -71,7 +71,7 @@ fn ecn_v4() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v6_dualstack() {
     let recv = socket2::Socket::new(
         socket2::Domain::IPV6,
@@ -114,7 +114,7 @@ fn ecn_v6_dualstack() {
 }
 
 #[test]
-#[cfg(not(any(target_os = "openbsd", target_os = "netbsd")))]
+#[cfg(not(any(target_os = "openbsd", target_os = "netbsd", target_os = "solaris")))]
 fn ecn_v4_mapped_v6() {
     let send = socket2::Socket::new(
         socket2::Domain::IPV6,

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-quinn"
-version = "0.11.3"
+version = "0.11.5"
 license.workspace = true
 repository.workspace = true
 description = "Versatile QUIC transport protocol implementation"
@@ -38,7 +38,7 @@ bytes = { workspace = true }
 futures-io = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 pin-project-lite = { workspace = true }
-proto = { package = "iroh-quinn-proto", path = "../quinn-proto", version = "0.11.2", default-features = false }
+proto = { package = "iroh-quinn-proto", path = "../quinn-proto", version = "0.11.8", default-features = false }
 rustls = { workspace = true, optional = true }
 smol = { workspace = true, optional = true }
 socket2 = { workspace = true }

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -523,6 +523,7 @@ fn run_echo(args: EchoArgs) {
             // requires modifying this test - please update the list of supported
             // platforms in the doc comment of `quinn_udp::RecvMeta::dst_ip`.
             if cfg!(target_os = "linux")
+                || cfg!(target_os = "android")
                 || cfg!(target_os = "freebsd")
                 || cfg!(target_os = "openbsd")
                 || cfg!(target_os = "netbsd")


### PR DESCRIPTION
This merges all the commits in the last release, i.e. the `main` branch up to the `quinn-udp-0.5.5` tag.

It adds one extra fix to CI to also run on pushes to the 0.11.x branch.  This was missed in the earlier creation of the 0.11.x branch.