### PR TITLE
fix some path status bugs, improve path status story

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -560,7 +560,7 @@ impl Connection {
         // Create PathData, schedule PATH_CHALLENGE to be sent.
         // TODO(flub): Not sure if we need to send a PATH_CHALLENGE in all situations?
         let mut path = PathData::new(remote, self.allow_mtud, None, now, &self.config);
-        path.status.local_status = initial_status;
+        path.status.local_update(initial_status);
         path.challenge = Some(self.rng.random());
         path.challenge_pending = true;
         self.paths.insert(
@@ -572,7 +572,10 @@ impl Connection {
         );
 
         // Inform the remote of the path status.
-        self.spaces[SpaceId::Data].pending.path_status.push(path_id);
+        self.spaces[SpaceId::Data]
+            .pending
+            .path_status
+            .insert(path_id);
         let pn_space = spaces::PacketNumberSpace::new(now, SpaceId::Data, &mut self.rng);
         self.spaces[SpaceId::Data]
             .number_spaces
@@ -628,10 +631,9 @@ impl Connection {
 
     /// Gets the [`PathStatus`] for a known [`PathId`]
     pub fn path_status(&self, path_id: PathId) -> Result<PathStatus, ClosedPath> {
-        match self.paths.get(&path_id) {
-            Some(path) => Ok(path.data.status.local_status),
-            None => Err(ClosedPath { _private: () }),
-        }
+        self.path(path_id)
+            .map(PathData::local_status)
+            .ok_or(ClosedPath { _private: () })
     }
 
     /// Sets the [`PathStatus`] for a known [`PathId`]
@@ -642,15 +644,18 @@ impl Connection {
         path_id: PathId,
         status: PathStatus,
     ) -> Result<PathStatus, ClosedPath> {
-        match self.paths.get_mut(&path_id) {
-            Some(path) => {
-                let prev_status = path.data.status.local_status;
-                path.data.status.local_status = status;
-                self.spaces[SpaceId::Data].pending.path_status.push(path_id);
-                Ok(prev_status)
+        let path = self.path_mut(path_id).ok_or(ClosedPath { _private: () })?;
+        let prev = match path.status.local_update(status) {
+            Some(prev) => {
+                self.spaces[SpaceId::Data]
+                    .pending
+                    .path_status
+                    .insert(path_id);
+                prev
             }
-            None => Err(ClosedPath { _private: () }),
-        }
+            None => path.local_status(),
+        };
+        Ok(prev)
     }
 
     /// Returns the remote path status
@@ -658,9 +663,7 @@ impl Connection {
     //    this as an API, but for now it allows me to write a test easily.
     // TODO(flub): Technically this should be a Result<Option<PathSTatus>>?
     pub fn remote_path_status(&self, path_id: PathId) -> Option<PathStatus> {
-        self.paths
-            .get(&path_id)
-            .and_then(|path| path.data.status.remote_status)
+        self.path(path_id).and_then(|path| path.remote_status())
     }
 
     /// Sets the max_idle_timeout for a specific path
@@ -826,7 +829,7 @@ impl Connection {
         let have_available_path = self
             .paths
             .values()
-            .any(|path| path.data.status.local_status == PathStatus::Available);
+            .any(|path| path.data.local_status() == PathStatus::Available);
 
         // Setup for the first path_id
         let mut transmit = TransmitBuf::new(
@@ -907,7 +910,7 @@ impl Connection {
             let path_should_send = {
                 let path_exclusive_only = space_id == SpaceId::Data
                     && have_available_path
-                    && self.path_data(path_id).status.local_status == PathStatus::Backup;
+                    && self.path_data(path_id).local_status() == PathStatus::Backup;
                 let path_should_send = if path_exclusive_only {
                     can_send.path_exclusive
                 } else {
@@ -1174,7 +1177,7 @@ impl Connection {
 
             let sent_frames = {
                 let path_exclusive_only = have_available_path
-                    && self.path_data(path_id).status.local_status == PathStatus::Backup;
+                    && self.path_data(path_id).local_status() == PathStatus::Backup;
                 let pn = builder.exact_number;
                 self.populate_packet(
                     now,
@@ -4399,22 +4402,16 @@ impl Connection {
             && space_id == SpaceId::Data
             && frame::PathAvailable::SIZE_BOUND <= buf.remaining_mut()
         {
-            let Some(path_id) = space.pending.path_status.pop() else {
+            let Some(path_id) = space.pending.path_status.pop_first() else {
                 break;
             };
-            let Some(path) = self
-                .paths
-                .get_mut(&path_id)
-                .map(|path_state| &mut path_state.data)
-            else {
+            let Some(path) = self.paths.get(&path_id).map(|path_state| &path_state.data) else {
                 trace!(%path_id, "discarding queued path status for unknown path");
                 continue;
             };
 
-            let status_state = &mut path.status;
-            let seq = status_state.local_seq;
-            status_state.local_seq = status_state.local_seq.saturating_add(1u8);
-            match status_state.local_status {
+            let seq = path.status.seq();
+            match path.local_status() {
                 PathStatus::Available => {
                     frame::PathAvailable {
                         path_id,
@@ -5126,7 +5123,7 @@ impl Connection {
     /// Handle new path status information: PATH_AVAILABLE, PATH_BACKUP
     fn on_path_status(&mut self, path_id: PathId, status: PathStatus, status_seq_no: VarInt) {
         if let Some(path) = self.paths.get_mut(&path_id) {
-            path.data.status.on_path_status(status, status_seq_no);
+            path.data.status.remote_update(status, status_seq_no);
         } else {
             debug!("PATH_AVAILABLE received unknown path {:?}", path_id);
         }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4413,6 +4413,7 @@ impl Connection {
             };
 
             let seq = path.status.seq();
+            sent.retransmits.get_or_create().path_status.insert(path_id);
             match path.local_status() {
                 PathStatus::Available => {
                     frame::PathAvailable {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4275,7 +4275,7 @@ impl Connection {
 
                 // TODO(@divma): this is a bit of a bandaid, revisit this once the validation story
                 // is clear
-                if !path.validated {
+                if is_multipath_negotiated && !path.validated {
                     // queue informing the path status along with the challenge
                     space.pending.path_status.insert(path_id);
                 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -571,11 +571,6 @@ impl Connection {
             },
         );
 
-        // Inform the remote of the path status.
-        self.spaces[SpaceId::Data]
-            .pending
-            .path_status
-            .insert(path_id);
         let pn_space = spaces::PacketNumberSpace::new(now, SpaceId::Data, &mut self.rng);
         self.spaces[SpaceId::Data]
             .number_spaces
@@ -4277,6 +4272,13 @@ impl Connection {
                 trace!("PATH_CHALLENGE {:08x}", token);
                 buf.write(frame::FrameType::PATH_CHALLENGE);
                 buf.write(token);
+
+                // TODO(@divma): this is a bit of a bandaid, revisit this once the validation story
+                // is clear
+                if !path.validated {
+                    // queue informing the path status along with the challenge
+                    space.pending.path_status.insert(path_id);
+                }
 
                 // Always include an OBSERVED_ADDR frame with a PATH_CHALLENGE, regardless
                 // of whether one has already been sent on this path.

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -548,9 +548,8 @@ impl PathStatusState {
             return None;
         }
 
-        let prev = std::mem::replace(&mut self.local_status, status);
         self.local_seq = self.local_seq.saturating_add(1u8);
-        return Some(prev);
+        Some(std::mem::replace(&mut self.local_status, status))
     }
 
     pub(crate) fn seq(&self) -> VarInt {

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -324,6 +324,14 @@ impl PathData {
             }
         }
     }
+
+    pub(crate) fn remote_status(&self) -> Option<PathStatus> {
+        self.status.remote_status.map(|(_seq, status)| status)
+    }
+
+    pub(crate) fn local_status(&self) -> PathStatus {
+        self.status.local_status
+    }
 }
 
 /// RTT estimation for a particular network path
@@ -510,29 +518,43 @@ impl InFlight {
 #[derive(Debug, Clone, Default)]
 pub(super) struct PathStatusState {
     /// The local status
-    pub(super) local_status: PathStatus,
+    local_status: PathStatus,
     /// Local sequence number, for both PATH_AVAIALABLE and PATH_BACKUP
     ///
     /// This is the number of the *next* path status frame to be sent.
-    pub(super) local_seq: VarInt,
+    local_seq: VarInt,
     /// The status set by the remote
-    pub(super) remote_status: Option<PathStatus>,
-    /// Remote sequence number, for both PATH_AVAIALABLE and PATH_BACKUP
-    pub(super) remote_seq: Option<VarInt>,
+    remote_status: Option<(VarInt, PathStatus)>,
 }
 
 impl PathStatusState {
     /// To be called on received PATH_AVAILABLE/PATH_BACKUP frames
-    pub(super) fn on_path_status(&mut self, status: PathStatus, seq: VarInt) {
-        if Some(seq) <= self.remote_seq {
-            tracing::warn!("whoops");
-            return;
+    pub(super) fn remote_update(&mut self, status: PathStatus, seq: VarInt) {
+        if self.remote_status.is_some_and(|(curr, _)| curr >= seq) {
+            return trace!(%seq, "ignoring path status update");
         }
-        self.remote_seq = Some(seq);
-        let prev = self.remote_status.replace(status);
+
+        let prev = self.remote_status.replace((seq, status)).map(|(_, s)| s);
         if prev != Some(status) {
             debug!(?status, ?seq, "remote changed path status");
         }
+    }
+
+    /// Updates the local status
+    ///
+    /// If the local status changed, the previous value is returned
+    pub(super) fn local_update(&mut self, status: PathStatus) -> Option<PathStatus> {
+        if self.local_status == status {
+            return None;
+        }
+
+        let prev = std::mem::replace(&mut self.local_status, status);
+        self.local_seq = self.local_seq.saturating_add(1u8);
+        return Some(prev);
+    }
+
+    pub(crate) fn seq(&self) -> VarInt {
+        self.local_seq
     }
 }
 

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp,
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     mem,
     ops::{Bound, Index, IndexMut},
 };
@@ -544,8 +544,8 @@ pub struct Retransmits {
     pub(super) new_tokens: Vec<SocketAddr>,
     /// Paths which need to be abandoned
     pub(super) path_abandon: Vec<(PathId, TransportErrorCode)>,
-    /// If a PATH_AVAILABLE and PATH_BACKUP frame needs to be sent for a path
-    pub(super) path_status: Vec<PathId>,
+    /// If a [`frame::PathAvailable`] and [`frame::PathBackup`] need to be sent for a path
+    pub(super) path_status: BTreeSet<PathId>,
     /// If a PATH_CIDS_BLOCKED frame needs to be sent for a path
     pub(super) path_cids_blocked: Vec<PathId>,
 }


### PR DESCRIPTION
- changes the `PathStatusState` to fully contain status updates, both local and remote
- change the scheduling of path status frames to be sent only after the challenge is sent. Note that this is probably not enough, just better than the current state. This is not enough because the application can (in theory, even if unlikely) change the status before the path is really open and this bypasses the initial scheduling
- changes the pending paths to ensure only the last status is sent
- registers the sent frame with retransmits