### PR TITLE
Bump the max padding allowe in GSO batches

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1322,7 +1322,7 @@ impl Connection {
                     // amounts of bandwidth. The exact threshold is a bit arbitrary
                     // and might benefit from further tuning, though there's no
                     // universally optimal value.
-                    const MAX_PADDING: usize = 16;
+                    const MAX_PADDING: usize = 32;
                     if builder.buf.datagram_remaining_mut()
                         > builder.predict_packet_end() + MAX_PADDING
                     {


### PR DESCRIPTION
When building packets in GSO batches the batch is terminated if too
many padding bytes would be needed to continue this batch.  This was
chosen fairly arbitrarily to be 16 bytes.

However when you have multipath enabled and allow a half-decent number
of simulatneous paths to be opened, you have to issue 5 *
initial_max_path_id PATH_NEW_CONNECTION_ID frames.  This quickly
spills over into multiple datagrams, especially since this happens
early in the connection when the PMTU has not yet been discovered.

CIDs however, are 32 bytes by default.  So if such a frame does no
longer fit in a datagram you would easily need more than 16 bytes of
padding.  And in that case the GSO batch would break.  Even though all
you're doing is sending a series of datagrams full of CIDs.

So tweaking this number to 32 allows us to build these packes without
breaking the GSO batch.