### PR TITLE
add public api for observed address with multipath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "fuzz"
 version = "0.1.0"
 dependencies = [
@@ -2320,6 +2326,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4164,6 +4164,8 @@ impl Connection {
                     let path = self.path_data_mut(path_id);
                     if remote == path.remote {
                         if let Some(updated) = path.update_observed_addr_report(observed) {
+                            // TODO(@divma): this event is being received awkwardly out of order
+                            // with the open path event
                             self.events.push_back(Event::Path(PathEvent::ObservedAddr {
                                 id: path_id,
                                 addr: updated,

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -171,6 +171,13 @@ pub(super) struct PathData {
     /// [`TransportParameters`]: crate::transport_parameters::TransportParameters
     pub(super) keep_alive: Option<Duration>,
 
+    /// Whether the path has already been considered opened from an application perspective
+    ///
+    /// This means, for paths other than the original [`PathId::ZERO`], a first path challenge has
+    /// been responded to, regardless of the initial validation status of the path. This state is
+    /// irreversible, since it's not affected by the path being closed.
+    pub(super) open: bool,
+
     /// Snapshot of the qlog recovery metrics
     #[cfg(feature = "qlog")]
     recovery_metrics: RecoveryMetrics,
@@ -229,6 +236,7 @@ impl PathData {
             pto_count: 0,
             idle_timeout: None,
             keep_alive: None,
+            open: false,
             #[cfg(feature = "qlog")]
             recovery_metrics: RecoveryMetrics::default(),
         }
@@ -262,6 +270,7 @@ impl PathData {
             pto_count: 0,
             idle_timeout: prev.idle_timeout,
             keep_alive: prev.keep_alive,
+            open: false,
             #[cfg(feature = "qlog")]
             recovery_metrics: prev.recovery_metrics.clone(),
         }

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -756,6 +756,22 @@ pub enum PathEvent {
         /// The new status set by the remote
         status: PathStatus,
     },
+    // TODO(@divma): remove after consideration
+    // The public API of quinn reports path events (this enum) and based on that it's convenient
+    // to include externally observed addresses here. This is maybe not the best in terms of
+    // separation of concerns, and a more appropriate aproach would be to create a new event type
+    // for the external API. Since this is the only "mixed topics" event so far, the alternative
+    // to having the event here is an overkill. We should consider both options depending on the
+    // number of non-strictly-multipath events that end up here and remove this note or make the
+    // change restoring the event to the higher level.
+    /// Received an observation of our external address from the peer.
+    ObservedAddr {
+        /// Path over which the observed address was reported, [`PathId::ZERO`] when multipath is
+        /// not negotiated
+        id: PathId,
+        /// The address observed by the remote over this path
+        addr: SocketAddr,
+    },
 }
 
 /// Error indicating that a path has not been opened or has already been abandoned

--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -3453,7 +3453,7 @@ fn address_discovery() {
     let conn = pair.client_conn_mut(conn_handle);
     assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
     assert_matches!(conn.poll(), Some(Event::Connected));
-    assert_matches!(conn.poll(), Some(Event::ObservedAddr(addr)) if addr == expected_addr);
+    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
     assert_matches!(conn.poll(), None);
 
     // check that the server received the correct address
@@ -3462,7 +3462,7 @@ fn address_discovery() {
     let conn = pair.server_conn_mut(conn_handle);
     assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
     assert_matches!(conn.poll(), Some(Event::Connected));
-    assert_matches!(conn.poll(), Some(Event::ObservedAddr(addr)) if addr == expected_addr);
+    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
     assert_matches!(conn.poll(), None);
 }
 
@@ -3658,8 +3658,7 @@ fn address_discovery_retransmission() {
 
     pair.drive();
     let conn = pair.client_conn_mut(client_ch);
-    assert_matches!(conn.poll(),
-        Some(Event::ObservedAddr(addr)) if addr == pair.client.addr);
+    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == pair.client.addr);
 }
 
 #[test]
@@ -3701,8 +3700,7 @@ fn address_discovery_rebind_retransmission() {
 
     pair.drive();
     let conn = pair.client_conn_mut(client_ch);
-    assert_matches!(conn.poll(),
-        Some(Event::ObservedAddr(addr)) if addr == pair.client.addr);
+    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == pair.client.addr);
 }
 
 #[test]

--- a/quinn-proto/src/tests/multipath.rs
+++ b/quinn-proto/src/tests/multipath.rs
@@ -14,7 +14,7 @@ use crate::{
     EndpointConfig, Instant, LOC_CID_COUNT, PathId, PathStatus, RandomConnectionIdGenerator,
     ServerConfig, TransportConfig, cid_queue::CidQueue,
 };
-use crate::{Event, PathError};
+use crate::{Event, PathError, PathEvent};
 
 use super::util::{min_opt, subscribe};
 use super::{Pair, client_config, server_config};
@@ -506,4 +506,67 @@ fn close_last_path() {
 
     assert!(pair.server_conn_mut(server_ch).is_closed());
     assert!(pair.client_conn_mut(client_ch).is_closed());
+}
+
+#[test]
+fn per_path_observed_address() {
+    let _guard = subscribe();
+    // create the endpoint pair with both address discovery and multipath enabled
+    let (mut pair, client_ch, server_ch) = {
+        let transport_cfg = Arc::new(TransportConfig {
+            max_concurrent_multipath_paths: NonZeroU32::new(MAX_PATHS),
+            address_discovery_role: crate::address_discovery::Role::Both,
+            ..TransportConfig::default()
+        });
+        let server_cfg = Arc::new(ServerConfig {
+            transport: transport_cfg.clone(),
+            ..server_config()
+        });
+        let server = Endpoint::new(Default::default(), Some(server_cfg), true, None);
+        let client = Endpoint::new(Default::default(), None, true, None);
+
+        let mut pair = Pair::new_from_endpoint(client, server);
+        let client_cfg = ClientConfig {
+            transport: transport_cfg,
+            ..client_config()
+        };
+        let (client_ch, server_ch) = pair.connect_with(client_cfg);
+        pair.drive();
+        info!("connected");
+        (pair, client_ch, server_ch)
+    };
+
+    // check that the client received the correct address
+    let expected_addr = pair.client.addr;
+    let conn = pair.client_conn_mut(client_ch);
+    // assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
+    // assert_matches!(conn.poll(), Some(Event::Connected));
+    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
+    assert_matches!(conn.poll(), None);
+
+    // check that the server received the correct address
+    let expected_addr = pair.server.addr;
+    let conn = pair.server_conn_mut(server_ch);
+    // assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
+    // assert_matches!(conn.poll(), Some(Event::Connected));
+    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
+    assert_matches!(conn.poll(), None);
+
+    // simulate a rebind on thte client
+    pair.client_conn_mut(client_ch).local_address_changed();
+    pair.client
+        .addr
+        .set_port(pair.client.addr.port().overflowing_add(1).0);
+
+    // open a second path
+    let remote = pair.server.addr;
+    let conn = pair.client_conn_mut(client_ch);
+    conn.open_path(remote, PathStatus::Available, Instant::now());
+
+    pair.drive();
+    let conn = pair.client_conn_mut(client_ch);
+    while let Some(event) = conn.poll() {
+        tracing::info!(?event, "after rebind and open path")
+    }
+    // assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == pair.client.addr);
 }

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -517,6 +517,7 @@ impl TestEndpoint {
         self.outbound.extend(split_transmit(transmit, &buf[..size]));
     }
 
+    #[track_caller]
     pub(super) fn assert_accept(&mut self) -> ConnectionHandle {
         self.accepted
             .take()
@@ -524,6 +525,7 @@ impl TestEndpoint {
             .expect("server experienced error connecting")
     }
 
+    #[track_caller]
     pub(super) fn assert_accept_error(&mut self) -> ConnectionError {
         self.accepted
             .take()
@@ -531,6 +533,7 @@ impl TestEndpoint {
             .expect_err("server did unexpectedly connect without error")
     }
 
+    #[track_caller]
     pub(super) fn assert_no_accept(&self) {
         assert!(self.accepted.is_none(), "server did unexpectedly connect")
     }

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -66,6 +66,7 @@ udp = { package = "iroh-quinn-udp", path = "../quinn-udp", version = "0.5", defa
 async-global-executor = { workspace = true, optional = true }
 async-fs = { workspace = true, optional = true }
 async-executor = { workspace = true, optional = true }
+tokio-stream = { version = "0.1.15", features = ["sync"] }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 socket2 = { workspace = true }

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1103,7 +1103,7 @@ pub(crate) struct State {
     /// Number of live handles that can be used to initiate or handle I/O; excludes the driver
     ref_count: usize,
     sender: Pin<Box<dyn UdpSender>>,
-    runtime: Arc<dyn Runtime>,
+    pub(crate) runtime: Arc<dyn Runtime>,
     send_buffer: Vec<u8>,
     /// We buffer a transmit when the underlying I/O would block
     buffered_transmit: Option<proto::Transmit>,

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1099,7 +1099,7 @@ pub(crate) struct State {
     open_path: FxHashMap<PathId, watch::Sender<Option<Result<(), PathError>>>>,
     /// Tracks paths being closed
     pub(crate) close_path: FxHashMap<PathId, oneshot::Sender<VarInt>>,
-    path_events: tokio::sync::broadcast::Sender<PathEvent>,
+    pub(crate) path_events: tokio::sync::broadcast::Sender<PathEvent>,
     /// Number of live handles that can be used to initiate or handle I/O; excludes the driver
     ref_count: usize,
     sender: Pin<Box<dyn UdpSender>>,
@@ -1107,7 +1107,8 @@ pub(crate) struct State {
     send_buffer: Vec<u8>,
     /// We buffer a transmit when the underlying I/O would block
     buffered_transmit: Option<proto::Transmit>,
-    /// Our last external address reported by the peer.
+    /// Our last external address reported by the peer. When multipath is enabled, this will be the
+    /// last report across all paths.
     pub(crate) observed_external_addr: watch::Sender<Option<SocketAddr>>,
 }
 
@@ -1255,7 +1256,8 @@ impl State {
                     wake_stream_notify(id, &mut self.stopped);
                     wake_stream(id, &mut self.blocked_writers);
                 }
-                ObservedAddr(observed) => {
+                Path(ref evt @ PathEvent::ObservedAddr { id, addr: observed }) => {
+                    self.path_events.send(evt.clone()).ok();
                     self.observed_external_addr.send_if_modified(|addr| {
                         let old = addr.replace(observed);
                         old != *addr

--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -1256,7 +1256,7 @@ impl State {
                     wake_stream_notify(id, &mut self.stopped);
                     wake_stream(id, &mut self.blocked_writers);
                 }
-                Path(ref evt @ PathEvent::ObservedAddr { id, addr: observed }) => {
+                Path(ref evt @ PathEvent::ObservedAddr { addr: observed, .. }) => {
                     self.path_events.send(evt.clone()).ok();
                     self.observed_external_addr.send_if_modified(|addr| {
                         let old = addr.replace(observed);

--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -195,8 +195,7 @@ impl Future for ClosePath {
 /// Stream produced by [`Path::observed_external_addr`]
 ///
 /// This will always return the external address most recently reported by the remote over this
-/// path. If the extension is not negotiated, this stream will never return. If the path is
-/// abandoned, the stream will end.
+/// path. If the extension is not negotiated, this stream will never return.
 // TODO(@divma): provide a way to check if the extension is negotiated.
 pub struct AddressDiscovery {
     watcher: WatchStream<SocketAddr>,

--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -209,10 +209,9 @@ impl AddressDiscovery {
         initial_value: Option<SocketAddr>,
         runtime: Arc<dyn Runtime>,
     ) -> Self {
-        // if the dummy value is used, it will be ignored
-        let (tx, rx) = watch::channel(
-            initial_value.unwrap_or_else(|| SocketAddr::new([0, 0, 0, 0].into(), 0)),
-        );
+        let (tx, rx) = watch::channel(initial_value.unwrap_or_else(||
+                // if the dummy value is used, it will be ignored
+                SocketAddr::new([0, 0, 0, 0].into(), 0)));
         let filter = async move {
             loop {
                 match path_events.recv().await {

--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -229,9 +229,10 @@ impl Future for ClosePath {
 
 /// Stream produced by [`Path::observed_external_addr`]
 ///
-/// Will always return the most recently seen observed address by the remote over this path. If the
-/// extension is not negotiated, this stream will never return. If the path is abandoned, the
-/// stream will end.
+/// This will always return the external address most recently reported by the remote over this
+/// path. If the extension is not negotiated, this stream will never return. If the path is
+/// abandoned, the stream will end.
+// TODO(@divma): provide a way to check if the extension is negotiated.
 pub struct AddressDiscovery {
     watcher: WatchStream<SocketAddr>,
     filter_future: AbortHandle,

--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -1,10 +1,15 @@
 use std::future::Future;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 use std::time::Duration;
 
-use proto::{ClosePathError, ClosedPath, ConnectionError, PathError, PathId, PathStatus, VarInt};
+use proto::{
+    ClosePathError, ClosedPath, ConnectionError, PathError, PathEvent, PathId, PathStatus, VarInt,
+};
 use tokio::sync::{oneshot, watch};
+use tokio::task::AbortHandle;
+use tokio_stream::{Stream, wrappers::WatchStream};
 
 use crate::connection::ConnectionRef;
 
@@ -152,6 +157,57 @@ impl Path {
         let mut state = self.conn.state.lock("path_set_keep_alive_interval");
         state.inner.set_path_keep_alive_interval(self.id, interval)
     }
+
+    /// Track changes on our external address as reported by the peer.
+    ///
+    /// If the address-discovery extension is not negotiated, the stream will never return.
+    pub fn observed_external_addr(&self) -> Result<AddressDiscovery, ClosedPath> {
+        let state = self.conn.state.lock("per_path_observed_address");
+        let mut path_events = state.path_events.subscribe();
+        let path_id = self.id;
+        let initial_value = state.inner.path_observed_address(path_id)?;
+        // if the dummy value is used, it will be ignored
+        let (tx, rx) = watch::channel(
+            initial_value.unwrap_or_else(|| SocketAddr::new([0, 0, 0, 0].into(), 0)),
+        );
+        let filter = async move {
+            loop {
+                match path_events.recv().await {
+                    Ok(PathEvent::ObservedAddr { id, addr: observed }) if id == path_id => {
+                        tx.send_if_modified(|addr| {
+                            let old = std::mem::replace(addr, observed);
+                            old != *addr
+                        });
+                    }
+                    Ok(PathEvent::Abandoned { id, .. }) if id == path_id => {
+                        // If the path is closed, terminate the stream
+                        break;
+                    }
+                    Ok(_) => {
+                        // ignore any other event
+                    }
+                    Err(_) => {
+                        // A lagged error should never happen since this (detached) task is
+                        // constantly reading from the channel. Therefore, if an error does happen,
+                        // the stream can terminate
+                        break;
+                    }
+                }
+            }
+        };
+
+        let watcher = if initial_value.is_some() {
+            WatchStream::new(rx)
+        } else {
+            WatchStream::from_changes(rx)
+        };
+
+        let filter_future = tokio::spawn(filter).abort_handle();
+        Ok(AddressDiscovery {
+            watcher,
+            filter_future,
+        })
+    }
 }
 
 /// Future produced by [`Path::close`]
@@ -168,5 +224,32 @@ impl Future for ClosePath {
             Ok(code) => Poll::Ready(Ok(code)),
             Err(_err) => todo!(), // TODO: appropriate error
         }
+    }
+}
+
+/// Stream produced by [`Path::observed_external_addr`]
+///
+/// Will always return the most recently seen observed address by the remote over this path. If the
+/// extension is not negotiated, this stream will never return. If the path is abandoned, the
+/// stream will end.
+pub struct AddressDiscovery {
+    watcher: WatchStream<SocketAddr>,
+    filter_future: AbortHandle,
+}
+
+impl Stream for AddressDiscovery {
+    type Item = SocketAddr;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.filter_future.is_finished() {
+            return Poll::Ready(None);
+        }
+        Pin::new(&mut self.watcher).poll_next(cx)
+    }
+}
+
+impl Drop for AddressDiscovery {
+    fn drop(&mut self) {
+        self.filter_future.abort();
     }
 }

--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -248,7 +248,7 @@ impl AddressDiscovery {
         runtime.spawn(Box::pin(filter));
         // TODO(@divma): check if there's a way to ensure the future ends. AbortHandle is not an
         // option
-        AddressDiscovery { watcher }
+        Self { watcher }
     }
 }
 

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -1007,17 +1007,13 @@ async fn test_multipath_observed_address() {
         // TODO(@divma): this is not fixed by removing the early check of remote CIDs, at least not
         // right now. Removing the check makes poll_transmit panic somewhere. So, eval removing
         // this sleep after the poll_transmit unwraps have been addressed
-        tracing::info!("starting sleep");
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-        tracing::info!("starting open path");
         let path = conn
             .open_path(server_addr, proto::PathStatus::Available)
             .await
             .unwrap();
-        tracing::info!("path open, starting reports");
         let mut reports = path.observed_external_addr().unwrap();
         let observed = reports.next().await.unwrap();
-        tracing::info!("report received");
 
         // in this instance the test is local and the locally known and remotely observed addresses
         // should coincide

--- a/quinn/src/tests.rs
+++ b/quinn/src/tests.rs
@@ -997,7 +997,6 @@ async fn test_multipath_observed_address() {
 
     let client = factory.endpoint_with_config("client", transport_config);
 
-    let client_addr = client.local_addr().unwrap();
     let client_task = async move {
         let conn = client
             .connect(server_addr, "localhost")


### PR DESCRIPTION
Some changes that are relevant in this PR:
- protocol wise changes are minimal since it was clear from the beginning that observed addresses were meant to be kept by path. 
- We _still_ send observed address reports with path challenges and responses. This was originally intended but now results on double reports when opening a path. This seems fine to me for now since helps reports to remain updated. We could evaluate removing this
- we keep track of whether the path has been informed as open to the application to emit the relevant events afterwards. We should probably use this for status as well if we continue with emitting the event when the path is in fact open (a packet has been successfully received)
- Address updates can be obtained via the `Path` api
- I noticed we might be missing a wake in processing events somwhere, there is a noticeable delay in the test, unrelated to address discovery as far as I can tell
- I had this using tokio, like one usually does, but then wasm failed due to the missing runtime future. Since tokio can't be used to spawn tasks, using instead the `Runtime` trait, there are some features I was using that are no longer available, like `AbortHandle`s. We could iterate over this to have better task cancellation on drop, maybe terminate the stream on closing/abandoning etc
- CI failures are unrelated