### PR TITLE
refactor: split up poll_transmit into per_path and per_space parts

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1061,6 +1061,8 @@ impl Connection {
         if self.state.is_established() {
             // Try MTU probing now
             for path_id in path_ids {
+                // Update per path state
+                transmit.set_segment_size(self.path_data(path_id).current_mtu().into());
                 self.poll_transmit_mtu_probe(now, &mut transmit, path_id);
                 if !transmit.is_empty() {
                     let transmit = self.build_transmit(path_id, transmit);
@@ -1073,6 +1075,11 @@ impl Connection {
     }
 
     fn build_transmit(&mut self, path_id: PathId, transmit: TransmitBuf<'_>) -> Transmit {
+        debug_assert!(
+            !transmit.is_empty(),
+            "must not be called with an empty transmit buffer"
+        );
+
         let network_path = self.path_data(path_id).network_path;
         trace!(
             segment_size = transmit.segment_size(),
@@ -1566,59 +1573,66 @@ impl Connection {
         transmit: &mut TransmitBuf<'_>,
         path_id: PathId,
     ) {
-        // MTU probing happens only in Data space.
-        let space_id = SpaceId::Data;
-        let probe_data = {
-            // We MTU probe all paths for which all of the following is true:
-            // - We have an active destination CID for the path.
-            // - The remote address *and* path are validated.
-            // - The path is not abandoned.
-            // - The MTU Discovery subsystem wants to probe the path.
-            let active_cid = self.rem_cids.get(&path_id).map(CidQueue::active);
-            let eligible = self.path_data(path_id).validated
-                && !self.path_data(path_id).is_validating_path()
-                && !self.abandoned_paths.contains(&path_id);
-            let probe_size = eligible
-                .then(|| {
-                    let next_pn = self.spaces[space_id].for_path(path_id).peek_tx_number();
-                    self.path_data_mut(path_id).mtud.poll_transmit(now, next_pn)
-                })
-                .flatten();
-
-            match (active_cid, probe_size) {
-                (Some(active_cid), Some(probe_size)) => Some((active_cid, probe_size)),
-                _ => None,
-            }
+        let Some((active_cid, probe_size)) = self.get_mtu_probe_data(now, path_id) else {
+            return;
         };
 
-        // Let's send an MTUD probe!
-        if let Some((active_cid, probe_size)) = probe_data {
-            // We are definitely sending a DPLPMTUD probe.
-            debug_assert_eq!(transmit.num_datagrams(), 0);
-            transmit.start_new_datagram_with_size(probe_size as usize);
+        // We are definitely sending a DPLPMTUD probe.
+        debug_assert_eq!(transmit.num_datagrams(), 0);
+        transmit.start_new_datagram_with_size(probe_size as usize);
 
-            let Some(mut builder) =
-                PacketBuilder::new(now, space_id, path_id, active_cid, transmit, true, self)
-            else {
-                return;
-            };
+        let Some(mut builder) = PacketBuilder::new(
+            now,
+            SpaceId::Data,
+            path_id,
+            active_cid,
+            transmit,
+            true,
+            self,
+        ) else {
+            return;
+        };
 
-            // We implement MTU probes as ping packets padded up to the probe size
-            trace!(?probe_size, "writing MTUD probe");
-            builder.write_frame(frame::Ping, &mut self.stats.frame_tx);
+        // We implement MTU probes as ping packets padded up to the probe size
+        trace!(?probe_size, "writing MTUD probe");
+        builder.write_frame(frame::Ping, &mut self.stats.frame_tx);
 
-            // If supported by the peer, we want no delays to the probe's ACK
-            if self.peer_supports_ack_frequency() {
-                builder.write_frame(frame::ImmediateAck, &mut self.stats.frame_tx);
-            }
-
-            builder.finish_and_track(now, self, path_id, PadDatagram::ToSize(probe_size));
-
-            self.path_stats
-                .entry(path_id)
-                .or_default()
-                .sent_plpmtud_probes += 1;
+        // If supported by the peer, we want no delays to the probe's ACK
+        if self.peer_supports_ack_frequency() {
+            builder.write_frame(frame::ImmediateAck, &mut self.stats.frame_tx);
         }
+
+        builder.finish_and_track(now, self, path_id, PadDatagram::ToSize(probe_size));
+
+        self.path_stats
+            .entry(path_id)
+            .or_default()
+            .sent_plpmtud_probes += 1;
+    }
+
+    fn get_mtu_probe_data(&mut self, now: Instant, path_id: PathId) -> Option<(ConnectionId, u16)> {
+        // We MTU probe all paths for which all of the following is true:
+        // - We have an active destination CID for the path.
+        // - The remote address *and* path are validated.
+        // - The path is not abandoned.
+        // - The MTU Discovery subsystem wants to probe the path.
+        let active_cid = self.rem_cids.get(&path_id).map(CidQueue::active)?;
+        let is_eligible = self.path_data(path_id).validated
+            && !self.path_data(path_id).is_validating_path()
+            && !self.abandoned_paths.contains(&path_id);
+
+        if !is_eligible {
+            return None;
+        }
+        let next_pn = self.spaces[SpaceId::Data]
+            .for_path(path_id)
+            .peek_tx_number();
+        let probe_size = self
+            .path_data_mut(path_id)
+            .mtud
+            .poll_transmit(now, next_pn)?;
+
+        Some((active_cid, probe_size))
     }
 
     /// Returns the [`SpaceId`] of the next packet space which has data to send

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1505,9 +1505,7 @@ impl Connection {
                     .datagram_remaining_mut()
                     .saturating_sub(builder.predict_packet_end())
                     > MIN_PACKET_SPACE
-                && self
-                    .next_send_space(space_id, path_id, builder.buf, close)
-                    .is_some()
+                && self.has_next_send_space(space_id, path_id, builder.buf, close)
             {
                 // We can append/coalesce the next packet into the current
                 // datagram. Finish the current packet without adding extra padding.
@@ -1641,17 +1639,17 @@ impl Connection {
         Some((active_cid, probe_size))
     }
 
-    /// Returns the [`SpaceId`] of the next packet space which has data to send
+    /// Returns if there is anext packet space which has data to send
     ///
     /// This takes into account the space available to frames in the next datagram.
     // TODO(flub): This duplication is not nice.
-    fn next_send_space(
+    fn has_next_send_space(
         &mut self,
         current_space_id: SpaceId,
         path_id: PathId,
         buf: &TransmitBuf<'_>,
         close: bool,
-    ) -> Option<SpaceId> {
+    ) -> bool {
         // Number of bytes available for frames if this is a 1-RTT packet. We're guaranteed
         // to be able to send an individual frame at least this large in the next 1-RTT
         // packet. This could be generalized to support every space, but it's only needed to
@@ -1662,15 +1660,14 @@ impl Connection {
         loop {
             let can_send = self.space_can_send(space_id, path_id, buf.segment_size(), close);
             if !can_send.is_empty() || (close && self.spaces[space_id].crypto.is_some()) {
-                return Some(space_id);
+                return true;
             }
-            space_id = match space_id {
-                SpaceId::Initial => SpaceId::Handshake,
-                SpaceId::Handshake => SpaceId::Data,
-                SpaceId::Data => break,
-            }
+            let Some(next_space) = space_id.next() else {
+                break;
+            };
+            space_id = next_space;
         }
-        None
+        false
     }
 
     /// Checks if creating a new datagram would be blocked by congestion control

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -322,19 +322,42 @@ pub struct Connection {
     qlog: QlogSink,
 }
 
+/// Return value for `poll_transmit_path`.
 #[derive(Debug)]
 enum PollPathStatus {
+    /// We have something to send, and data has been accumulated
+    /// on the passed in `transmit`.
     Send,
-    SendTransmit { transmit: Transmit },
-    NothingToSend { congestion_blocked: bool },
+    /// A transmit is ready to be sent out.
+    SendTransmit {
+        /// The transmit to send.
+        transmit: Transmit,
+    },
+    /// Nothing to send currently.
+    NothingToSend {
+        /// Set to `true` if we consider the current inability to send something because of congestion control
+        congestion_blocked: bool,
+    },
 }
 
+/// Return value for `poll_transmit_path_space`.
 #[derive(Debug)]
 enum PollPathSpaceStatus {
+    /// Nothing to send on this space, continue to the next one.
     NextSpace,
+    /// We have something to send, and data has been accumulated
+    /// on the passed in `transmit`.
     Send { last_packet_number: Option<u64> },
-    SendTransmit { transmit: Transmit },
-    NothingToSend { congestion_blocked: bool },
+    /// A transmit is ready to be sent out.
+    SendTransmit {
+        /// The transmit to send.
+        transmit: Transmit,
+    },
+    /// Nothing to send currently.
+    NothingToSend {
+        /// Set to `true` if we consider the current inability to send something because of congestion control
+        congestion_blocked: bool,
+    },
 }
 
 impl Connection {

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1122,6 +1122,15 @@ impl Connection {
         have_available_path: bool,
         close: bool,
     ) -> PollPathStatus {
+        // Check if there is at least one active CID to use for sending
+        let Some(remote_cid) = self.rem_cids.get(&path_id).map(CidQueue::active) else {
+            self.on_remote_cids_exhausted(now, path_id);
+
+            return PollPathStatus::NothingToSend {
+                congestion_blocked: false,
+            };
+        };
+
         // Whether this packet can be coalesced with another one in the same datagram.
         let mut coalesce = true;
 
@@ -1144,6 +1153,7 @@ impl Connection {
                 transmit,
                 path_id,
                 space_id,
+                remote_cid,
                 have_available_path,
                 close,
                 &mut coalesce,
@@ -1201,22 +1211,15 @@ impl Connection {
         transmit: &mut TransmitBuf<'_>,
         path_id: PathId,
         space_id: SpaceId,
+        remote_cid: ConnectionId,
         have_available_path: bool,
         close: bool,
         coalesce: &mut bool,
         pad_datagram: &mut PadDatagram,
     ) -> PollPathSpaceStatus {
         let mut last_packet_number = None;
+
         loop {
-            // Check if there is at least one active CID to use for sending
-            let Some(remote_cid) = self.rem_cids.get(&path_id).map(CidQueue::active) else {
-                self.on_remote_cids_exhausted(now, path_id);
-
-                return PollPathSpaceStatus::NothingToSend {
-                    congestion_blocked: false,
-                };
-            };
-
             // Determine if anything can be sent in this packet number space (SpaceId + PathId).
             let max_packet_size = if transmit.datagram_remaining_mut() > 0 {
                 // We are trying to coalesce another packet into this datagram.

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -323,16 +323,18 @@ pub struct Connection {
 }
 
 #[derive(Debug)]
-enum PathSendStatus {
-    SendTransmit { transmit: Option<Transmit> },
+enum PollPathStatus {
+    Send,
+    SendTransmit { transmit: Transmit },
     NothingToSend { congestion_blocked: bool },
 }
 
-enum PathSpaceStatus {
+#[derive(Debug)]
+enum PollPathSpaceStatus {
     NextSpace,
-    NothingToSend { congestion_blocked: bool },
     Send { last_packet_number: Option<u64> },
     SendTransmit { transmit: Transmit },
+    NothingToSend { congestion_blocked: bool },
 }
 
 impl Connection {
@@ -1026,16 +1028,14 @@ impl Connection {
             }
 
             match self.poll_transmit_path(now, &mut transmit, path_id, have_available_path, close) {
-                PathSendStatus::SendTransmit { transmit: t } => match t {
-                    None => {
-                        let transmit = self.build_transmit(path_id, transmit);
-                        return Some(transmit);
-                    }
-                    Some(transmit) => {
-                        return Some(transmit);
-                    }
-                },
-                PathSendStatus::NothingToSend {
+                PollPathStatus::SendTransmit { transmit } => {
+                    return Some(transmit);
+                }
+                PollPathStatus::Send => {
+                    let transmit = self.build_transmit(path_id, transmit);
+                    return Some(transmit);
+                }
+                PollPathStatus::NothingToSend {
                     congestion_blocked: cb,
                 } => {
                     // TODO: congestion blocked should be per path? how to deal with this better
@@ -1114,7 +1114,7 @@ impl Connection {
         path_id: PathId,
         have_available_path: bool,
         close: bool,
-    ) -> PathSendStatus {
+    ) -> PollPathStatus {
         // Whether this packet can be coalesced with another one in the same datagram.
         let mut coalesce = true;
 
@@ -1143,21 +1143,19 @@ impl Connection {
                 &mut pad_datagram,
             );
             match res {
-                PathSpaceStatus::Send {
+                PollPathSpaceStatus::Send {
                     last_packet_number: lp,
                 } => {
                     last_packet_number = lp;
                     break;
                 }
-                PathSpaceStatus::SendTransmit { transmit } => {
-                    return PathSendStatus::SendTransmit {
-                        transmit: Some(transmit),
-                    };
+                PollPathSpaceStatus::SendTransmit { transmit } => {
+                    return PollPathStatus::SendTransmit { transmit };
                 }
-                PathSpaceStatus::NothingToSend { congestion_blocked } => {
-                    return PathSendStatus::NothingToSend { congestion_blocked };
+                PollPathSpaceStatus::NothingToSend { congestion_blocked } => {
+                    return PollPathStatus::NothingToSend { congestion_blocked };
                 }
-                PathSpaceStatus::NextSpace => {
+                PollPathSpaceStatus::NextSpace => {
                     // moving onto the next space
                 }
             }
@@ -1180,11 +1178,11 @@ impl Connection {
         );
 
         if transmit.is_empty() {
-            PathSendStatus::NothingToSend {
+            PollPathStatus::NothingToSend {
                 congestion_blocked: false,
             }
         } else {
-            PathSendStatus::SendTransmit { transmit: None }
+            PollPathStatus::Send
         }
     }
 
@@ -1200,7 +1198,7 @@ impl Connection {
         close: bool,
         coalesce: &mut bool,
         pad_datagram: &mut PadDatagram,
-    ) -> PathSpaceStatus {
+    ) -> PollPathSpaceStatus {
         let mut last_packet_number = None;
         loop {
             // Check if there is at least one active CID to use for sending
@@ -1229,7 +1227,7 @@ impl Connection {
                     trace!(%path_id, "remote CIDs retired for abandoned path");
                 }
 
-                return PathSpaceStatus::NothingToSend {
+                return PollPathSpaceStatus::NothingToSend {
                     congestion_blocked: false,
                 };
             };
@@ -1262,7 +1260,7 @@ impl Connection {
                 if self.spaces[space_id].crypto.is_some() {
                     trace!(?space_id, %path_id, "nothing to send in space");
                 }
-                return PathSpaceStatus::NextSpace;
+                return PollPathSpaceStatus::NextSpace;
             }
 
             let send_blocked = if path_should_send && transmit.datagram_remaining_mut() == 0 {
@@ -1284,7 +1282,7 @@ impl Connection {
             if send_blocked != PathBlocked::No && space_id < SpaceId::Data {
                 // Higher spaces might still have tail-loss probes to send, which are not
                 // congestion blocked.
-                return PathSpaceStatus::NextSpace;
+                return PollPathSpaceStatus::NextSpace;
             }
             if !path_should_send || send_blocked != PathBlocked::No {
                 // Nothing more to send on this path, check the next path if possible.
@@ -1292,16 +1290,16 @@ impl Connection {
                 // If there are any datagrams in the transmit, packets for another path can
                 // not be built.
                 if transmit.num_datagrams() > 0 {
-                    return PathSpaceStatus::Send { last_packet_number };
+                    return PollPathSpaceStatus::Send { last_packet_number };
                 }
 
-                return PathSpaceStatus::NothingToSend { congestion_blocked };
+                return PollPathSpaceStatus::NothingToSend { congestion_blocked };
             }
 
             if transmit.datagram_remaining_mut() == 0 {
                 if transmit.num_datagrams() >= transmit.max_datagrams().get() {
                     // No more datagrams allowed
-                    return PathSpaceStatus::Send { last_packet_number };
+                    return PollPathSpaceStatus::Send { last_packet_number };
                 }
 
                 match self.spaces[space_id].for_path(path_id).loss_probes {
@@ -1363,7 +1361,7 @@ impl Connection {
                 can_send.other,
                 self,
             ) else {
-                return PathSpaceStatus::NothingToSend { congestion_blocked };
+                return PollPathSpaceStatus::NothingToSend { congestion_blocked };
             };
             last_packet_number = Some(builder.exact_number);
             *coalesce = *coalesce && !builder.short_header;
@@ -1435,12 +1433,12 @@ impl Connection {
                     // CONNECTION_CLOSE on a single path since we expect our paths to work.
                     self.close = false;
                     // `CONNECTION_CLOSE` is the final packet
-                    return PathSpaceStatus::Send { last_packet_number };
+                    return PollPathSpaceStatus::Send { last_packet_number };
                 } else {
                     // Send a close frame in every possible space for robustness, per
                     // RFC9000 "Immediate Close during the Handshake". Don't bother trying
                     // to send anything else.
-                    return PathSpaceStatus::NextSpace;
+                    return PollPathSpaceStatus::NextSpace;
                 }
             }
 
@@ -1460,8 +1458,7 @@ impl Connection {
                     builder.write_frame_with_log_msg(frame, stats, Some("(off-path)"));
                     builder.finish_and_track(now, self, path_id, PadDatagram::ToMinMtu);
                     self.stats.udp_tx.on_sent(1, transmit.len());
-
-                    return PathSpaceStatus::SendTransmit {
+                    return PollPathSpaceStatus::SendTransmit {
                         transmit: Transmit {
                             destination: network_path.remote,
                             size: transmit.len(),
@@ -1547,7 +1544,7 @@ impl Connection {
                             builder.buf.datagram_remaining_mut() - builder.predict_packet_end()
                         );
                         builder.finish_and_track(now, self, path_id, PadDatagram::No);
-                        return PathSpaceStatus::Send { last_packet_number };
+                        return PollPathSpaceStatus::Send { last_packet_number };
                     }
 
                     // Pad the current datagram to GSO segment size so it can be

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -331,7 +331,7 @@ enum PathSendStatus {
 enum PathSpaceStatus {
     NextSpace,
     NothingToSend { congestion_blocked: bool },
-    Send,
+    Send { last_packet_number: Option<u64> },
     SendTransmit { transmit: Transmit },
 }
 
@@ -1141,10 +1141,12 @@ impl Connection {
                 close,
                 &mut coalesce,
                 &mut pad_datagram,
-                &mut last_packet_number,
             );
             match res {
-                PathSpaceStatus::Send => {
+                PathSpaceStatus::Send {
+                    last_packet_number: lp,
+                } => {
+                    last_packet_number = lp;
                     break;
                 }
                 PathSpaceStatus::SendTransmit { transmit } => {
@@ -1198,8 +1200,8 @@ impl Connection {
         close: bool,
         coalesce: &mut bool,
         pad_datagram: &mut PadDatagram,
-        last_packet_number: &mut Option<u64>,
     ) -> PathSpaceStatus {
+        let mut last_packet_number = None;
         loop {
             // Check if there is at least one active CID to use for sending
             let Some(remote_cid) = self.rem_cids.get(&path_id).map(CidQueue::active) else {
@@ -1290,7 +1292,7 @@ impl Connection {
                 // If there are any datagrams in the transmit, packets for another path can
                 // not be built.
                 if transmit.num_datagrams() > 0 {
-                    return PathSpaceStatus::Send;
+                    return PathSpaceStatus::Send { last_packet_number };
                 }
 
                 return PathSpaceStatus::NothingToSend { congestion_blocked };
@@ -1299,7 +1301,7 @@ impl Connection {
             if transmit.datagram_remaining_mut() == 0 {
                 if transmit.num_datagrams() >= transmit.max_datagrams().get() {
                     // No more datagrams allowed
-                    return PathSpaceStatus::Send;
+                    return PathSpaceStatus::Send { last_packet_number };
                 }
 
                 match self.spaces[space_id].for_path(path_id).loss_probes {
@@ -1363,7 +1365,7 @@ impl Connection {
             ) else {
                 return PathSpaceStatus::NothingToSend { congestion_blocked };
             };
-            *last_packet_number = Some(builder.exact_number);
+            last_packet_number = Some(builder.exact_number);
             *coalesce = *coalesce && !builder.short_header;
 
             if space_id == SpaceId::Initial && (self.side.is_client() || can_send.other) {
@@ -1433,7 +1435,7 @@ impl Connection {
                     // CONNECTION_CLOSE on a single path since we expect our paths to work.
                     self.close = false;
                     // `CONNECTION_CLOSE` is the final packet
-                    return PathSpaceStatus::Send;
+                    return PathSpaceStatus::Send { last_packet_number };
                 } else {
                     // Send a close frame in every possible space for robustness, per
                     // RFC9000 "Immediate Close during the Handshake". Don't bother trying
@@ -1545,7 +1547,7 @@ impl Connection {
                             builder.buf.datagram_remaining_mut() - builder.predict_packet_end()
                         );
                         builder.finish_and_track(now, self, path_id, PadDatagram::No);
-                        return PathSpaceStatus::Send;
+                        return PathSpaceStatus::Send { last_packet_number };
                     }
 
                     // Pad the current datagram to GSO segment size so it can be

--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1210,29 +1210,7 @@ impl Connection {
         loop {
             // Check if there is at least one active CID to use for sending
             let Some(remote_cid) = self.rem_cids.get(&path_id).map(CidQueue::active) else {
-                let err = PathError::RemoteCidsExhausted;
-                if !self.abandoned_paths.contains(&path_id) {
-                    debug!(?err, %path_id, "no active CID for path");
-                    self.events.push_back(Event::Path(PathEvent::LocallyClosed {
-                        id: path_id,
-                        error: err,
-                    }));
-                    // Locally we should have refused to open this path, the remote should
-                    // have given us CIDs for this path before opening it.  So we can always
-                    // abandon this here.
-                    self.close_path(
-                        now,
-                        path_id,
-                        TransportErrorCode::NO_CID_AVAILABLE_FOR_PATH.into(),
-                    )
-                    .ok();
-                    self.spaces[SpaceId::Data]
-                        .pending
-                        .path_cids_blocked
-                        .insert(path_id);
-                } else {
-                    trace!(%path_id, "remote CIDs retired for abandoned path");
-                }
+                self.on_remote_cids_exhausted(now, path_id);
 
                 return PollPathSpaceStatus::NothingToSend {
                     congestion_blocked: false,
@@ -1565,6 +1543,31 @@ impl Connection {
                 }
             }
         }
+    }
+
+    fn on_remote_cids_exhausted(&mut self, now: Instant, path_id: PathId) {
+        if self.abandoned_paths.contains(&path_id) {
+            trace!(%path_id, "remote CIDs retired for abandoned path");
+            return;
+        }
+
+        let error = PathError::RemoteCidsExhausted;
+        debug!(?error, %path_id, "no active CID for path");
+        self.events
+            .push_back(Event::Path(PathEvent::LocallyClosed { id: path_id, error }));
+        // Locally we should have refused to open this path, the remote should
+        // have given us CIDs for this path before opening it.  So we can always
+        // abandon this here.
+        self.close_path(
+            now,
+            path_id,
+            TransportErrorCode::NO_CID_AVAILABLE_FOR_PATH.into(),
+        )
+        .ok();
+        self.spaces[SpaceId::Data]
+            .pending
+            .path_cids_blocked
+            .insert(path_id);
     }
 
     fn poll_transmit_mtu_probe(

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -282,7 +282,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         conn: &mut Connection,
         path_id: PathId,
         pad_datagram: PadDatagram,
-    ) {
+    ) -> u64 {
         match pad_datagram {
             PadDatagram::No => (),
             PadDatagram::ToSize(size) => self.pad_to(size),
@@ -329,6 +329,8 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             conn.set_loss_detection_timer(now, path_id);
             conn.path_data_mut(path_id).pacing.on_transmit(size);
         }
+
+        exact_number
     }
 
     /// Encrypt packet, returning the length of the packet and whether padding was added

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -935,7 +935,7 @@ impl SpaceId {
     /// Returns the next higher packet space.
     ///
     /// Returns `None` if at  [`SpaceId::Data`].
-    pub fn next(&self) -> Option<Self> {
+    pub(crate) fn next(&self) -> Option<Self> {
         match self {
             Self::Initial => Some(Self::Handshake),
             Self::Handshake => Some(Self::Data),

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -453,20 +453,6 @@ impl Header {
         )
     }
 
-    /// Is this packet allowed to be coalesced with others?
-    ///
-    /// Ref <https://www.rfc-editor.org/rfc/rfc9000.html#name-coalescing-packets>
-    pub(crate) fn can_coalesce(&self) -> bool {
-        use Header::*;
-        match *self {
-            Initial(_) => true,
-            Long { .. } => true,
-            Retry { .. } => false,
-            Short { .. } => false,
-            VersionNegotiate { .. } => false,
-        }
-    }
-
     pub(crate) fn dst_cid(&self) -> ConnectionId {
         use Header::*;
         match *self {

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -934,12 +934,12 @@ impl SpaceId {
 
     /// Returns the next higher packet space.
     ///
-    /// Keeps returning [`SpaceId::Data`] as the highest space.
-    pub(crate) fn next(&self) -> Self {
+    /// Returns `None` if at  [`SpaceId::Data`].
+    pub fn next(&self) -> Option<Self> {
         match self {
-            Self::Initial => Self::Handshake,
-            Self::Handshake => Self::Data,
-            Self::Data => Self::Data,
+            Self::Initial => Some(Self::Handshake),
+            Self::Handshake => Some(Self::Data),
+            Self::Data => None,
         }
     }
 }

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -453,6 +453,20 @@ impl Header {
         )
     }
 
+    /// Is this packet allowed to be coalesced with others?
+    ///
+    /// Ref <https://www.rfc-editor.org/rfc/rfc9000.html#name-coalescing-packets>
+    pub(crate) fn can_coalesce(&self) -> bool {
+        use Header::*;
+        match *self {
+            Initial(_) => true,
+            Long { .. } => true,
+            Retry { .. } => false,
+            Short { .. } => false,
+            VersionNegotiate { .. } => false,
+        }
+    }
+
     pub(crate) fn dst_cid(&self) -> ConnectionId {
         use Header::*;
         match *self {


### PR DESCRIPTION
Starts to split up `poll_transmit` into per_path and per_space parts.