### PR TITLE
perf(iroh-quinn): Add a mutable buffer so small writes are less expensive

### DIFF
--- a/quinn-proto/src/connection/send_buffer.rs
+++ b/quinn-proto/src/connection/send_buffer.rs
@@ -38,7 +38,7 @@ pub(super) struct SendBuffer {
 /// Maximum number of bytes to combine into a single segment
 ///
 /// Any segment larger than this will be stored as-is, possibly triggering a flush of the buffer.
-const MAX_COMBINE: usize = 1024;
+const MAX_COMBINE: usize = 1452;
 
 /// This is where the data of the send buffer lives. It supports appending at the end,
 /// removing from the front, and retrieving data by range.


### PR DESCRIPTION
## Description

Coalesces small writes, while keeping large writes as separate slices.

E.g. you got iroh-blobs writing a bunch of hash pairs and then an entire 16 KiB chunk group. Writes will be this:

```
[u8;64]
[u8;64]
[u8;64]
...
[u8;64]
[u8;1024 * 16]
```

In this branch the SendBuffer won't store the [u8;64] as separate Bytes but will append the to the last_segment of the SendBuffer until that reaches the threshold of MAX_COMBINE (currently 1024).

This means that the actual segment buffer `segments: VecDeque<Bytes>` contains fewer elements and all those linear scans we do aren't that expensive.

If we get lucky and we get polled quickly enough, for small writes the data will never make it out of last_segment but will be copied right from there.

The next step would be to make sure the Bytes that are currently created when using AsyncWrite::write are not created. But that's for the next PR.

~~Todo: basic tests and proptests for SendBufferData~~

We got proptests for SendBuffer now.

## Breaking Changes

None

## Notes & open questions

Q: Value for MAX_COMBINE? 1024 seems reasonable. This shouldn't be much more than what will be requested in poll_transmit.