### PR TITLE
fix: Check higher spaces if blocked for any reason

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1103,7 +1103,7 @@ impl Connection {
                 trace!(?space_id, %path_id, ?send_blocked, "congestion blocked");
                 congestion_blocked = true;
             }
-            if send_blocked == PathBlocked::Congestion && space_id < SpaceId::Data {
+            if send_blocked != PathBlocked::No && space_id < SpaceId::Data {
                 // Higher spaces might still have tail-loss probes to send, which are not
                 // congestion blocked.
                 space_id = space_id.next();


### PR DESCRIPTION
## Description

This is a bug that did sneak in with the introduction of the
PathBlocked enum. If a PacketNumberSpace is blocked for any
reason (anti-amplification, congestion or pacing), we still need to be
able to send tail-loss probes on higher PacketNumberSpaces. Otherwise
those spaces could end up in a deadlock too.

## Breaking Changes

n/a

## Notes & open questions

I don't know if it is currently possible to write tests for these kind
of scenarios.