### PR TITLE
feat: qlog timers

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1834,8 +1834,7 @@ impl Connection {
     /// `Instant` that was output by `poll_timeout`; however spurious extra calls will simply
     /// no-op and therefore are safe.
     pub fn handle_timeout(&mut self, now: Instant) {
-        while let Some((timer, _time)) = self.timers.expire_before(now) {
-            self.qlog.with_time(now).emit_timer_expire(timer);
+        while let Some((timer, _time)) = self.timers.expire_before(now, &self.qlog) {
             // TODO(@divma): remove `at` when the unicorn is born
             trace!(?timer, at=?now, "timeout");
             match timer {


### PR DESCRIPTION
## Description

This enables emitting qlog events for timers, according to [the spec](https://www.ietf.org/archive/id/draft-ietf-quic-qlog-quic-events-12.html#name-timer_updated).

It is based on #218 because this simplifies the implementation significantly (don't have to pass around the initial_dst_cid for each timer set).

I chose to implement this by passing a `QlogSinkWithTime` to all functions on the `timer_map`. Reasoning is:
* I think we want the qlog logging to happen in the TimerMap, otherwise it is far too easy to miss calling out to qlog when setting a timer
* I didn't want to pass another `Instant` (for the `now` timestamp) to the methods on timer map, because IMO having two Instant arguments in the function is quite error-prone. The signatures as chosen in this PR also make quite clear that the `now` timestamp is not used in the `TimerMap` itself but only for qlog logging.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->