### PR TITLE
Fix: only consider a path available if it has CIDs

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -912,7 +912,7 @@ impl Connection {
         // If there is any available path we only want to send frames to any backup path
         // that must be sent on that backup path exclusively.
         let have_available_path = self.paths.iter().any(|(id, path)| {
-            path.data.local_status() == PathStatus::Available && self.rem_cids.contains_key(&id)
+            path.data.local_status() == PathStatus::Available && self.rem_cids.contains_key(id)
         });
 
         // Setup for the first path_id


### PR DESCRIPTION
Since when we locally abandon a path we retire the CIDs for it, we can
then no longer send on it.  We need to take this into account for
deciding which paths we want to send something on.

We do the CID check rather than just check of the path is in our
abandoned paths, since that is the check which is used lower down in
the loop as well.  I think this is essentially the same state.  Maybe
we could have done without the explicit set of abandoned paths as
separate state.  I'm not sure.