### PR TITLE
fix: Only use PATH_CHALLENGE/RESPONSE RTT for initial RTT

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4290,10 +4290,16 @@ impl Connection {
                         path.data.challenges_sent.clear();
                         path.data.send_new_challenge = false;
                         path.data.validated = true;
-                        path.data.rtt.update(
-                            Duration::ZERO,
-                            now.saturating_duration_since(challenge_sent),
-                        );
+                        if path.data.total_recvd == 0 {
+                            // This RTT can only be used for the initial RTT, not as a
+                            // normal sample:
+                            // https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2-2. Hence
+                            // only use this RTT if this is the very first packet received
+                            // on this path.
+                            let rtt = now.saturating_duration_since(challenge_sent);
+                            trace!(?rtt, "resetting initial RTT from PATH_RESPONSE");
+                            path.data.rtt.reset(rtt);
+                        }
                         self.events
                             .push_back(Event::Path(PathEvent::Opened { id: path_id }));
                         // mark the path as open from the application perspective now that Opened


### PR DESCRIPTION
## Description

According to https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2-2:

   A connection MAY use the delay between sending a PATH_CHALLENGE and
   receiving a PATH_RESPONSE to set the initial RTT (see kInitialRtt
   in Appendix A.2) for a new path, but the delay SHOULD NOT be
   considered an RTT sample.

Before we used this as a normal sample, this fixes this to only use it
as the initial RTT.

## Breaking Changes

n/a

## Notes & open questions

Note that this would not be true for off-path PATH_RESPONSE
frames. When we add support for those we need to adjust this to store
the data we have about the new remote, since the remote is now
validated but not yet used for a path. When later that path is
actually opened later on we might want to check if the validated
remote/path info is recent enough and use it as initial values there
too.