### PR TITLE
fix(proto): Emit updated qlog tuple when a path's remote changes

### DIFF
--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -242,7 +242,7 @@ impl QlogSink {
         }
     }
 
-    pub(super) fn emit_new_path(&self, path_id: PathId, remote: SocketAddr, now: Instant) {
+    pub(super) fn emit_tuple_assigned(&self, path_id: PathId, remote: SocketAddr, now: Instant) {
         #[cfg(feature = "qlog")]
         {
             let Some(stream) = self.stream.as_ref() else {


### PR DESCRIPTION
## Description

A small fix so we can actually show the correct remote addrs in qlog viewers.

Before:
<img width="1522" height="732" alt="image" src="https://github.com/user-attachments/assets/07cd10f9-3c9a-4285-809b-387ca2ffdf60" />
(Never updates the tuple, thus keeps thinking the remote address of path 0 is `[fd15:70a:510b::1]:12345` forever)

After:
<img width="1522" height="732" alt="image" src="https://github.com/user-attachments/assets/554e2f6a-0e70-44b0-9d54-027e9d22366b" />
Here, we get another `tuple_assigned` event, thus the viewer knows that the path updated.

The same fix should now also apply for migrations (those wouldn't update their tuple as well).

## Notes & open questions

I also renamed `emit_new_path` to `emit_tuple_assigned` to better match the name of the qlog event, and to indicate what it actually does better.