### PR TITLE
fix: reset tail-loss probes when discarding a space

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3264,7 +3264,7 @@ impl Connection {
         pns.loss_time = None;
         pns.loss_probes = 0;
         let sent_packets = mem::take(&mut pns.sent_packets);
-        let mut path = self.paths.get_mut(&PathId::ZERO).unwrap();
+        let path = self.paths.get_mut(&PathId::ZERO).unwrap();
         for packet in sent_packets.into_values() {
             path.data.remove_in_flight(&packet);
         }


### PR DESCRIPTION
If a space had a tail-loss probe scheduled when the space is discarded
the poll_transmit function was still trying to send on it.  Even
though there are no more crypto keys available for it.