### PR TITLE
cohre: Disable fuzz code unless fuzzing config is set

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,9 @@ features = ["arbitrary"]
 path = "../quinn-proto"
 package = "iroh-quinn-proto"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(fuzzing)"] }
+
 [[bin]]
 name = "streams"
 path = "fuzz_targets/streams.rs"

--- a/fuzz/fuzz_targets/packet.rs
+++ b/fuzz/fuzz_targets/packet.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![cfg(fuzzing)]
 
 extern crate proto;
 

--- a/fuzz/fuzz_targets/streamid.rs
+++ b/fuzz/fuzz_targets/streamid.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![cfg(fuzzing)]
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 

--- a/fuzz/fuzz_targets/streams.rs
+++ b/fuzz/fuzz_targets/streams.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![cfg(fuzzing)]
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;


### PR DESCRIPTION
## Description

With this we no longer get compile errors in vscode because the fuzzing code uses fns that are themselves gated with cfg(fuzzing).

We have to tell rust about the feature in Cargo.toml to avoid warnings.

## Breaking Changes

None

## Notes & open questions

Q: we could also expose the fuzzing helper fns under a feature flag, but then these would become part of the public API and we would have to document that this ff is not considered stable. I don't really care what we do, just want the errors gone.