### PR TITLE
Fix the LossDetection timer for multipath

### DIFF
--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -244,7 +244,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
                 }
                 conn.permit_idle_reset = false;
             }
-            conn.set_loss_detection_timer(path_id, now);
+            conn.set_loss_detection_timer(now);
             conn.path_data_mut(path_id).pacing.on_transmit(size);
         }
     }

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -9,7 +9,7 @@ use super::PathId;
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub(crate) enum Timer {
     /// When to send an ack-eliciting probe packet or declare unacked packets lost
-    LossDetection(PathId),
+    LossDetection,
     /// When to close the connection after no activity
     Idle,
     /// When the close timer expires, the connection has been gracefully terminated.


### PR DESCRIPTION
When setting the timer you need to find the earliest time it might fire across all paths.  So it does not need to know the path it is trying to be set on because it always looks at all paths.  And the timer itself does not need to know the PathId either, since when it fires it is looked up again.