### PR TITLE
ci: Run docs preview, as long as it's a run in the `n0-computer/quinn` repo

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ jobs:
     permissions: write-all
     timeout-minutes: 30
     name: Docs preview
-    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' ) && github.event.pull_request.head.repo.name == "n0-computer/quinn" }}
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: "sccache"


### PR DESCRIPTION
## Description

We used to check for `repo.fork`. On github, this repo is marked as a fork from `quinn-rs/quinn`, so we'd always skip the docs run.

The reason we had that check is so that the docs preview run wouldn't be generated when people wanted to contribute to iroh from a fork, as that would fail with permission errors.

This changes the check to look for `repo.name == "n0-computer/quinn"`, which should be the value [according to github documentation](https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28).

## Notes & open questions

We need to remember to change this value when we rename the repo, but I can't pull in the repo name from the environment. I'm also not sure if `.startsWith` is in scope in whatever language I'm writing this in actually.