### PR TITLE
Rename PathMigrationData

### DIFF
--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -226,7 +226,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             stream_frames: sent.stream_frames,
         };
 
-        conn.paths.get_mut(&path_id).unwrap().path.sent(
+        conn.paths.get_mut(&path_id).unwrap().data.sent(
             path_id,
             exact_number,
             packet,


### PR DESCRIPTION
I mostly want to be able to write `path.data` to refer to the PathData rather than `path.path` or so.