### PR TITLE
feat: publicly export `UnorderedRecvStream`

### DIFF
--- a/quinn/src/lib.rs
+++ b/quinn/src/lib.rs
@@ -82,7 +82,9 @@ pub use crate::connection::{
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};
 pub use crate::path::{OpenPath, Path};
-pub use crate::recv_stream::{ReadError, ReadExactError, ReadToEndError, RecvStream, ResetError};
+pub use crate::recv_stream::{
+    ReadError, ReadExactError, ReadToEndError, RecvStream, ResetError, UnorderedRecvStream,
+};
 #[cfg(feature = "runtime-smol")]
 pub use crate::runtime::SmolRuntime;
 #[cfg(feature = "runtime-tokio")]


### PR DESCRIPTION
## Description

blocking https://github.com/n0-computer/iroh/pull/3757

Allows us to re-export `UnorderedRecvStream` from `iroh`