### PR TITLE
Do not remember multipath transport parameter for 0rtt

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3115,6 +3115,7 @@ impl Connection {
                         min_ack_delay: None,
                         ack_delay_exponent: TransportParameters::default().ack_delay_exponent,
                         max_ack_delay: TransportParameters::default().max_ack_delay,
+                        initial_max_path_id: None,
                         ..params
                     };
                     self.set_peer_params(params);


### PR DESCRIPTION
I can't find any existing tests that test transport parameters for
0rtt, so I'm going to skip tests...