### PR TITLE
fix(proto): correct logic change for noting congestion on acks

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -2435,7 +2435,7 @@ impl Connection {
             .remove_in_flight(&info);
         let app_limited = self.app_limited;
         let path = self.path_data_mut(path_id);
-        if info.ack_eliciting && path.challenges_sent.is_empty() {
+        if info.ack_eliciting && !path.is_validating_path() {
             // Only pass ACKs to the congestion controller if we are not validating the current
             // path, so as to ignore any ACKs from older paths still coming in.
             let rtt = path.rtt;


### PR DESCRIPTION
This fixes the drastic perf degradations seen in the benchmarks.

Originally introduced in 334ab73f58843908b63a78eb6b55d47993a229a7