### PR TITLE
refactor: update to `draft-ietf-quic-multipath-18`

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -4639,7 +4639,7 @@ impl Connection {
                         self.qlog.with_time(now),
                     );
                 }
-                Frame::PathAvailable(info) => {
+                Frame::PathStatusAvailable(info) => {
                     span.record("path", tracing::field::debug(&info.path_id));
                     if self.is_multipath_negotiated() {
                         self.on_path_status(
@@ -4649,7 +4649,7 @@ impl Connection {
                         );
                     } else {
                         return Err(TransportError::PROTOCOL_VIOLATION(
-                            "received PATH_AVAILABLE frame when multipath was not negotiated",
+                            "received PATH_STATUS_AVAILABLE frame when multipath was not negotiated",
                         ));
                     }
                 }
@@ -5322,10 +5322,10 @@ impl Connection {
                 .or_insert(error_code);
         }
 
-        // PATH_AVAILABLE & PATH_STATUS_BACKUP
+        // PATH_STATUS_AVAILABLE & PATH_STATUS_BACKUP
         while !path_exclusive_only
             && space_id == SpaceId::Data
-            && frame::PathAvailable::SIZE_BOUND <= buf.remaining_mut()
+            && frame::PathStatusAvailable::SIZE_BOUND <= buf.remaining_mut()
         {
             let Some(path_id) = space.pending.path_status.pop_first() else {
                 break;
@@ -5339,14 +5339,14 @@ impl Connection {
             sent.retransmits.get_or_create().path_status.insert(path_id);
             match path.local_status() {
                 PathStatus::Available => {
-                    let frame = frame::PathAvailable {
+                    let frame = frame::PathStatusAvailable {
                         path_id,
                         status_seq_no: seq,
                     };
                     frame.encode(buf);
-                    qlog.frame(&Frame::PathAvailable(frame));
-                    self.stats.frame_tx.path_available += 1;
-                    trace!(%path_id, %seq, "PATH_AVAILABLE")
+                    qlog.frame(&Frame::PathStatusAvailable(frame));
+                    self.stats.frame_tx.path_status_available += 1;
+                    trace!(%path_id, %seq, "PATH_STATUS_AVAILABLE")
                 }
                 PathStatus::Backup => {
                     let frame = frame::PathStatusBackup {
@@ -6165,12 +6165,12 @@ impl Connection {
         }
     }
 
-    /// Handle new path status information: PATH_AVAILABLE, PATH_STATUS_BACKUP
+    /// Handle new path status information: PATH_STATUS_AVAILABLE, PATH_STATUS_BACKUP
     fn on_path_status(&mut self, path_id: PathId, status: PathStatus, status_seq_no: VarInt) {
         if let Some(path) = self.paths.get_mut(&path_id) {
             path.data.status.remote_update(status, status_seq_no);
         } else {
-            debug!("PATH_AVAILABLE received unknown path {:?}", path_id);
+            debug!("PATH_STATUS_AVAILABLE received unknown path {:?}", path_id);
         }
         self.events.push_back(
             PathEvent::RemoteStatus {

--- a/quinn-proto/src/connection/paths.rs
+++ b/quinn-proto/src/connection/paths.rs
@@ -719,12 +719,12 @@ impl InFlight {
     }
 }
 
-/// State for QUIC-MULTIPATH PATH_AVAILABLE and PATH_STATUS_BACKUP frames
+/// State for QUIC-MULTIPATH PATH_STATUS_AVAILABLE and PATH_STATUS_BACKUP frames
 #[derive(Debug, Clone, Default)]
 pub(super) struct PathStatusState {
     /// The local status
     local_status: PathStatus,
-    /// Local sequence number, for both PATH_AVAIALABLE and PATH_STATUS_BACKUP
+    /// Local sequence number, for both PATH_STATUS_AVAILABLE and PATH_STATUS_BACKUP
     ///
     /// This is the number of the *next* path status frame to be sent.
     local_seq: VarInt,
@@ -733,7 +733,7 @@ pub(super) struct PathStatusState {
 }
 
 impl PathStatusState {
-    /// To be called on received PATH_AVAILABLE/PATH_STATUS_BACKUP frames
+    /// To be called on received PATH_STATUS_AVAILABLE/PATH_STATUS_BACKUP frames
     pub(super) fn remote_update(&mut self, status: PathStatus, seq: VarInt) {
         if self.remote_status.is_some_and(|(curr, _)| curr >= seq) {
             return trace!(%seq, "ignoring path status update");

--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -788,7 +788,7 @@ impl Frame {
                 error_code: frame.error_code.into(),
                 raw: None,
             },
-            Self::PathAvailable(frame) => QuicFrame::PathStatusAvailable {
+            Self::PathStatusAvailable(frame) => QuicFrame::PathStatusAvailable {
                 path_id: frame.path_id.as_u32().into(),
                 path_status_sequence_number: frame.status_seq_no.into(),
                 raw: None,

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -531,7 +531,7 @@ pub struct Retransmits {
     pub(super) new_tokens: Vec<SocketAddr>,
     /// Paths which need to be abandoned
     pub(super) path_abandon: BTreeMap<PathId, TransportErrorCode>,
-    /// If a [`frame::PathAvailable`] and [`frame::PathStatusBackup`] need to be sent for a path
+    /// If a [`frame::PathStatusAvailable`] and [`frame::PathStatusBackup`] need to be sent for a path
     pub(super) path_status: BTreeSet<PathId>,
     /// If a PATH_CIDS_BLOCKED frame needs to be sent for a path
     pub(super) path_cids_blocked: Vec<PathId>,

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -61,7 +61,7 @@ pub struct FrameStats {
     pub stream: u64,
     pub observed_addr: u64,
     pub path_abandon: u64,
-    pub path_available: u64,
+    pub path_status_available: u64,
     pub path_status_backup: u64,
     pub max_path_id: u64,
     pub paths_blocked: u64,
@@ -119,7 +119,9 @@ impl FrameStats {
             Frame::HandshakeDone => self.handshake_done = self.handshake_done.saturating_add(1),
             Frame::ObservedAddr(_) => self.observed_addr += 1,
             Frame::PathAbandon(_) => self.path_abandon = self.path_abandon.saturating_add(1),
-            Frame::PathAvailable(_) => self.path_available = self.path_available.saturating_add(1),
+            Frame::PathStatusAvailable(_) => {
+                self.path_status_available = self.path_status_available.saturating_add(1)
+            }
             Frame::PathStatusBackup(_) => {
                 self.path_status_backup = self.path_status_backup.saturating_add(1)
             }
@@ -156,7 +158,7 @@ impl std::fmt::Debug for FrameStats {
             .field("PATHS_BLOCKED", &self.paths_blocked)
             .field("PATH_ABANDON", &self.path_abandon)
             .field("PATH_ACK", &self.path_acks)
-            .field("PATH_AVAILABLE", &self.path_available)
+            .field("PATH_STATUS_AVAILABLE", &self.path_status_available)
             .field("PATH_STATUS_BACKUP", &self.path_status_backup)
             .field("PATH_CHALLENGE", &self.path_challenge)
             .field("PATH_CIDS_BLOCKED", &self.path_cids_blocked)

--- a/quinn-proto/src/frame.rs
+++ b/quinn-proto/src/frame.rs
@@ -144,7 +144,7 @@ frame_types! {
     PATH_ACK_ECN = 0x15228c01,
     PATH_ABANDON = 0x15228c05,
     PATH_STATUS_BACKUP = 0x15228c07,
-    PATH_AVAILABLE = 0x15228c08,
+    PATH_STATUS_AVAILABLE = 0x15228c08,
     PATH_NEW_CONNECTION_ID = 0x15228c09,
     PATH_RETIRE_CONNECTION_ID = 0x15228c0a,
     MAX_PATH_ID = 0x15228c0c,
@@ -189,7 +189,7 @@ pub(crate) enum Frame {
     HandshakeDone,
     ObservedAddr(ObservedAddr),
     PathAbandon(PathAbandon),
-    PathAvailable(PathAvailable),
+    PathStatusAvailable(PathStatusAvailable),
     PathStatusBackup(PathStatusBackup),
     MaxPathId(MaxPathId),
     PathsBlocked(PathsBlocked),
@@ -241,7 +241,7 @@ impl Frame {
             HandshakeDone => FrameType::HANDSHAKE_DONE,
             ObservedAddr(ref observed) => observed.get_type(),
             PathAbandon(_) => FrameType::PATH_ABANDON,
-            PathAvailable(_) => FrameType::PATH_AVAILABLE,
+            PathStatusAvailable(_) => FrameType::PATH_STATUS_AVAILABLE,
             PathStatusBackup(_) => FrameType::PATH_STATUS_BACKUP,
             MaxPathId(_) => FrameType::MAX_PATH_ID,
             PathsBlocked(_) => FrameType::PATHS_BLOCKED,
@@ -279,7 +279,7 @@ impl Frame {
             Self::PathAck(_)
                 | Self::PathAbandon(_)
                 | Self::PathStatusBackup(_)
-                | Self::PathAvailable(_)
+                | Self::PathStatusAvailable(_)
                 | Self::MaxPathId(_)
                 | Self::PathsBlocked(_)
                 | Self::PathCidsBlocked(_)
@@ -1045,8 +1045,8 @@ impl Iter {
                 Frame::ObservedAddr(observed)
             }
             FrameType::PATH_ABANDON => Frame::PathAbandon(PathAbandon::decode(&mut self.bytes)?),
-            FrameType::PATH_AVAILABLE => {
-                Frame::PathAvailable(PathAvailable::decode(&mut self.bytes)?)
+            FrameType::PATH_STATUS_AVAILABLE => {
+                Frame::PathStatusAvailable(PathStatusAvailable::decode(&mut self.bytes)?)
             }
             FrameType::PATH_STATUS_BACKUP => {
                 Frame::PathStatusBackup(PathStatusBackup::decode(&mut self.bytes)?)
@@ -1500,14 +1500,14 @@ impl PathAbandon {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct PathAvailable {
+pub(crate) struct PathStatusAvailable {
     pub(crate) path_id: PathId,
     pub(crate) status_seq_no: VarInt,
 }
 
-impl PathAvailable {
-    const TYPE: FrameType = FrameType::PATH_AVAILABLE;
-    pub(crate) const SIZE_BOUND: usize = VarInt(FrameType::PATH_AVAILABLE.0).size() + 8 + 8;
+impl PathStatusAvailable {
+    const TYPE: FrameType = FrameType::PATH_STATUS_AVAILABLE;
+    pub(crate) const SIZE_BOUND: usize = VarInt(FrameType::PATH_STATUS_AVAILABLE.0).size() + 8 + 8;
 
     /// Encode [`Self`] into the given buffer
     pub(crate) fn encode<W: BufMut>(&self, buf: &mut W) {
@@ -1910,18 +1910,18 @@ mod test {
     }
 
     #[test]
-    fn test_path_available_roundtrip() {
-        let path_avaiable = PathAvailable {
+    fn test_path_status_available_roundtrip() {
+        let path_status_available = PathStatusAvailable {
             path_id: PathId(42),
             status_seq_no: VarInt(73),
         };
         let mut buf = Vec::new();
-        path_avaiable.encode(&mut buf);
+        path_status_available.encode(&mut buf);
 
         let mut decoded = frames(buf);
         assert_eq!(decoded.len(), 1);
         match decoded.pop().expect("non empty") {
-            Frame::PathAvailable(decoded) => assert_eq!(decoded, path_avaiable),
+            Frame::PathStatusAvailable(decoded) => assert_eq!(decoded, path_status_available),
             x => panic!("incorrect frame {x:?}"),
         }
     }

--- a/quinn-proto/src/tests/multipath.rs
+++ b/quinn-proto/src/tests/multipath.rs
@@ -134,15 +134,15 @@ fn path_status() {
     );
 
     let client_stats = pair.client_conn_mut(client_ch).stats();
-    assert_eq!(client_stats.frame_tx.path_available, 0);
+    assert_eq!(client_stats.frame_tx.path_status_available, 0);
     assert_eq!(client_stats.frame_tx.path_status_backup, 1);
-    assert_eq!(client_stats.frame_rx.path_available, 0);
+    assert_eq!(client_stats.frame_rx.path_status_available, 0);
     assert_eq!(client_stats.frame_rx.path_status_backup, 0);
 
     let server_stats = pair.server_conn_mut(server_ch).stats();
-    assert_eq!(server_stats.frame_tx.path_available, 0);
+    assert_eq!(server_stats.frame_tx.path_status_available, 0);
     assert_eq!(server_stats.frame_tx.path_status_backup, 0);
-    assert_eq!(server_stats.frame_rx.path_available, 0);
+    assert_eq!(server_stats.frame_rx.path_status_available, 0);
     assert_eq!(server_stats.frame_rx.path_status_backup, 1);
 }
 


### PR DESCRIPTION
Only material adjustment was changing the frame naming from `PATH_BACKUP` and `PATH_AVAILABLE` to `PATH_STATUS_BACKUP` and `PATH_STATUS_AVAILABLE`:

- PATH_BACKUP => PATH_STATUS_BACKUP
- PathBackup => PathStatusBackup
- path_backup => path_status_backup
- PATH_AVAILABLE => PATH_STATUS_Available
- PathAvailable => PathStatusAvailable
- path_available => path_status_available

As the draft is not yet published, the experimental values for the frame types and error types remain the same, though I did double check our values were inline with those experimental values.

maybe closes https://github.com/n0-computer/iroh/issues/3531 unless we want to keep that open until multipath is published?