### PR TITLE
ack-frequencies is allowed together with multipath

### DIFF
--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -2601,7 +2601,7 @@ fn immediate_ack_triggers_ack() {
 
     let acks_after_connect = pair.client_conn_mut(client_ch).stats().frame_rx.acks;
 
-    pair.client_conn_mut(client_ch).immediate_ack();
+    pair.client_conn_mut(client_ch).immediate_ack(PathId(0));
     pair.drive_client(); // Send immediate ack
     pair.drive_server(); // Process immediate ack
     pair.drive_client(); // Give the client a chance to process the ack


### PR DESCRIPTION
This moves the immediate-ack state to the path, I think this is multipath-compatible as much as normal acks are.