### PR TITLE
release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-executor",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn-proto"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-quinn-udp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "cfg_aliases",
  "criterion",
@@ -1532,7 +1532,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tracing",
- "windows-sys 0.61.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/book/Cargo.toml
+++ b/docs/book/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 bytes = { workspace = true }
-quinn = { version = "0.14", path = "../../quinn", package = "iroh-quinn" }
+quinn = { version = "0.15", path = "../../quinn", package = "iroh-quinn" }
 rcgen.workspace = true
 rustls.workspace = true

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-quinn-proto"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn-udp/Cargo.toml
+++ b/quinn-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-quinn-udp"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/quinn/Cargo.toml
+++ b/quinn/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-quinn"
-version = "0.14.0"
+version = "0.15.0"
 license.workspace = true
 repository.workspace = true
 description = "Versatile QUIC transport protocol implementation"
@@ -59,13 +59,13 @@ bytes = { workspace = true }
 futures-io = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 pin-project-lite = { workspace = true }
-proto = { package = "iroh-quinn-proto", path = "../quinn-proto", version = "0.13.0", default-features = false }
+proto = { package = "iroh-quinn-proto", path = "../quinn-proto", version = "0.14.0", default-features = false }
 rustls = { workspace = true, optional = true }
 smol = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing =  { workspace = true }
 tokio = { workspace = true }
-udp = { package = "iroh-quinn-udp", path = "../quinn-udp", version = "0.6", default-features = false, features = ["tracing"] }
+udp = { package = "iroh-quinn-udp", path = "../quinn-udp", version = "0.7", default-features = false, features = ["tracing"] }
 
 # Fix minimal dependencies for indirect deps
 async-global-executor = { workspace = true, optional = true }


### PR DESCRIPTION
`cargo release` command successfully published the crates, but the commit created by `cargo release` to update the version numbers was rejected, because I don't have permissions to push to the `main` branch directly.

These are the appropriate changes to ensure the version numbers in our code align with the released crates.