### PR TITLE
Address ToDo about packet protection and 0rtt validation

### DIFF
--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -605,8 +605,7 @@ impl Endpoint {
             .packet
             .remote
             .decrypt(
-                None, // TODO(@divma): this is the initial packet check if we should have the cid
-                // -> path_id association already
+                None, // for the first packet multipath has not been negotiated
                 packet_number,
                 &incoming.packet.header_data,
                 &mut incoming.packet.payload,
@@ -908,8 +907,10 @@ impl Endpoint {
             INITIAL_MTU as usize - partial_encode.header_len - crypto.packet.local.tag_len();
         frame::Close::from(reason).encode(buf, max_len);
         buf.resize(buf.len() + crypto.packet.local.tag_len(), 0);
-        // TODO(@divma): unclear what does here, need to read more about initial close
-        let path_id: Option<crate::PathId> = None;
+        // initial close is done before the handshake is completed. At this point the multipath
+        // extension negotiation has not been finalized.
+        // TODO(@divma): verify
+        let path_id = None;
         partial_encode.finish(
             buf,
             &*crypto.header.local,

--- a/quinn-proto/src/transport_parameters.rs
+++ b/quinn-proto/src/transport_parameters.rs
@@ -216,7 +216,6 @@ impl TransportParameters {
                 "0-RTT accepted with incompatible transport parameters",
             ));
         }
-        // TODO(@divma): multipath validations?
         Ok(())
     }
 


### PR DESCRIPTION
This addresses 3 ToDos that don't actually change the code:
1. what path should be used to attempt to remove packet protection when receiving the first packet?
  None. The extension has not been successfully negotiated
2. what path should be used for packet protection of an initial close?
  None. Initial close is done before the handshake is completed and the extension has not been negotiated.
3. 0-rtt multipath validations:
  None: Section 7 of rfc9000 states that extensions must declare what happens with 0-rtt transport parameters and the draft states that `initial_max_path_id` must not be remembered. This is (to me) equivalent to silently ignoring any 0-rtt params as what comes from finalizing the handshake is used

All of this needs some review from someone else