### PR TITLE
Remove some TODOs since the current state is fine

### DIFF
--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -677,10 +677,6 @@ impl InFlight {
 }
 
 /// State for QUIC-MULTIPATH PATH_AVAILABLE and PATH_BACKUP frames
-// TODO(flub): We might want to keep track of whether the local state was set explicitly.
-//    OTOH our open path API allows explicitly setting the path status, which means it is
-//    always set explicitly.  So basically we currently just use the local state and only
-//    keep track of the remote state.
 #[derive(Debug, Clone, Default)]
 pub(super) struct PathStatusState {
     /// The local status
@@ -788,14 +784,6 @@ pub enum PathEvent {
         /// The new status set by the remote
         status: PathStatus,
     },
-    // TODO(@divma): remove after consideration
-    // The public API of quinn reports path events (this enum) and based on that it's convenient
-    // to include externally observed addresses here. This is maybe not the best in terms of
-    // separation of concerns, and a more appropriate aproach would be to create a new event type
-    // for the external API. Since this is the only "mixed topics" event so far, the alternative
-    // to having the event here is an overkill. We should consider both options depending on the
-    // number of non-strictly-multipath events that end up here and remove this note or make the
-    // change restoring the event to the higher level.
     /// Received an observation of our external address from the peer.
     ObservedAddr {
         /// Path over which the observed address was reported, [`PathId::ZERO`] when multipath is


### PR DESCRIPTION
We are almost done and there seems to be no need to handle missing local states or to split the address discovery event. Code can continue as it is