### PR TITLE
simplify Timer::PushNewCid logic

### DIFF
--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -23,7 +23,7 @@ pub(crate) enum Timer {
     /// When pacing will allow us to send a packet
     Pacing(PathId),
     /// When to invalidate old CID and proactively push new one via NEW_CONNECTION_ID frame
-    PushNewCid(PathId),
+    PushNewCid,
     /// When to send an immediate ACK if there are unacked ack-eliciting packets of the peer
     MaxAckDelay,
 }


### PR DESCRIPTION
`Timer::PushNewCid` is never stopped so it doesn't need to be guarded against incidental stops. Doing this in a loop is more efficient than rearming constantly because we know there _will_ be push new cid timers that share the same expiry: from "proactively issuing new CIDs" when the connection is established and multipath is negotiated

I had already added some tests for this and the test keeps working fine