### PR TITLE
refactor(proto): store ArrayRangeSet in Acks

### DIFF
--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -971,9 +971,7 @@ impl Frame {
             Self::Ack(f) => QuicFrame::Ack {
                 ack_delay: Some(f.delay as f32),
                 acked_ranges: Some(AckedRanges::Double(
-                    f.iter()
-                        .map(|range| (*range.start(), *range.end()))
-                        .collect(),
+                    f.iter().map(|range| (range.start, range.end)).collect(),
                 )),
                 ect1: f.ecn.as_ref().map(|e| e.ect1),
                 ect0: f.ecn.as_ref().map(|e| e.ect0),
@@ -1025,8 +1023,9 @@ impl Frame {
                 ce: ack.ecn.as_ref().map(|e| e.ce),
                 raw: None,
                 acked_ranges: Some(AckedRanges::Double(
-                    ack.into_iter()
-                        .map(|range| (*range.start(), *range.end()))
+                    ack.ranges
+                        .iter()
+                        .map(|range| (range.start, range.end))
                         .collect(),
                 )),
             },

--- a/quinn-proto/src/connection/spaces.rs
+++ b/quinn-proto/src/connection/spaces.rs
@@ -351,10 +351,7 @@ impl PacketNumberSpace {
     }
 
     /// Checks whether a skipped packet number was ACKed.
-    pub(super) fn check_ack(
-        &self,
-        range: std::ops::RangeInclusive<u64>,
-    ) -> Result<(), TransportError> {
+    pub(super) fn check_ack(&self, range: std::ops::Range<u64>) -> Result<(), TransportError> {
         if let Some(ref filter) = self.pn_filter {
             if filter
                 .prev_skipped_packet_number

--- a/quinn-proto/src/range_set/array_range_set.rs
+++ b/quinn-proto/src/range_set/array_range_set.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Write};
 use std::ops::Range;
 
 use tinyvec::TinyVec;
@@ -16,8 +17,24 @@ use tinyvec::TinyVec;
 /// `ArrayRangeSet` is especially useful for tracking ACK ranges where the amount
 /// of ranges is usually very low (since ACK numbers are in consecutive fashion
 /// unless reordering or packet loss occur).
-#[derive(Debug, Default)]
+#[derive(Default, PartialEq, Eq)]
 pub(crate) struct ArrayRangeSet(TinyVec<[Range<u64>; ARRAY_RANGE_SET_INLINE_CAPACITY]>);
+
+impl fmt::Debug for ArrayRangeSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_char('[')?;
+        let mut first = true;
+        for range in self.0.iter() {
+            if !first {
+                f.write_char(',')?;
+            }
+            write!(f, "{range:?}")?;
+            first = false;
+        }
+        f.write_char(']')?;
+        Ok(())
+    }
+}
 
 /// The capacity of elements directly stored in [`ArrayRangeSet`]
 ///


### PR DESCRIPTION
## Description

Before they were decoded lazily, but that work as done many times over and over again, when they where ever logged in debug mode. This decodes these immediately and stores them in an `ArrayRangeSet`

Also moves the debug impl to the `ArrayRangeSet` making that print more easily

This also is more efficient at the end, as we do not read these ranges more than once per Ack