### PR TITLE
chore: unblock CI

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -19,6 +19,7 @@ jobs:
       rust-version: beta
 
   notify:
+    timeout-minutes: 45
     needs: tests
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   clean_docs_branch:
+    timeout-minutes: 45
     permissions:
       issues: write
       contents: write

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -21,6 +21,7 @@ jobs:
   test-freebsd:
     # see https://github.com/actions/runner/issues/385
     # use https://github.com/vmactions/freebsd-vm for now
+    timeout-minutes: 45
     name: test on freebsd
     runs-on: ubuntu-latest
     steps:
@@ -44,6 +45,7 @@ jobs:
             cargo build --locked --all-targets && cargo test --locked && cargo test --locked -- --ignored stress && cargo test --locked -p iroh-quinn-udp --benches
 
   test-solaris:
+    timeout-minutes: 45
     name: test on solaris
     runs-on: ubuntu-latest
     steps:
@@ -69,6 +71,7 @@ jobs:
             cargo build --locked --all-targets && cargo test --locked && cargo test --locked -p iroh-quinn-udp --benches
 
   test-illumos:
+    timeout-minutes: 45
     name: test on illumos
     runs-on: ubuntu-latest
     steps:
@@ -92,12 +95,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        include:
+          - os: linux
+            runs-on: [self-hosted, linux, X64]
+          - os: macos
+            runs-on: [self-hosted, macOS, ARM64]
+    runs-on: ${{ matrix.runs-on }}
     env:
       RUSTFLAGS: -Dwarnings
       # skip FIPS features outside of Linux
-      SKIP_FEATURES: ${{ matrix.os != 'ubuntu-latest' && 'rustls-aws-lc-rs-fips,aws-lc-rs-fips,aws-lc-fips-sys,__rustls-post-quantum-test' || '' }}
+      SKIP_FEATURES: ${{ matrix.os != 'linux' && 'rustls-aws-lc-rs-fips,aws-lc-rs-fips,aws-lc-fips-sys,__rustls-post-quantum-test' || '' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -106,6 +113,7 @@ jobs:
       - run: cargo hack check --feature-powerset --depth 3 --optional-deps --no-dev-deps --ignore-private --skip "${{env.SKIP_FEATURES}}"
 
   notify:
+    timeout-minutes: 45
     needs: [test-freebsd, test-solaris, test-illumos, features]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,10 +48,10 @@ jobs:
             release-os: darwin
             release-arch: aarch64
             runner: [self-hosted, macOS, ARM64]
-    env:
+    # env:
       # Using self-hosted runners so use local cache for sccache and
       # not SCCACHE_GHA_ENABLED.
-      RUSTC_WRAPPER: "sccache"
+      # RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -68,8 +68,9 @@ jobs:
         with:
           tool: nextest@${{ env.NEXTEST_VERSION }}
 
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+      # bugging out on macos cause it thinks its x86_64
+      # - name: Install sccache
+      #   uses: mozilla-actions/sccache-action@v0.0.9
 
       # Go is required for FIPS builds (aws-lc-rs-fips feature)
       - name: Setup Go
@@ -305,6 +306,7 @@ jobs:
           compression-level: 0
 
   minimal-crates:
+    timeout-minutes: 45
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

- Introduce job timeouts for most as it had it get stuck in the past and hog a machine
- Drop sccache on nix tests for now as it incorrectly labels mac runners as x86_64
- Moved feature powerset tests to self hosted runners, should work out of the box, will see tomorrow.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->