### PR TITLE
fix: Improve condition of when a PATH_RESPONSE RTT can be used

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4291,16 +4291,12 @@ impl Connection {
                         path.data.challenges_sent.clear();
                         path.data.send_new_challenge = false;
                         path.data.validated = true;
-                        if path.data.total_recvd == 0 {
-                            // This RTT can only be used for the initial RTT, not as a
-                            // normal sample:
-                            // https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2-2. Hence
-                            // only use this RTT if this is the very first packet received
-                            // on this path.
-                            let rtt = now.saturating_duration_since(challenge_sent);
-                            trace!(?rtt, "resetting initial RTT from PATH_RESPONSE");
-                            path.data.rtt.reset(rtt);
-                        }
+
+                        // This RTT can only be used for the initial RTT, not as a normal
+                        // sample: https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2-2.
+                        let rtt = now.saturating_duration_since(challenge_sent);
+                        path.data.rtt.reset_initial_rtt(rtt);
+
                         self.events
                             .push_back(Event::Path(PathEvent::Opened { id: path_id }));
                         // mark the path as open from the application perspective now that Opened

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -549,6 +549,9 @@ impl RttEstimator {
 
     /// Resets the estimator using a new initial_rtt value.
     ///
+    /// This only resets the initial_rtt **if** no samples have been recorded yet. If there
+    /// are any recorded samples the initial estimate can not be adjusted after the fact.
+    ///
     /// This is useful when you receive a PATH_RESPONSE in the first packet received on a
     /// new path. In this case you can use the delay of the PATH_CHALLENGE-PATH_RESPONSE as
     /// the initial RTT to get a better expected estimation.
@@ -556,11 +559,12 @@ impl RttEstimator {
     /// A PATH_CHALLENGE-PATH_RESPONSE pair later in the connection should not be used
     /// explicitly as an estimation since PATH_CHALLENGE is an ACK-eliciting packet itself
     /// already.
-    pub(crate) fn reset(&mut self, initial_rtt: Duration) {
-        self.latest = initial_rtt;
-        self.smoothed = None;
-        self.var = initial_rtt / 2;
-        self.min = initial_rtt;
+    pub(crate) fn reset_initial_rtt(&mut self, initial_rtt: Duration) {
+        if self.smoothed.is_none() {
+            self.latest = initial_rtt;
+            self.var = initial_rtt / 2;
+            self.min = initial_rtt;
+        }
     }
 
     /// The current best RTT estimation.


### PR DESCRIPTION
## Description

This improves the condition of when the RTT learned from a
PATH_RESPONSE can be used. The easiest way to achieve this correctly
is by embedding the logic in the RttEstimator itself.

## Breaking Changes

n/a

## Notes & open questions

n/a