### PR TITLE
Trace log the OBSERVED_ADDR frames

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4192,6 +4192,7 @@ impl Connection {
                 }
                 Frame::ObservedAddr(observed) => {
                     // check if params allows the peer to send report and this node to receive it
+                    trace!(seq_no = %observed.seq_no, ip = %observed.ip, port = observed.port);
                     if !self
                         .peer_params
                         .address_discovery_role


### PR DESCRIPTION
This in the same style as the other frames are logged.  It's very
confusing to not have a trace log of this.