### PR TITLE
Fix open path api

### DIFF
--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -22,7 +22,7 @@ enum OpenPathInner {
     ///
     /// This migth fail later on.
     Ongoing {
-        opened: watch::Receiver<Option<Result<(), PathError>>>,
+        opened: WatchStream<Result<(), PathError>>,
         path_id: PathId,
         conn: ConnectionRef,
     },
@@ -41,11 +41,11 @@ enum OpenPathInner {
 impl OpenPath {
     pub(crate) fn new(
         path_id: PathId,
-        opened: watch::Receiver<Option<Result<(), PathError>>>,
+        opened: watch::Receiver<Result<(), PathError>>,
         conn: ConnectionRef,
     ) -> Self {
         Self(OpenPathInner::Ongoing {
-            opened,
+            opened: WatchStream::from_changes(opened),
             path_id,
             conn,
         })
@@ -68,15 +68,19 @@ impl Future for OpenPath {
                 ref mut opened,
                 path_id,
                 ref mut conn,
-            } => {
-                let mut fut = std::pin::pin!(opened.wait_for(|v| v.is_some()));
-                fut.as_mut().poll(ctx).map(|_| {
-                    Ok(Path {
-                        id: path_id,
-                        conn: conn.clone(),
-                    })
-                })
-            }
+            } => match Pin::new(opened).poll_next(ctx) {
+                Poll::Ready(Some(value)) => Poll::Ready(value.map(|_| Path {
+                    id: path_id,
+                    conn: conn.clone(),
+                })),
+                Poll::Ready(None) => {
+                    // This only happens if receiving a notification change failed, this means the
+                    // sender was dropped. This generally should not happen so we use a transient
+                    // error
+                    Poll::Ready(Err(PathError::ValidationFailed))
+                }
+                Poll::Pending => Poll::Pending,
+            },
             OpenPathInner::Ready {
                 path_id,
                 ref mut conn,

--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -68,18 +68,17 @@ impl Future for OpenPath {
                 ref mut opened,
                 path_id,
                 ref mut conn,
-            } => match Pin::new(opened).poll_next(ctx) {
-                Poll::Ready(Some(value)) => Poll::Ready(value.map(|_| Path {
+            } => match ready!(Pin::new(opened).poll_next(ctx)) {
+                Some(value) => Poll::Ready(value.map(|_| Path {
                     id: path_id,
                     conn: conn.clone(),
                 })),
-                Poll::Ready(None) => {
+                None => {
                     // This only happens if receiving a notification change failed, this means the
                     // sender was dropped. This generally should not happen so we use a transient
                     // error
                     Poll::Ready(Err(PathError::ValidationFailed))
                 }
-                Poll::Pending => Poll::Pending,
             },
             OpenPathInner::Ready {
                 path_id,


### PR DESCRIPTION
The introduction of the watcher into the `OpenPathInner` broke the upwards wake, making the future that handles dealing with the state changes not being polled. Because of this tests that use the `open_path` api take several seconds, until the runtime decides by chance to poll the future. By changing this to store a stream (an actual future, until a watcher, the futures are now polled in a timelly matter. The test for address discovery for examples used to take 30.22seconds, now it's 0.22 seconds

This also simplifies the code by watching for changes instead of values, which removes the need to deal with `None`s that will never happen