### PR TITLE
Add path id to spans to help with debugging

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -485,6 +485,7 @@ impl Connection {
     /// Open a new path
     ///
     /// Further errors might occur and they will be emitted in [`PathEvent::LocallyClosed`] events.
+    /// When the path is opened it will be reported as an [`PathEvent::Opened`].
     pub fn open_path(
         &mut self,
         remote: SocketAddr,
@@ -2934,8 +2935,8 @@ impl Connection {
             }
             Ok((packet, number)) => {
                 let span = match number {
-                    Some(pn) => trace_span!("recv", space = ?packet.header.space(), pn),
-                    None => trace_span!("recv", space = ?packet.header.space()),
+                    Some(pn) => trace_span!("recv", space = ?packet.header.space(), pn, %path_id),
+                    None => trace_span!("recv", space = ?packet.header.space(), %path_id),
                 };
                 let _guard = span.enter();
 
@@ -3405,7 +3406,7 @@ impl Connection {
             let frame = result?;
             let span = match frame {
                 Frame::Padding => continue,
-                _ => trace_span!("frame", ty = %frame.ty()),
+                _ => trace_span!("frame", ty = %frame.ty(), ?path_id),
             };
 
             self.stats.frame_rx.record(&frame);

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -87,7 +87,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
 
         let space = &mut conn.spaces[space_id];
         let exact_number = space.for_path(path_id).get_tx_number(&mut conn.rng);
-        let span = trace_span!("send", space = ?space_id, pn = exact_number).entered();
+        let span = trace_span!("send", space = ?space_id, pn = exact_number, %path_id).entered();
 
         let number = PacketNumber::new(
             exact_number,


### PR DESCRIPTION
Adds the path id to the send and recv spans to help with debugging. Probably useful for everyone so adding this change early