### PR TITLE
fix(proto): Store pending PATH_CID_BLOCKED frames in a BTreeSet

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -609,7 +609,7 @@ impl Connection {
             self.spaces[SpaceId::Data]
                 .pending
                 .path_cids_blocked
-                .push(path_id);
+                .insert(path_id);
             return Err(PathError::RemoteCidsExhausted);
         }
 
@@ -1056,7 +1056,7 @@ impl Connection {
                     self.spaces[SpaceId::Data]
                         .pending
                         .path_cids_blocked
-                        .push(path_id);
+                        .insert(path_id);
                 } else {
                     trace!(%path_id, "remote CIDs retired for abandoned path");
                 }
@@ -5522,7 +5522,7 @@ impl Connection {
         // PATH_CIDS_BLOCKED
         while space_id == SpaceId::Data && frame::PathCidsBlocked::SIZE_BOUND <= buf.remaining_mut()
         {
-            let Some(path_id) = space.pending.path_cids_blocked.pop() else {
+            let Some(path_id) = space.pending.path_cids_blocked.pop_first() else {
                 break;
             };
             let next_seq = match self.rem_cids.get(&path_id) {
@@ -5538,7 +5538,7 @@ impl Connection {
             sent.retransmits
                 .get_or_create()
                 .path_cids_blocked
-                .push(path_id);
+                .insert(path_id);
             trace!(%path_id, next_seq, "PATH_CIDS_BLOCKED");
             self.stats.frame_tx.path_cids_blocked += 1;
         }

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -534,7 +534,7 @@ pub struct Retransmits {
     /// If a [`frame::PathStatusAvailable`] and [`frame::PathStatusBackup`] need to be sent for a path
     pub(super) path_status: BTreeSet<PathId>,
     /// If a PATH_CIDS_BLOCKED frame needs to be sent for a path
-    pub(super) path_cids_blocked: Vec<PathId>,
+    pub(super) path_cids_blocked: BTreeSet<PathId>,
 
     // Nat traversal data
     /// Addresses to report in `ADD_ADDRESS` frames


### PR DESCRIPTION
## Description

When adding items to this we generally don't want to worry about
checking if the value is already pending. Currently we keep adding to
the Vec with the same value in some situations, resulting in sending
the frame many times for the same path.

This avoids duplicate entries.

## Breaking Changes

n/a

## Notes & open questions

Part of #305 