### PR TITLE
Use %path_id in tracing fields

### DIFF
--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -322,7 +322,7 @@ impl PacketNumberSpace {
     /// PacketNumberSpace.  While the space will work it will not skip packet numbers to
     /// protect against eaget ack attacks.
     fn new_default(space_id: SpaceId, path_id: PathId) -> Self {
-        error!(?path_id, ?space_id, "PacketNumberSpace created by default");
+        error!(%path_id, ?space_id, "PacketNumberSpace created by default");
         Self {
             rx_packet: 0,
             next_packet_number: 0,

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -127,7 +127,7 @@ impl Endpoint {
                     .get_mut(&path_id)
                     .and_then(|pcid| pcid.cids.remove(&seq))
                 {
-                    trace!(?path_id, "local CID retired {}: {}", seq, cid);
+                    trace!(%path_id, "local CID retired {}: {}", seq, cid);
                     self.index.retire(cid);
                     if allow_more_cids {
                         return Some(self.send_new_identifiers(path_id, now, ch, 1));


### PR DESCRIPTION
Printing `path_id=PahtId(2)` is not very useful, `path_id=2` is
shorter and as readable.