### PR TITLE
cleanup frame.rs ToDos and unwraps

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -5102,9 +5102,11 @@ impl Connection {
         let delay = delay_micros >> ack_delay_exp.into_inner();
 
         if send_path_acks {
-            trace!("PATH_ACK {path_id:?} {ranges:?}, Delay = {delay_micros}us");
-            frame::PathAck::encode(path_id, delay as _, ranges, ecn, buf);
-            stats.frame_tx.path_acks += 1;
+            if !ranges.is_empty() {
+                trace!("PATH_ACK {path_id:?} {ranges:?}, Delay = {delay_micros}us");
+                frame::PathAck::encode(path_id, delay as _, ranges, ecn, buf);
+                stats.frame_tx.path_acks += 1;
+            }
         } else {
             trace!("ACK {ranges:?}, Delay = {delay_micros}us");
             frame::Ack::encode(delay as _, ranges, ecn, buf);

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -451,7 +451,7 @@ impl fmt::Debug for PathAck {
             if !first {
                 ranges.push(',');
             }
-            write!(ranges, "{range:?}").unwrap();
+            write!(ranges, "{range:?}")?;
             first = false;
         }
         ranges.push(']');
@@ -480,6 +480,8 @@ impl PathAck {
     ///
     /// The [`FrameType`] will be either [`FrameType::PATH_ACK_ECN`] or [`FrameType::PATH_ACK`]
     /// depending on whether [`EcnCounts`] are provided.
+    ///
+    /// PANICS: if `ranges` is empty.
     pub fn encode<W: BufMut>(
         path_id: PathId,
         delay: u64,
@@ -488,7 +490,9 @@ impl PathAck {
         buf: &mut W,
     ) {
         let mut rest = ranges.iter().rev();
-        let first = rest.next().unwrap();
+        let first = rest
+            .next()
+            .expect("Caller has verified ranges is non empty");
         let largest = first.end - 1;
         let first_size = first.end - first.start;
         let kind = match ecn.is_some() {


### PR DESCRIPTION
- remove obsolete dead code annotation
- add missing docs for coding and encoding path related frames
- make RetireConnectionId max size into consts
- make NewConnectionId max size into consts
- remove unwraps coming from n0 members in frame.rs