### PR TITLE
fix(proto): Send the close frame on the available path

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1081,7 +1081,7 @@ impl Connection {
                     !can_send.is_empty()
                 };
                 let needs_loss_probe = self.spaces[space_id].for_path(path_id).loss_probes > 0;
-                path_should_send || needs_loss_probe || can_send.close
+                path_should_send || needs_loss_probe
             };
 
             if !path_should_send && space_id < SpaceId::Data {


### PR DESCRIPTION
## Description

Without this change, it's possible that we send the close frame on a broken path only, if the broken path happens to have a path ID lower than the available path.

## Notes & open questions

Setting `path_should_send` to true if `can_send.close` would make sense, if we sent a close on every path, but we don't, we stop sending after we've sent the close on one path.

I think it's possible to fix this in either direction, but IMO we should send the close on the path we usually use for application data in general.