### PR TITLE
fix: add missing frames to qlog

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -5013,6 +5013,7 @@ impl Connection {
                         .get_or_insert_with(|| (*round, Default::default()));
                     sent_reachouts.1.push(local_addr);
                     self.stats.frame_tx.reach_out = self.stats.frame_tx.reach_out.saturating_add(1);
+                    qlog.frame(&Frame::ReachOut(reach_out));
                 } else {
                     addresses.push(local_addr);
                     break;
@@ -5555,6 +5556,7 @@ impl Connection {
                     .add_address
                     .insert(added_address);
                 self.stats.frame_tx.add_address = self.stats.frame_tx.add_address.saturating_add(1);
+                qlog.frame(&Frame::AddAddress(added_address));
             } else {
                 break;
             }
@@ -5571,6 +5573,7 @@ impl Connection {
                     .insert(removed_address);
                 self.stats.frame_tx.remove_address =
                     self.stats.frame_tx.remove_address.saturating_add(1);
+                qlog.frame(&Frame::RemoveAddress(removed_address));
             } else {
                 break;
             }


### PR DESCRIPTION
## Description

Adds the QNT frames on the send side to qlog, they were missed in the previous commits.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->