### PR TITLE
feat(proto): Use `UdpStats` in `PathStats` and add receive stats

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1332,6 +1332,11 @@ impl Connection {
                     builder.write_frame_with_log_msg(frame, stats, Some("(off-path)"));
                     builder.finish_and_track(now, self, path_id, PadDatagram::ToMinMtu);
                     self.stats.udp_tx.on_sent(1, transmit.len());
+                    self.path_stats
+                        .entry(path_id)
+                        .or_default()
+                        .udp_tx
+                        .on_sent(1, transmit.len());
                     return Some(Transmit {
                         destination: network_path.remote,
                         size: transmit.len(),
@@ -1539,6 +1544,11 @@ impl Connection {
         self.stats
             .udp_tx
             .on_sent(transmit.num_datagrams() as u64, transmit.len());
+        self.path_stats
+            .entry(path_id)
+            .or_default()
+            .udp_tx
+            .on_sent(transmit.num_datagrams() as u64, transmit.len());
 
         Some(Transmit {
             destination: network_path.remote,
@@ -1691,6 +1701,11 @@ impl Connection {
 
         builder.finish(self, now);
         self.stats.udp_tx.on_sent(1, buf.len());
+        self.path_stats
+            .entry(path_id)
+            .or_default()
+            .udp_tx
+            .on_sent(1, buf.len());
 
         Some(Transmit {
             destination: network_path.remote,
@@ -1766,6 +1781,9 @@ impl Connection {
 
                 self.stats.udp_rx.datagrams += 1;
                 self.stats.udp_rx.bytes += first_decode.len() as u64;
+                let rx = &mut self.path_stats.entry(path_id).or_default().udp_rx;
+                rx.datagrams += 1;
+                rx.bytes += first_decode.len() as u64;
                 let data_len = first_decode.len();
 
                 self.handle_decode(now, network_path, path_id, ecn, first_decode);
@@ -1779,6 +1797,7 @@ impl Connection {
 
                 if let Some(data) = remaining {
                     self.stats.udp_rx.bytes += data.len() as u64;
+                    self.path_stats.entry(path_id).or_default().udp_rx.bytes += data.len() as u64;
                     self.handle_coalesced(now, network_path, path_id, ecn, data);
                 }
 
@@ -3568,6 +3587,8 @@ impl Connection {
         mut qlog: QlogRecvPacket,
     ) {
         self.stats.udp_rx.ios += 1;
+        self.path_stats.entry(path_id).or_default().udp_rx.ios += 1;
+
         if let Some(ref packet) = packet {
             trace!(
                 "got {:?} packet ({} bytes) from {} using id {}",

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -314,7 +314,6 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             packet,
             conn.spaces[space_id].for_path(path_id),
         );
-        conn.path_stats.entry(path_id).or_default().sent_packets += 1;
         conn.reset_keep_alive(path_id, now);
         if size != 0 {
             if ack_eliciting {

--- a/quinn-proto/src/connection/stats.rs
+++ b/quinn-proto/src/connection/stats.rs
@@ -6,7 +6,7 @@ use crate::FrameType;
 /// Statistics about UDP datagrams transmitted or received on a connection
 ///
 /// All QUIC packets are carried by UDP datagrams. Hence, these statistics cover all traffic on a connection.
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct UdpStats {
     /// The amount of UDP datagrams observed
@@ -167,6 +167,10 @@ impl std::fmt::Debug for FrameStats {
 pub struct PathStats {
     /// Current best estimate of this connection's latency (round-trip-time)
     pub rtt: Duration,
+    /// Statistics about datagrams and bytes sent on this path
+    pub udp_tx: UdpStats,
+    /// Statistics about datagrams and bytes received on this path
+    pub udp_rx: UdpStats,
     /// Current congestion window of the connection
     pub cwnd: u64,
     /// Congestion events on the connection
@@ -175,9 +179,7 @@ pub struct PathStats {
     pub lost_packets: u64,
     /// The amount of bytes lost on this path
     pub lost_bytes: u64,
-    /// The amount of packets sent on this path
-    pub sent_packets: u64,
-    /// The amount of PLPMTUD probe packets sent on this path (also counted by `sent_packets`)
+    /// The amount of PLPMTUD probe packets sent on this path (also counted by `udp_tx.datagrams`)
     pub sent_plpmtud_probes: u64,
     /// The amount of PLPMTUD probe packets lost on this path (ignored by `lost_packets` and
     /// `lost_bytes`)


### PR DESCRIPTION
## Description

I noticed we only have `PathStats::sent_packets`, but not sent bytes or numbers of received datagrams, bytes, etc.

We have all of this info in `ConnectionStats` via `UdpStats`.
This updates `PathStats` to use `UdpStats` for stats on sending, replacing `sent_packets`.
This also adds `PathStats::udp_rx: UdpStats` to add info on received bytes.

## Breaking Changes

- Removed `iroh_quinn::PathStats::sent_packets`
- Added `iroh_quinn::PathStats::udp_tx: UdpStats` (mirroring `ConnectionStats::udp_tx`)
- Added `iroh_quinn::PathStats::udp_rx: UpdStats` (mirroring `ConnectionStats::udp_rx`)