### PR TITLE
handle some edge cases in opening a path

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4511,9 +4511,11 @@ impl Connection {
                 buf.write(frame::FrameType::PATH_CHALLENGE);
                 buf.write(token);
 
-                // TODO(@divma): this is a bit of a bandaid, revisit this once the validation story
-                // is clear
                 if is_multipath_negotiated && !path.validated {
+                    let pto = self.ack_frequency.max_ack_delay_for_pto() + path.rtt.pto_base();
+                    self.timers
+                        .set(Timer::PathValidation(path_id), now + 3 * pto);
+
                     // queue informing the path status along with the challenge
                     space.pending.path_status.insert(path_id);
                 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3725,7 +3725,7 @@ impl Connection {
             let frame = result?;
             let span = match frame {
                 Frame::Padding => continue,
-                _ => trace_span!("frame", ty = %frame.ty(), %path_id),
+                _ => trace_span!("frame", ty = %frame.ty()),
             };
 
             self.stats.frame_rx.record(&frame);

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -576,24 +576,9 @@ impl Connection {
             return Err(PathError::RemoteCidsExhausted);
         }
 
-        // Create PathData, schedule PATH_CHALLENGE to be sent.
-        // TODO(flub): Not sure if we need to send a PATH_CHALLENGE in all situations?
-        let mut path = PathData::new(remote, self.allow_mtud, None, now, &self.config);
+        debug!(%path_id, "ensuring path");
+        let path = self.ensure_path(path_id, remote, now, None);
         path.status.local_update(initial_status);
-        path.challenge = Some(self.rng.random());
-        path.challenge_pending = true;
-        self.paths.insert(
-            path_id,
-            PathState {
-                data: path,
-                prev: None,
-            },
-        );
-
-        let pn_space = spaces::PacketNumberSpace::new(now, SpaceId::Data, &mut self.rng);
-        self.spaces[SpaceId::Data]
-            .number_spaces
-            .insert(path_id, pn_space);
 
         Ok(path_id)
     }
@@ -750,24 +735,44 @@ impl Connection {
         &mut self.paths.get_mut(&path_id).expect("known path").data
     }
 
-    fn ensure_path(&mut self, path_id: PathId, remote: SocketAddr, now: Instant, pn: Option<u64>) {
-        // TODO(@divma): consider adding here some validation params/logic, ej: if the remote is
-        // known, adding a challenge, etc
-        let btree_map::Entry::Vacant(vacant_entry) = self.paths.entry(path_id) else {
-            return;
+    fn ensure_path(
+        &mut self,
+        path_id: PathId,
+        remote: SocketAddr,
+        now: Instant,
+        pn: Option<u64>,
+    ) -> &mut PathData {
+        let validated = self
+            .paths
+            .values()
+            .any(|path_state| path_state.data.remote == remote && path_state.data.validated);
+        // TODO(@divma): we might want to ensure the path has been recently active to consider the
+        // address validated
+
+        let vacant_entry = match self.paths.entry(path_id) {
+            btree_map::Entry::Vacant(vacant_entry) => vacant_entry,
+            btree_map::Entry::Occupied(occupied_entry) => {
+                return &mut occupied_entry.into_mut().data;
+            }
         };
 
-        debug!(%path_id, "path added");
+        debug!(%validated, %path_id, "path added");
         let peer_max_udp_payload_size =
             u16::try_from(self.peer_params.max_udp_payload_size.into_inner()).unwrap_or(u16::MAX);
-        let data = PathData::new(
+        let mut data = PathData::new(
             remote,
             self.allow_mtud,
             Some(peer_max_udp_payload_size),
             now,
             &self.config,
         );
-        vacant_entry.insert(PathState { data, prev: None });
+
+        if !validated {
+            data.challenge = Some(self.rng.random());
+            data.challenge_pending = true;
+        }
+
+        let path = vacant_entry.insert(PathState { data, prev: None });
 
         let mut pn_space = spaces::PacketNumberSpace::new(now, SpaceId::Data, &mut self.rng);
         if let Some(pn) = pn {
@@ -776,6 +781,7 @@ impl Connection {
         self.spaces[SpaceId::Data]
             .number_spaces
             .insert(path_id, pn_space);
+        &mut path.data
     }
     /// Returns packets to transmit
     ///
@@ -969,7 +975,7 @@ impl Connection {
 
             if !path_should_send && space_id < SpaceId::Data {
                 if self.spaces[space_id].crypto.is_some() {
-                    trace!(?space_id, ?path_id, "nothing to send in space");
+                    trace!(?space_id, %path_id, "nothing to send in space");
                 }
                 space_id = space_id.next();
                 continue;
@@ -982,7 +988,7 @@ impl Connection {
                 PathBlocked::No
             };
             if send_blocked != PathBlocked::No {
-                trace!(?space_id, ?path_id, ?send_blocked, "congestion blocked");
+                trace!(?space_id, %path_id, ?send_blocked, "congestion blocked");
                 congestion_blocked = true;
             }
             if send_blocked == PathBlocked::Congestion && space_id < SpaceId::Data {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -771,7 +771,7 @@ impl Connection {
 
         data.validated = validated;
 
-        // for the path to be opened we need to send a package on the path. Sending a challenge
+        // for the path to be opened we need to send a packet on the path. Sending a challenge
         // guarantees this
         data.challenge = Some(self.rng.random());
         data.challenge_pending = true;

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -5578,7 +5578,7 @@ pub enum PathError {
     MaxPathIdReached,
     /// No remote CIDs avaiable to open a new path
     RemoteCidsExhausted,
-    /// Path could not be validated and was abandoned
+    /// Path could not be validated and will be abandoned
     ValidationFailed,
 }
 

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -18,8 +18,10 @@ pub(crate) enum Timer {
     Close,
     /// When keys are discarded because they should not be needed anymore
     KeyDiscard,
-    /// When to give up on validating a new path to the peer
+    /// When to give up on validating a new path from unintentional migration
     PathValidation(PathId),
+    /// When to give up on validating an intentionally created new (multi)path
+    PathOpen(PathId),
     /// When to send a `PING` frame to keep the connection alive
     KeepAlive,
     /// When to send a `PING` frame to keep the path alive

--- a/quinn-proto/src/tests/multipath.rs
+++ b/quinn-proto/src/tests/multipath.rs
@@ -386,7 +386,7 @@ fn open_path() {
     );
 }
 
-/// Client starts opening a path but validation fails
+/// Client starts opening a path but the server fails to validate the path
 ///
 /// The client should receive an event closing the path.
 #[test]
@@ -407,6 +407,9 @@ fn open_path_validation_fails_server_side() {
         client_conn.poll().unwrap(),
         Event::Path(crate::PathEvent::LocallyClosed { id, error: PathError::ValidationFailed  }) if id == path_id
     );
+
+    let server_conn = pair.server_conn_mut(client_ch);
+    assert!(server_conn.poll().is_none());
 }
 
 #[test]

--- a/quinn-proto/src/tests/multipath.rs
+++ b/quinn-proto/src/tests/multipath.rs
@@ -377,6 +377,12 @@ fn open_path() {
         client_conn.poll().unwrap(),
         Event::Path(crate::PathEvent::Opened { id  }) if id == path_id
     );
+
+    let server_conn = pair.server_conn_mut(client_ch);
+    assert_matches!(
+        server_conn.poll().unwrap(),
+        Event::Path(crate::PathEvent::Opened { id  }) if id == path_id
+    );
 }
 
 #[test]

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -551,7 +551,11 @@ impl ::std::ops::DerefMut for TestEndpoint {
 
 pub(super) fn subscribe() -> tracing::subscriber::DefaultGuard {
     let builder = tracing_subscriber::FmtSubscriber::builder()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::Level::TRACE.into())
+                .from_env_lossy(),
+        )
         .with_line_number(true)
         .with_writer(|| TestWriter);
     // tracing uses std::time to trace time, which panics in wasm.

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -165,6 +165,7 @@ impl Pair {
         }
     }
 
+    /// Drive both endpoints optionally preventing them from receiving traffic
     pub(super) fn blackhole_step(
         &mut self,
         server_blackhole: bool,

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -536,7 +536,7 @@ impl ::std::ops::DerefMut for TestEndpoint {
 
 pub(super) fn subscribe() -> tracing::subscriber::DefaultGuard {
     let builder = tracing_subscriber::FmtSubscriber::builder()
-        .with_max_level(tracing::Level::TRACE)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_line_number(true)
         .with_writer(|| TestWriter);
     // tracing uses std::time to trace time, which panics in wasm.


### PR DESCRIPTION
This PR continues work around opening a path:
- check if the remote is known to consider a path validated on both client and server sides
- still send the PATH_CHALLENGE. The reason for this is keeping some logic simple: emitting the event that declares to the application that the path is open is supposed to be "usable" more than open, for this we need the path to be open and validated. Simply sending the PATH_CHALLENGE ensures the path is opened in any case by guaranteeing something is sent on the path and something is received in return (the PATH_RESPONSE). This is a single frame that ids in this, while still keeping the path as validated and immediately usable if the remote is known
- sets validation timers for opening a path. For this I chose a different timer because the current one deals with unintentional migration, similar but ultimately unrelated
- expand the existing opening path test to include the server getting informed of a path being opened
- add both test cases for validation failures on both sides
- miscellaneous changes in spans, fields removed because they exist in the parent span, use of display for paths, etc