### PR TITLE
quic holepunching public api

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -76,8 +76,8 @@ pub use rustls;
 pub use udp;
 
 pub use crate::connection::{
-    AcceptBi, AcceptUni, Connecting, Connection, OpenBi, OpenUni, ReadDatagram, SendDatagram,
-    SendDatagramError, WeakConnectionHandle, ZeroRttAccepted,
+    AcceptBi, AcceptUni, Connecting, Connection, NotAClient, NotAServer, OpenBi, OpenUni,
+    ReadDatagram, SendDatagram, SendDatagramError, WeakConnectionHandle, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};


### PR DESCRIPTION
Adds the public api as initially thought, in a very non committing way.

While writing docs and errors, I want to explore this use, and consider if it makes sense to move a chunk of these to the endpoint. Publicly reachable addresses are shared for the endpoint, so having this per connection seems quite strange. From an api perspective a benefit is that we don't need to reject adding or removing addresses. These can be kept and used when requested over connections in which we have the correct role. 

Extensions are handled by connection in general, but it isn't unheard of enpoints keeping some state surrounding connections, CIDs are a main example since they are used for demultiplexing.

THere is probably a bunch of considerations to be made, etc, but long term I think this makes more sense. Not doing it now because of how unclear the path is

The comment is somewhat unrelated to the actual code changes. If anything, it's an explanation of why every single line of docs took me forever to write