### PR TITLE
fix: cleanup path closing errors

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -992,8 +992,12 @@ impl Connection {
                     // Locally we should have refused to open this path, the remote should
                     // have given us CIDs for this path before opening it.  So we can always
                     // abandon this here.
-                    self.close_path(now, path_id, TransportErrorCode::NO_CID_AVAILABLE.into())
-                        .ok();
+                    self.close_path(
+                        now,
+                        path_id,
+                        TransportErrorCode::NO_CID_AVAILABLE_FOR_PATH.into(),
+                    )
+                    .ok();
                     self.spaces[SpaceId::Data]
                         .pending
                         .path_cids_blocked
@@ -1965,7 +1969,7 @@ impl Connection {
                             if let Err(err) = self.close_path(
                                 now,
                                 path_id,
-                                TransportErrorCode::UNSTABLE_INTERFACE.into(),
+                                TransportErrorCode::PATH_UNSTABLE_OR_POOR.into(),
                             ) {
                                 warn!(?err, "failed closing path");
                             }
@@ -6175,8 +6179,11 @@ impl Connection {
                 .unwrap_or(false);
 
             if !validated {
-                let _ =
-                    self.close_path(now, path_id, TransportErrorCode::APPLICATION_ABANDON.into());
+                let _ = self.close_path(
+                    now,
+                    path_id,
+                    TransportErrorCode::APPLICATION_ABANDON_PATH.into(),
+                );
             }
         }
 

--- a/quinn-proto/src/transport_error.rs
+++ b/quinn-proto/src/transport_error.rs
@@ -171,8 +171,8 @@ errors! {
     KEY_UPDATE_ERROR(0xE) "key update error";
     AEAD_LIMIT_REACHED(0xF) "the endpoint has reached the confidentiality or integrity limit for the AEAD algorithm";
     NO_VIABLE_PATH(0x10) "no viable network path exists";
-    APPLICATION_ABANDON(0x004150504142414e) "Path abandoned at the application's request";
-    RESOURCE_LIMIT_REACHED(0x0052534c494d4954) "Path abandoned due to resource limitations in the transport";
-    UNSTABLE_INTERFACE(0x00554e5f494e5446) "Path abandoned due to unstable interfaces";
-    NO_CID_AVAILABLE(0x004e4f5f4349445f) "Path abandoned due to no available connection IDs for the path";
+    APPLICATION_ABANDON_PATH(0x004150504142414e) "Path abandoned at the application's request";
+    PATH_RESOURCE_LIMIT_REACHED(0x0052534c494d4954) "Path abandoned due to resource limitations in the transport";
+    PATH_UNSTABLE_OR_POOR(0x00554e5f494e5446) "Path abandoned due to unstable interfaces";
+    NO_CID_AVAILABLE_FOR_PATH(0x004e4f5f4349445f) "Path abandoned due to no available connection IDs for the path";
 }

--- a/quinn/src/path.rs
+++ b/quinn/src/path.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use proto::{
     ClosePathError, ClosedPath, ConnectionError, PathError, PathEvent, PathId, PathStatus,
-    SetPathStatusError, VarInt,
+    SetPathStatusError, TransportErrorCode, VarInt,
 };
 use tokio::sync::{oneshot, watch};
 use tokio_stream::{Stream, wrappers::WatchStream};
@@ -141,19 +141,18 @@ impl Path {
 
     /// Closes this path
     ///
-    /// The passed in `error_code` is sent to the remote.  The future will resolve to the
-    /// `error_code` received from the remote.
-    ///
     /// The future will resolve when all the path state is dropped.  This only happens after
     /// the remote has confirmed the path as closed **and** after an additional timeout to
     /// give any in-flight packets the time to arrive.
-    pub fn close(&self, error_code: VarInt) -> Result<ClosePath, ClosePathError> {
+    pub fn close(&self) -> Result<ClosePath, ClosePathError> {
         let (on_path_close_send, on_path_close_recv) = oneshot::channel();
         {
             let mut state = self.conn.state.lock("close_path");
-            state
-                .inner
-                .close_path(crate::Instant::now(), self.id, error_code)?;
+            state.inner.close_path(
+                crate::Instant::now(),
+                self.id,
+                TransportErrorCode::APPLICATION_ABANDON_PATH.into(),
+            )?;
             state.close_path.insert(self.id, on_path_close_send);
         }
 


### PR DESCRIPTION
- update names to more closely match the RFC
- pass a fixed error code when the application closes the path

Closes https://github.com/n0-computer/iroh/issues/3633
