### PR TITLE
feat: in qlog, also record src/dst addrs and path id for packets

### DIFF
--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 
 mod transport;
 #[cfg(feature = "qlog")]
-pub use transport::QlogConfig;
+pub use transport::{QlogConfig, VantagePointType};
 pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
 
 #[cfg(doc)]

--- a/quinn-proto/src/config/mod.rs
+++ b/quinn-proto/src/config/mod.rs
@@ -26,9 +26,9 @@ use crate::{
 };
 
 mod transport;
+pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
 #[cfg(feature = "qlog")]
 pub use transport::{QlogConfig, VantagePointType};
-pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
 
 #[cfg(doc)]
 pub use transport::DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED;

--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -7,6 +7,8 @@ use std::{
 use std::{io, sync::Mutex, time::Instant};
 
 #[cfg(feature = "qlog")]
+pub use qlog::VantagePointType;
+#[cfg(feature = "qlog")]
 use qlog::streamer::QlogStreamer;
 
 #[cfg(feature = "qlog")]
@@ -703,6 +705,7 @@ pub struct QlogConfig {
     title: Option<String>,
     description: Option<String>,
     start_time: Instant,
+    vantage_point: qlog::VantagePoint,
 }
 
 #[cfg(feature = "qlog")]
@@ -731,17 +734,19 @@ impl QlogConfig {
         self
     }
 
+    /// Vantage point for this trace
+    pub fn vantage_point(&mut self, vantage_point: VantagePointType, name: Option<String>) {
+        self.vantage_point.name = name;
+        self.vantage_point.ty = vantage_point;
+    }
+
     /// Construct the [`QlogStream`] described by this configuration
     pub fn into_stream(self) -> Option<QlogStream> {
         use tracing::warn;
 
         let writer = self.writer?;
         let trace = qlog::TraceSeq::new(
-            qlog::VantagePoint {
-                name: None,
-                ty: qlog::VantagePointType::Unknown,
-                flow: None,
-            },
+            self.vantage_point,
             self.title.clone(),
             self.description.clone(),
             Some(qlog::Configuration {
@@ -780,6 +785,11 @@ impl Default for QlogConfig {
             title: None,
             description: None,
             start_time: Instant::now(),
+            vantage_point: qlog::VantagePoint {
+                name: None,
+                ty: qlog::VantagePointType::Unknown,
+                flow: None,
+            },
         }
     }
 }

--- a/quinn-proto/src/config/transport.rs
+++ b/quinn-proto/src/config/transport.rs
@@ -735,9 +735,14 @@ impl QlogConfig {
     }
 
     /// Vantage point for this trace
-    pub fn vantage_point(&mut self, vantage_point: VantagePointType, name: Option<String>) {
+    pub fn vantage_point(
+        &mut self,
+        vantage_point: VantagePointType,
+        name: Option<String>,
+    ) -> &mut Self {
         self.vantage_point.name = name;
         self.vantage_point.ty = vantage_point;
+        self
     }
 
     /// Construct the [`QlogStream`] described by this configuration
@@ -763,7 +768,7 @@ impl QlogConfig {
             None,
             self.start_time,
             trace,
-            qlog::events::EventImportance::Core,
+            qlog::events::EventImportance::Extra,
             writer,
         );
 

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3243,7 +3243,7 @@ impl Connection {
 
         let packet: Packet = packet.into();
 
-        let mut qlog = QlogRecvPacket::new(len);
+        let mut qlog = QlogRecvPacket::new(len, remote, path_id);
         qlog.header(&packet.header, Some(packet_number));
 
         self.process_decrypted_packet(
@@ -3487,7 +3487,7 @@ impl Connection {
         ecn: Option<EcnCodepoint>,
         partial_decode: PartialDecode,
     ) {
-        let qlog = QlogRecvPacket::new(partial_decode.len());
+        let qlog = QlogRecvPacket::new(partial_decode.len(), remote, path_id);
         if let Some(decoded) = packet_crypto::unprotect_header(
             partial_decode,
             &self.spaces,

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3244,8 +3244,7 @@ impl Connection {
         let packet: Packet = packet.into();
 
         let mut qlog = QlogRecvPacket::new(len);
-        #[cfg(feature = "qlog")]
-        qlog.header(&packet, Some(packet_number));
+        qlog.header(&packet.header, Some(packet_number));
 
         self.process_decrypted_packet(
             now,
@@ -3584,8 +3583,7 @@ impl Connection {
                 }
             }
             Ok((packet, number)) => {
-                #[cfg(feature = "qlog")]
-                qlog.header(&packet, number);
+                qlog.header(&packet.header, number);
                 let span = match number {
                     Some(pn) => trace_span!("recv", space = ?packet.header.space(), pn),
                     None => trace_span!("recv", space = ?packet.header.space()),
@@ -3748,7 +3746,6 @@ impl Connection {
                             continue;
                         }
                     };
-                    #[cfg(feature = "qlog")]
                     qlog.frame(&frame);
 
                     if let Frame::Padding = frame {
@@ -4042,7 +4039,6 @@ impl Connection {
         let mut ack_eliciting = false;
         for result in frame::Iter::new(packet.payload.freeze())? {
             let frame = result?;
-            #[cfg(feature = "qlog")]
             qlog.frame(&frame);
             let span = match frame {
                 Frame::Padding => continue,
@@ -4113,7 +4109,6 @@ impl Connection {
         let mut migration_observed_addr = None;
         for result in frame::Iter::new(payload)? {
             let frame = result?;
-            #[cfg(feature = "qlog")]
             qlog.frame(&frame);
             let span = match frame {
                 Frame::Padding => continue,

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -269,8 +269,8 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
     pub(super) fn finish(
         self,
         conn: &mut Connection,
-        now: Instant,
-        #[allow(unused_mut)] mut qlog: QlogSentPacket,
+        #[allow(unused)] now: Instant,
+        #[allow(unused)] mut qlog: QlogSentPacket,
     ) -> (usize, bool) {
         debug_assert!(
             self.buf.len() <= self.buf.datagram_max_offset() - self.tag_len,
@@ -317,7 +317,9 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         let packet_len = self.buf.len() - encode_start;
         trace!(size = %packet_len, short_header = %self.short_header, "wrote packet");
         qlog.finalize(packet_len);
-        conn.config.qlog_sink.emit_packet_sent(conn, qlog, now);
+        conn.config
+            .qlog_sink
+            .emit_packet_sent(conn, self.path, qlog, now);
         (packet_len, pad)
     }
 

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -166,7 +166,6 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         let max_size = buffer.datagram_max_offset() - tag_len;
         debug_assert!(max_size >= min_size);
 
-        #[cfg(feature = "qlog")]
         qlog.header(
             &header,
             Some(exact_number),
@@ -317,7 +316,6 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
 
         let packet_len = self.buf.len() - encode_start;
         trace!(size = %packet_len, short_header = %self.short_header, "wrote packet");
-        #[cfg(feature = "qlog")]
         qlog.finalize(packet_len);
         conn.config.qlog_sink.emit_packet_sent(conn, qlog, now);
         (packet_len, pad)

--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -9,10 +9,6 @@
 // Function bodies in this module are regularly cfg'd out
 #![allow(unused_variables)]
 
-use std::net::{IpAddr, SocketAddr};
-#[cfg(feature = "qlog")]
-use std::sync::{Arc, Mutex};
-
 #[cfg(feature = "qlog")]
 use std::sync::{Arc, Mutex};
 use std::{

--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -3,14 +3,18 @@
 
 #[cfg(feature = "qlog")]
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 
 #[cfg(feature = "qlog")]
 use qlog::{
     events::{
-        Event, EventData,
+        Event, EventData, RawInfo,
         quic::{
             PacketHeader, PacketLost, PacketLostTrigger, PacketReceived, PacketSent, PacketType,
+            QuicFrame, StreamType,
         },
     },
     streamer::QlogStreamer,
@@ -19,9 +23,14 @@ use qlog::{
 use tracing::warn;
 
 use crate::{
-    ConnectionId, Instant,
+    Connection, ConnectionId, Instant,
     connection::{PathData, SentPacket},
     packet::SpaceId,
+};
+#[cfg(feature = "qlog")]
+use crate::{
+    FrameType,
+    packet::{Header, Packet},
 };
 
 /// Shareable handle to a single qlog output stream
@@ -31,10 +40,10 @@ pub struct QlogStream(pub(crate) Arc<Mutex<QlogStreamer>>);
 
 #[cfg(feature = "qlog")]
 impl QlogStream {
-    fn emit_event(&self, orig_rem_cid: ConnectionId, event: EventData, now: Instant) {
+    fn emit_event(&self, initial_dst_cid: ConnectionId, event: EventData, now: Instant) {
         // Time will be overwritten by `add_event_with_instant`
         let mut event = Event::with_time(0.0, event);
-        event.group_id = Some(orig_rem_cid.to_string());
+        event.group_id = Some(initial_dst_cid.to_string());
 
         let mut qlog_streamer = self.0.lock().unwrap();
         if let Err(e) = qlog_streamer.add_event_with_instant(event, now) {
@@ -62,12 +71,49 @@ impl QlogSink {
         }
     }
 
+    pub(super) fn emit_connection_started(
+        &self,
+        now: Instant,
+        loc_cid: ConnectionId,
+        rem_cid: ConnectionId,
+        remote: SocketAddr,
+        local_ip: Option<IpAddr>,
+        initial_dst_cid: ConnectionId,
+    ) {
+        #[cfg(feature = "qlog")]
+        {
+            use qlog::events::connectivity::ConnectionStarted;
+
+            let Some(stream) = self.stream.as_ref() else {
+                return;
+            };
+            // TODO: Review fields. The standard has changed since.
+            stream.emit_event(
+                initial_dst_cid,
+                EventData::ConnectionStarted(ConnectionStarted {
+                    ip_version: Some(String::from(match remote.ip() {
+                        IpAddr::V4(_) => "v4",
+                        IpAddr::V6(_) => "v6",
+                    })),
+                    src_ip: local_ip.map(|addr| addr.to_string()).unwrap_or_default(),
+                    dst_ip: remote.ip().to_string(),
+                    protocol: None,
+                    src_port: None,
+                    dst_port: Some(remote.port()),
+                    src_cid: Some(loc_cid.to_string()),
+                    dst_cid: Some(rem_cid.to_string()),
+                }),
+                now,
+            );
+        }
+    }
+
     pub(super) fn emit_recovery_metrics(
         &self,
         pto_count: u32,
         path: &mut PathData,
         now: Instant,
-        orig_rem_cid: ConnectionId,
+        initial_dst_cid: ConnectionId,
     ) {
         #[cfg(feature = "qlog")]
         {
@@ -79,7 +125,7 @@ impl QlogSink {
                 return;
             };
 
-            stream.emit_event(orig_rem_cid, EventData::MetricsUpdated(metrics), now);
+            stream.emit_event(initial_dst_cid, EventData::MetricsUpdated(metrics), now);
         }
     }
 
@@ -90,7 +136,7 @@ impl QlogSink {
         loss_delay: Duration,
         space: SpaceId,
         now: Instant,
-        orig_rem_cid: ConnectionId,
+        initial_dst_cid: ConnectionId,
     ) {
         #[cfg(feature = "qlog")]
         {
@@ -114,63 +160,285 @@ impl QlogSink {
                 ),
             };
 
-            stream.emit_event(orig_rem_cid, EventData::PacketLost(event), now);
+            stream.emit_event(initial_dst_cid, EventData::PacketLost(event), now);
         }
     }
 
-    pub(super) fn emit_packet_sent(
-        &self,
-        pn: u64,
-        len: usize,
-        space: SpaceId,
-        is_0rtt: bool,
-        now: Instant,
-        orig_rem_cid: ConnectionId,
-    ) {
+    pub(super) fn emit_packet_sent(&self, conn: &Connection, packet: QlogSentPacket, now: Instant) {
         #[cfg(feature = "qlog")]
         {
             let Some(stream) = self.stream.as_ref() else {
                 return;
             };
-
-            let event = PacketSent {
-                header: PacketHeader {
-                    packet_number: Some(pn),
-                    packet_type: packet_type(space, is_0rtt),
-                    length: Some(len as u16),
-                    ..Default::default()
-                },
-                ..Default::default()
-            };
-
-            stream.emit_event(orig_rem_cid, EventData::PacketSent(event), now);
+            stream.emit_event(
+                conn.initial_dst_cid,
+                EventData::PacketSent(packet.inner),
+                now,
+            );
         }
     }
 
     pub(super) fn emit_packet_received(
         &self,
-        pn: u64,
-        space: SpaceId,
-        is_0rtt: bool,
+        conn: &Connection,
+        packet: QlogRecvPacket,
         now: Instant,
-        orig_rem_cid: ConnectionId,
     ) {
         #[cfg(feature = "qlog")]
         {
             let Some(stream) = self.stream.as_ref() else {
                 return;
             };
+            let mut packet = packet;
+            packet.emit_padding();
+            let event = packet.inner;
+            stream.emit_event(conn.initial_dst_cid, EventData::PacketReceived(event), now);
+        }
+    }
+}
 
-            let event = PacketReceived {
-                header: PacketHeader {
-                    packet_number: Some(pn),
-                    packet_type: packet_type(space, is_0rtt),
-                    ..Default::default()
-                },
-                ..Default::default()
-            };
+#[derive(Default)]
+pub(crate) struct QlogSentPacket {
+    #[cfg(feature = "qlog")]
+    inner: PacketSent,
+}
 
-            stream.emit_event(orig_rem_cid, EventData::PacketReceived(event), now);
+#[cfg(feature = "qlog")]
+impl QlogSentPacket {
+    pub(crate) fn header(
+        &mut self,
+        header: &Header,
+        pn: Option<u64>,
+        space: SpaceId,
+        is_0rtt: bool,
+    ) {
+        self.inner.header.scid = header.src_cid().map(encode_cid);
+        self.inner.header.dcid = Some(encode_cid(header.dst_cid()));
+        self.inner.header.packet_number = pn;
+        self.inner.header.packet_type = packet_type(space, is_0rtt);
+    }
+
+    pub(crate) fn frame(&mut self, frame: QuicFrame) {
+        self.inner.frames.get_or_insert_default().push(frame);
+    }
+
+    pub(crate) fn unknown_frame(&mut self, frame: &FrameType) {
+        let ty = frame.to_u64();
+        self.frame(unknown_frame(frame))
+    }
+
+    pub(super) fn finalize(&mut self, len: usize) {
+        self.inner.header.length = Some(len as u16);
+    }
+}
+
+pub(crate) struct QlogRecvPacket {
+    #[cfg(feature = "qlog")]
+    inner: PacketReceived,
+    #[cfg(feature = "qlog")]
+    padding: usize,
+}
+
+#[cfg(not(feature = "qlog"))]
+impl QlogRecvPacket {
+    pub(crate) fn new(_len: usize) -> Self {
+        Self {}
+    }
+}
+
+#[cfg(feature = "qlog")]
+impl QlogRecvPacket {
+    pub(crate) fn new(len: usize) -> Self {
+        let mut this = Self {
+            inner: Default::default(),
+            padding: 0,
+        };
+        this.inner.header.length = Some(len as u16);
+        this
+    }
+
+    pub(crate) fn header(&mut self, packet: &Packet, pn: Option<u64>) {
+        let header = &packet.header;
+        let is_0rtt = !packet.header.is_1rtt();
+        self.inner.header.scid = header.src_cid().map(encode_cid);
+        self.inner.header.dcid = Some(encode_cid(header.dst_cid()));
+        self.inner.header.packet_number = pn;
+        self.inner.header.packet_type = packet_type(header.space(), is_0rtt);
+    }
+
+    fn emit_padding(&mut self) {
+        if self.padding > 0 {
+            self.inner
+                .frames
+                .get_or_insert_default()
+                .push(QuicFrame::Padding {
+                    length: Some(self.padding as u32),
+                    payload_length: self.padding as u32,
+                });
+            self.padding = 0;
+        }
+    }
+
+    pub(crate) fn frame(&mut self, frame: &crate::Frame) {
+        if matches!(frame, crate::Frame::Padding) {
+            self.padding += 1;
+        } else {
+            self.emit_padding();
+            self.inner
+                .frames
+                .get_or_insert_default()
+                .push(frame.to_qlog())
+        }
+    }
+}
+
+#[cfg(feature = "qlog")]
+fn unknown_frame(frame: &FrameType) -> QuicFrame {
+    let ty = frame.to_u64();
+    QuicFrame::Unknown {
+        raw_frame_type: ty,
+        frame_type_value: Some(ty),
+        raw: Some(RawInfo {
+            length: None,
+            payload_length: None,
+            data: Some(format!("{frame}")),
+        }),
+    }
+}
+
+#[cfg(feature = "qlog")]
+impl crate::Frame {
+    fn to_qlog(&self) -> QuicFrame {
+        use qlog::events::quic::AckedRanges;
+
+        match self {
+            Self::Padding => QuicFrame::Padding {
+                length: None,
+                payload_length: 1,
+            },
+            Self::Ping => QuicFrame::Ping {
+                length: None,
+                payload_length: None,
+            },
+            Self::Ack(ack) => QuicFrame::Ack {
+                ack_delay: Some(ack.delay as f32),
+                acked_ranges: Some(AckedRanges::Double(
+                    ack.iter()
+                        .map(|range| (*range.start(), *range.end()))
+                        .collect(),
+                )),
+                ect1: ack.ecn.as_ref().map(|e| e.ect1),
+                ect0: ack.ecn.as_ref().map(|e| e.ect0),
+                ce: ack.ecn.as_ref().map(|e| e.ce),
+                length: None,
+                payload_length: None,
+            },
+            Self::ResetStream(f) => QuicFrame::ResetStream {
+                stream_id: f.id.into(),
+                error_code: f.error_code.into(),
+                final_size: f.final_offset.into(),
+                length: None,
+                payload_length: None,
+            },
+            Self::StopSending(f) => QuicFrame::StopSending {
+                stream_id: f.id.into(),
+                error_code: f.error_code.into(),
+                length: None,
+                payload_length: None,
+            },
+            Self::Crypto(c) => QuicFrame::Crypto {
+                offset: c.offset,
+                length: c.data.len() as u64,
+            },
+            Self::NewToken(t) => {
+                use ::qlog;
+                QuicFrame::NewToken {
+                    token: qlog::Token {
+                        ty: Some(::qlog::TokenType::Retry),
+                        raw: Some(qlog::events::RawInfo {
+                            data: qlog::HexSlice::maybe_string(Some(&t.token)),
+                            length: Some(t.token.len() as u64),
+                            payload_length: None,
+                        }),
+                        details: None,
+                    },
+                }
+            }
+            Self::Stream(s) => QuicFrame::Stream {
+                stream_id: s.id.into(),
+                offset: s.offset,
+                length: s.data.len() as u64,
+                fin: Some(s.fin),
+                raw: None,
+            },
+            Self::MaxData(v) => QuicFrame::MaxData {
+                maximum: (*v).into(),
+            },
+            Self::MaxStreamData { id, offset } => QuicFrame::MaxStreamData {
+                stream_id: (*id).into(),
+                maximum: *offset,
+            },
+            Self::MaxStreams { dir, count } => QuicFrame::MaxStreams {
+                maximum: *count,
+                stream_type: (*dir).into(),
+            },
+            Self::DataBlocked { offset } => QuicFrame::DataBlocked { limit: *offset },
+            Self::StreamDataBlocked { id, offset } => QuicFrame::StreamDataBlocked {
+                stream_id: (*id).into(),
+                limit: *offset,
+            },
+            Self::StreamsBlocked { dir, limit } => QuicFrame::StreamsBlocked {
+                stream_type: (*dir).into(),
+                limit: *limit,
+            },
+            Self::NewConnectionId(f) => QuicFrame::NewConnectionId {
+                sequence_number: f.sequence as u32,
+                retire_prior_to: f.retire_prior_to as u32,
+                connection_id_length: Some(f.id.len() as u8),
+                connection_id: format!("{}", f.id),
+                stateless_reset_token: Some(format!("{}", f.reset_token)),
+            },
+            Self::RetireConnectionId(f) => QuicFrame::RetireConnectionId {
+                sequence_number: f.sequence as u32,
+            },
+            Self::PathChallenge(_) => QuicFrame::PathChallenge { data: None },
+            Self::PathResponse(_) => QuicFrame::PathResponse { data: None },
+            Self::Close(close) => QuicFrame::ConnectionClose {
+                error_space: None,
+                error_code: Some(close.error_code()),
+                error_code_value: None,
+                reason: None,
+                trigger_frame_type: None,
+            },
+            Self::Datagram(d) => QuicFrame::Datagram {
+                length: d.data.len() as u64,
+                raw: None,
+            },
+            Self::HandshakeDone => QuicFrame::HandshakeDone,
+            // Extensions and unsupported frames → Unknown
+            Self::AckFrequency(_)
+            | Self::ImmediateAck
+            | Self::ObservedAddr(_)
+            | Self::PathAck(_)
+            | Self::PathAbandon(_)
+            | Self::PathAvailable(_)
+            | Self::PathBackup(_)
+            | Self::MaxPathId(_)
+            | Self::PathsBlocked(_)
+            | Self::PathCidsBlocked(_)
+            | Self::AddAddress(_)
+            | Self::ReachOut(_)
+            | Self::RemoveAddress(_) => unknown_frame(&self.ty()),
+        }
+    }
+}
+
+#[cfg(feature = "qlog")]
+impl From<crate::Dir> for StreamType {
+    fn from(value: crate::Dir) -> Self {
+        match value {
+            crate::Dir::Bi => Self::Bidirectional,
+            crate::Dir::Uni => Self::Unidirectional,
         }
     }
 }
@@ -190,4 +458,9 @@ fn packet_type(space: SpaceId, is_0rtt: bool) -> PacketType {
         SpaceId::Data if is_0rtt => PacketType::ZeroRtt,
         SpaceId::Data => PacketType::OneRtt,
     }
+}
+
+#[cfg(feature = "qlog")]
+fn encode_cid(cid: ConnectionId) -> String {
+    format!("{cid}")
 }

--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -19,7 +19,7 @@ use std::{
 #[cfg(feature = "qlog")]
 use qlog::{
     events::{
-        Event, EventData, RawInfo,
+        Event, EventData, ExData, RawInfo,
         connectivity::ConnectionStarted,
         quic::{
             PacketHeader, PacketLost, PacketLostTrigger, PacketReceived, PacketSent, PacketType,
@@ -34,7 +34,7 @@ use tracing::warn;
 #[cfg(feature = "qlog")]
 use crate::FrameType;
 use crate::{
-    Connection, ConnectionId, Instant,
+    Connection, ConnectionId, Instant, PathId,
     connection::{PathData, SentPacket},
     packet::{Header, SpaceId},
 };
@@ -46,15 +46,25 @@ pub struct QlogStream(pub(crate) Arc<Mutex<QlogStreamer>>);
 
 #[cfg(feature = "qlog")]
 impl QlogStream {
-    fn emit_event(&self, initial_dst_cid: ConnectionId, event: EventData, now: Instant) {
+    fn emit_event_ex(
+        &self,
+        initial_dst_cid: ConnectionId,
+        event: EventData,
+        now: Instant,
+        ex: ExData,
+    ) {
         // Time will be overwritten by `add_event_with_instant`
-        let mut event = Event::with_time(0.0, event);
+        let mut event = Event::with_time_ex(0.0, event, ex);
         event.group_id = Some(initial_dst_cid.to_string());
 
         let mut qlog_streamer = self.0.lock().unwrap();
         if let Err(e) = qlog_streamer.add_event_with_instant(event, now) {
             warn!("could not emit qlog event: {e}");
         }
+    }
+
+    fn emit_event(&self, initial_dst_cid: ConnectionId, event: EventData, now: Instant) {
+        self.emit_event_ex(initial_dst_cid, event, now, Default::default());
     }
 }
 
@@ -168,16 +178,28 @@ impl QlogSink {
         }
     }
 
-    pub(super) fn emit_packet_sent(&self, conn: &Connection, packet: QlogSentPacket, now: Instant) {
+    pub(super) fn emit_packet_sent(
+        &self,
+        conn: &Connection,
+        path_id: PathId,
+        packet: QlogSentPacket,
+        now: Instant,
+    ) {
         #[cfg(feature = "qlog")]
         {
             let Some(stream) = self.stream.as_ref() else {
                 return;
             };
-            stream.emit_event(
+            let remote = conn.path_data(path_id).remote;
+            let ex = [
+                ("dst_addr", remote.to_string()),
+                ("path_id", path_id.to_string()),
+            ];
+            stream.emit_event_ex(
                 conn.initial_dst_cid,
                 EventData::PacketSent(packet.inner),
                 now,
+                ex.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
             );
         }
     }
@@ -196,7 +218,16 @@ impl QlogSink {
             let mut packet = packet;
             packet.emit_padding();
             let event = packet.inner;
-            stream.emit_event(conn.initial_dst_cid, EventData::PacketReceived(event), now);
+            let ex = [
+                ("src_addr", packet.remote.to_string()),
+                ("path_id", packet.path_id.to_string()),
+            ];
+            stream.emit_event_ex(
+                conn.initial_dst_cid,
+                EventData::PacketReceived(event),
+                now,
+                ex.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
+            );
         }
     }
 }
@@ -263,13 +294,17 @@ pub(crate) struct QlogRecvPacket {
     inner: PacketReceived,
     #[cfg(feature = "qlog")]
     padding: usize,
+    #[cfg(feature = "qlog")]
+    remote: SocketAddr,
+    #[cfg(feature = "qlog")]
+    path_id: PathId,
 }
 
 impl QlogRecvPacket {
     /// Creates a new [`QlogRecvPacket`]. Noop if `qlog` feature is not enabled.
     ///
     /// `len` is the packet's full length (before decryption).
-    pub(crate) fn new(len: usize) -> Self {
+    pub(crate) fn new(len: usize, remote: SocketAddr, path_id: PathId) -> Self {
         #[cfg(not(feature = "qlog"))]
         let this = Self {};
 
@@ -278,6 +313,8 @@ impl QlogRecvPacket {
             let mut this = Self {
                 inner: Default::default(),
                 padding: 0,
+                remote,
+                path_id,
             };
             this.inner.header.length = Some(len as u16);
             this

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -39,6 +39,11 @@ impl FrameType {
             None
         }
     }
+
+    #[cfg(feature = "qlog")]
+    pub(crate) fn to_u64(self) -> u64 {
+        self.0
+    }
 }
 
 impl coding::Codec for FrameType {
@@ -337,6 +342,13 @@ impl Close {
 
     pub(crate) fn is_transport_layer(&self) -> bool {
         matches!(*self, Self::Connection(_))
+    }
+
+    pub(crate) fn error_code(&self) -> u64 {
+        match self {
+            Self::Connection(frame) => frame.error_code.into(),
+            Self::Application(frame) => frame.error_code.into(),
+        }
     }
 }
 

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -58,7 +58,7 @@ mod config;
 #[cfg(doc)]
 pub use config::DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED;
 #[cfg(feature = "qlog")]
-pub use config::QlogConfig;
+pub use config::{QlogConfig, VantagePointType};
 pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
     ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,

--- a/quinn-proto/src/lib.rs
+++ b/quinn-proto/src/lib.rs
@@ -57,12 +57,12 @@ pub use rustls;
 mod config;
 #[cfg(doc)]
 pub use config::DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED;
-#[cfg(feature = "qlog")]
-pub use config::{QlogConfig, VantagePointType};
 pub use config::{
     AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
     ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
 };
+#[cfg(feature = "qlog")]
+pub use config::{QlogConfig, VantagePointType};
 
 pub mod crypto;
 

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -475,6 +475,17 @@ impl Header {
             VersionNegotiate { .. } => false,
         }
     }
+
+    #[cfg(feature = "qlog")]
+    pub(crate) fn src_cid(&self) -> Option<ConnectionId> {
+        match self {
+            Self::Initial(initial_header) => Some(initial_header.src_cid),
+            Self::Long { src_cid, .. } => Some(*src_cid),
+            Self::Retry { src_cid, .. } => Some(*src_cid),
+            Self::Short { .. } => None,
+            Self::VersionNegotiate { src_cid, .. } => Some(*src_cid),
+        }
+    }
 }
 
 pub(crate) struct PartialEncode {


### PR DESCRIPTION
This records the path id remote address when sending or receiving packets. This makes debugging iroh much more useful.

`qlog` doesn't seem to have fields for this, there's a way to add extra fields however. This uses this. The extra fields are shown in the JSON when clicking on an event in https://qvis.quictools.info/, so this is actually usable this way even though non-standard.

Not sure what the best way forward here is, but with this we can now see the path id  and src/dst remote addr for each packet when using with iroh.

Edit: The current Qlog draft adds a `tuple` field to record the 4-tuple in the top-level event
https://quicwg.org/qlog/draft-ietf-quic-qlog-main-schema.html#name-tuple
