### PR TITLE
fix open path timer issues

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -771,6 +771,9 @@ impl Connection {
 
         data.validated = validated;
 
+        let pto = self.ack_frequency.max_ack_delay_for_pto() + data.rtt.pto_base();
+        self.timers.set(Timer::PathOpen(path_id), now + 3 * pto);
+
         // for the path to be opened we need to send a packet on the path. Sending a challenge
         // guarantees this
         data.challenge = Some(self.rng.random());
@@ -4586,9 +4589,6 @@ impl Connection {
                 buf.write(token);
 
                 if is_multipath_negotiated && !path.validated && path.challenge_pending {
-                    let pto = self.ack_frequency.max_ack_delay_for_pto() + path.rtt.pto_base();
-                    self.timers.set(Timer::PathOpen(path_id), now + 3 * pto);
-
                     // queue informing the path status along with the challenge
                     space.pending.path_status.insert(path_id);
                 }

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3884,8 +3884,11 @@ impl Connection {
                         .get_mut(&path_id)
                         .expect("payload is processed only after the path becomes known");
                     if path.data.challenge == Some(token) && remote == path.data.remote {
-                        trace!("new path validated");
                         self.timers.stop(Timer::PathValidation(path_id));
+                        if !path.data.validated {
+                            trace!("new path validated");
+                        }
+                        self.timers.stop(Timer::PathOpen(path_id));
                         path.data.challenge = None;
                         path.data.validated = true;
                         self.events

--- a/quinn-proto/src/connection/timer.rs
+++ b/quinn-proto/src/connection/timer.rs
@@ -18,9 +18,9 @@ pub(crate) enum Timer {
     Close,
     /// When keys are discarded because they should not be needed anymore
     KeyDiscard,
-    /// When to give up on validating a new path from unintentional migration
+    /// When to give up on validating a new path from RFC9000 migration
     PathValidation(PathId),
-    /// When to give up on validating an intentionally created new (multi)path
+    /// When to give up on validating a new (multi)path
     PathOpen(PathId),
     /// When to send a `PING` frame to keep the connection alive
     KeepAlive,


### PR DESCRIPTION
- improve comment to distinguish migrations only as RFC9000 and multipath's path creation
- actually stop timer when frames are received
- set the open path timer when the path is created in the internal state, not when the frame is sent