### PR TITLE
fix(proto): ensure ImmediateAcks are sent in Data space

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4255,9 +4255,7 @@ impl Connection {
                         //    so, but it still is something untidy. We should instead
                         //    suppress this when we know the remote is still validating the
                         //    path.
-                        match self.peer_supports_ack_frequency()
-                            && self.highest_space == SpaceId::Data
-                        {
+                        match self.peer_supports_ack_frequency() {
                             true => self.immediate_ack(path_id),
                             false => {
                                 self.ping_path(path_id).ok();


### PR DESCRIPTION
I have not been able to confirm this restriction with the RFCs, but it is currently implemented on the receiving side like this, so need to ensure the sending side follows this.

Closes https://github.com/n0-computer/quinn/issues/225
