### PR TITLE
fix: max pto based on actuall rtt

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1904,6 +1904,7 @@ impl Connection {
             match timer {
                 Timer::Conn(timer) => match timer {
                     ConnTimer::Close => {
+                        trace!("close timer fired, moving to drained");
                         self.state.move_to_drained(None);
                         self.endpoint_events.push_back(EndpointEventInner::Drained);
                     }
@@ -3095,12 +3096,26 @@ impl Connection {
     fn pto_max_path(&self, space: SpaceId) -> Duration {
         match space {
             SpaceId::Initial | SpaceId::Handshake => self.pto(space, PathId::ZERO),
-            SpaceId::Data => self
-                .paths
-                .keys()
-                .map(|path_id| self.pto(space, *path_id))
-                .max()
-                .expect("there should be one at least path"),
+            SpaceId::Data => {
+                // For Data space, prefer paths that have actual RTT measurements.
+                // Pre-provisioned paths that were never used still have their initial_rtt
+                // estimate which can inflate the close timer unnecessarily.
+                let measured_pto = self
+                    .paths
+                    .iter()
+                    .filter(|(_, path_state)| path_state.data.rtt.has_measurement())
+                    .map(|(path_id, _)| self.pto(space, *path_id))
+                    .max();
+
+                measured_pto.unwrap_or_else(|| {
+                    // Fall back to all paths if none have measurements yet
+                    self.paths
+                        .keys()
+                        .map(|path_id| self.pto(space, *path_id))
+                        .max()
+                        .expect("there should be at least one path")
+                })
+            }
         }
     }
 

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -570,6 +570,11 @@ impl RttEstimator {
         self.get() + cmp::max(4 * self.var, TIMER_GRANULARITY)
     }
 
+    /// Whether an actual RTT measurement has been received (vs using initial estimate)
+    pub(crate) fn has_measurement(&self) -> bool {
+        self.smoothed.is_some()
+    }
+
     pub(crate) fn update(&mut self, ack_delay: Duration, rtt: Duration) {
         self.latest = rtt;
         // min_rtt ignores ack delay.

--- a/quinn/src/endpoint.rs
+++ b/quinn/src/endpoint.rs
@@ -36,7 +36,7 @@ use rustc_hash::FxHashMap;
 ))]
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::sync::{Notify, futures::Notified, mpsc};
-use tracing::{Instrument, Span};
+use tracing::{trace, Instrument, Span};
 use udp::{BATCH_SIZE, RecvMeta};
 
 use crate::{
@@ -553,6 +553,7 @@ impl State {
             if event.is_drained() {
                 self.recv_state.connections.senders.remove(&ch);
                 if self.recv_state.connections.is_empty() {
+                    trace!("all connections drained, notifying waiters");
                     shared.idle.notify_waiters();
                 }
             }


### PR DESCRIPTION
## Description

For close timeouts, pto_max took also initial RTT of paths which might not have updated resulting in a slightly slower close flow. Locally it's now 2.8s vs 3.1s it used to be, but that also helps avoid the deadline elapsed error on the transfer example in iroh.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->