### PR TITLE
test(quinn-proto): Add proptests for assembler

### DIFF
--- a/quinn-proto/src/connection/assembler.rs
+++ b/quinn-proto/src/connection/assembler.rs
@@ -674,7 +674,7 @@ mod test {
 #[cfg(all(test, not(target_family = "wasm")))]
 mod proptests {
     use proptest::prelude::*;
-    use test_strategy::{proptest, Arbitrary};
+    use test_strategy::{Arbitrary, proptest};
 
     use super::*;
 
@@ -684,9 +684,17 @@ mod proptests {
     #[derive(Debug, Clone, Arbitrary)]
     enum Op {
         #[weight(10)]
-        Insert { #[strategy(0..MAX_OFFSET)] offset: u64, #[strategy(1..MAX_LEN)] len: usize },
+        Insert {
+            #[strategy(0..MAX_OFFSET)]
+            offset: u64,
+            #[strategy(1..MAX_LEN)]
+            len: usize,
+        },
         #[weight(10)]
-        Read { #[strategy(1..MAX_LEN)] max_len: usize },
+        Read {
+            #[strategy(1..MAX_LEN)]
+            max_len: usize,
+        },
         #[weight(1)]
         EnsureOrdering { ordered: bool },
         #[weight(1)]


### PR DESCRIPTION
## Description

Add a simple proptest for the assembler, to make sure the range set ops in unordered mode get properly exercised.

Also fix a bug in the assembler when going to unordered state after reading data, and add a regression test for that case.

## Breaking Changes

None

## Notes & open questions

Note: the unordered API is somewhat unintuitive. See https://github.com/n0-computer/quinn/issues/245