### PR TITLE
move future challenges out of Retransmits

### DIFF
--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -577,12 +577,6 @@ pub struct Retransmits {
     pub(super) remove_address: BTreeSet<RemoveAddress>,
     /// Round and local addresses to advertise in `REACH_OUT` frames
     pub(super) reach_out: Option<(VarInt, Vec<(IpAddr, u16)>)>,
-    /// Round of the nat traversal rand data that are pending
-    ///
-    /// This is only used for bitwise operations on the pending data.
-    pub(super) hole_punch_round: VarInt,
-    /// Remote addresses to which random data needs to be sent
-    pub(super) hole_punch_to: Vec<(IpAddr, u16)>,
 }
 
 impl Retransmits {
@@ -609,7 +603,6 @@ impl Retransmits {
             && self.add_address.is_empty()
             && self.remove_address.is_empty()
             && self.reach_out.is_none()
-            && self.hole_punch_to.is_empty()
     }
 }
 
@@ -648,13 +641,6 @@ impl ::std::ops::BitOrAssign for Retransmits {
                 self.reach_out = rhs.reach_out.clone()
             }
             _ => {}
-        }
-
-        if self.hole_punch_round < rhs.hole_punch_round {
-            self.hole_punch_round = rhs.hole_punch_round;
-            self.hole_punch_to = rhs.hole_punch_to.clone();
-        } else if self.hole_punch_round == rhs.hole_punch_round {
-            self.hole_punch_to.extend_from_slice(&rhs.hole_punch_to);
         }
     }
 }


### PR DESCRIPTION
## Description

Challenges aren't re-transmittable data. So being there is conceptually wrong and redundant. Pragmatically, this change is a precursor to use actual path challenges, since the rand data sent is now stored.

## Breaking Changes

n/a

## Notes & open questions

This is it's own PR to make reviewing using path challenges easier
