### PR TITLE
fix: make WeakConnectionHandle more lightweight

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -306,7 +306,7 @@ pub struct Connection(ConnectionRef);
 impl Connection {
     /// Returns a weak reference to the inner connection struct.
     pub fn weak_handle(&self) -> WeakConnectionHandle {
-        WeakConnectionHandle(Arc::downgrade(&self.0.0))
+        WeakConnectionHandle(Arc::downgrade(&Arc::new(self.0.0.clone())))
     }
 
     /// Initiate a new outgoing unidirectional stream.
@@ -1247,7 +1247,7 @@ pub(crate) struct ConnectionInner {
 /// This contains a weak reference to the connection so will not itself keep the connection
 /// alive.
 #[derive(Debug, Clone)]
-pub struct WeakConnectionHandle(Weak<ConnectionInner>);
+pub struct WeakConnectionHandle(Weak<Arc<ConnectionInner>>);
 
 impl WeakConnectionHandle {
     /// Returns `true` if the [`Connection`] associated with this handle is still alive.
@@ -1259,7 +1259,7 @@ impl WeakConnectionHandle {
     pub fn upgrade(&self) -> Option<Connection> {
         self.0
             .upgrade()
-            .map(|inner| Connection(ConnectionRef::from_arc(inner)))
+            .map(|inner| Connection(ConnectionRef::from_arc((*inner).clone())))
     }
 }
 


### PR DESCRIPTION
## Description

Prevent WeakConnectionHandle from keeping the allocation for a ConnectionInner alive.

ConnectionInner is quite large, 6048 bytes when I measured it. Arc<ConnectionInner> is just an 8 byte pointer. So before the weak handle would keep a large allocation alive. Now it just keeps a tiny allocation alive, consisting of a pointer and 2 refcounts, so 24 bytes on 64 bit machines.

The downside of this approach is that it does a tiny allocation in fn weak_handle. The alternative would be to do the double arc inside Connection, which would make every connection access a double dereference, but prevent this allocation.

I would assume that tiny allocations are pretty fast though. But just in case we want to do the other variant, here it is: https://github.com/n0-computer/quinn/pull/277

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->