### PR TITLE
perf(quinn-proto): Introduce BytesOrSlice trait to defer creation of Bytes

### DIFF
--- a/quinn-proto/src/connection/streams/mod.rs
+++ b/quinn-proto/src/connection/streams/mod.rs
@@ -526,3 +526,14 @@ enum StreamHalf {
     Send,
     Recv,
 }
+
+/// A helper trait to unify Bytes, Vec<u8> and &[u8] as sources of bytes
+pub(super) trait BytesOrSlice: AsRef<[u8]> + Into<Bytes> {
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+    fn is_empty(&self) -> bool {
+        self.as_ref().is_empty()
+    }
+}
+impl<T: AsRef<[u8]> + Into<Bytes>> BytesOrSlice for T {}


### PR DESCRIPTION
## Description

Introduce BytesOrSlice trait / constraint alias to defer creation of Bytes.

That way for small writes we don't have to do it!

A small write will be kept as a slice and just appended to the last_segment buffer inside SendBuffer/SendBufferData. No allocation.

For a large write, we will use Into<Bytes> to turn it into a bytes, which allocates if the write was a slice, but does not allocate if the write was already a Bytes - Into is a noop then.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->