### PR TITLE
fix(proto): return error in initiate_nat_traversal_round

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -6329,6 +6329,13 @@ impl Connection {
             }
         }
 
+        if let Some(err) = err {
+            // We failed to probe any addresses, bail out
+            if probed_addresses.is_empty() {
+                return Err(iroh_hp::Error::Multipath(err));
+            }
+        }
+
         self.iroh_hp
             .client_side_mut()
             .expect("connection side validated")


### PR DESCRIPTION
The error was never returned. Not sure this is the best way to do it, but it is a step forward