### PR TITLE
fix: don't panic if peer sends ABANDON_PATH for already abandoned path

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4329,9 +4329,9 @@ impl Connection {
                             Timer::PerPath(path_id, PathTimer::PathAbandoned),
                             now + delay,
                         );
-                        self.timers
-                            .stop(Timer::PerPath(path_id, PathTimer::PathNotAbandoned));
                     }
+                    self.timers
+                        .stop(Timer::PerPath(path_id, PathTimer::PathNotAbandoned));
                 }
                 Frame::PathAvailable(info) => {
                     span.record("path", tracing::field::debug(&info.path_id));


### PR DESCRIPTION
I did not dive into things more deeply, this might be very incorrect, but want to try this on an iroh branch to see if it fixes the panic that occurred here  https://github.com/n0-computer/iroh/actions/runs/19267694047/job/55087507843#step:10:1

Iroh CI run with this is here: https://github.com/n0-computer/iroh/pull/3648
Has *other* panics now.