### PR TITLE
fix(proto): properly encode can_coalesce during packet building

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1237,7 +1237,7 @@ impl Connection {
                 self,
             )?;
             last_packet_number = Some(builder.exact_number);
-            coalesce = coalesce && !builder.short_header;
+            coalesce = coalesce && builder.can_coalesce;
 
             if space_id == SpaceId::Initial && (self.side.is_client() || can_send.other) {
                 // https://www.rfc-editor.org/rfc/rfc9000.html#section-14.1

--- a/quinn-proto/src/connection/packet_builder.rs
+++ b/quinn-proto/src/connection/packet_builder.rs
@@ -26,7 +26,8 @@ pub(super) struct PacketBuilder<'a, 'b> {
     pub(super) partial_encode: PartialEncode,
     pub(super) ack_eliciting: bool,
     pub(super) exact_number: u64,
-    pub(super) short_header: bool,
+    /// Is this packet allowed to be coalesced?
+    pub(super) can_coalesce: bool,
     /// Smallest absolute position in the associated buffer that must be occupied by this packet's
     /// frames
     pub(super) min_size: usize,
@@ -182,7 +183,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             path: path_id,
             partial_encode,
             exact_number,
-            short_header: header.is_short(),
+            can_coalesce: header.can_coalesce(),
             min_size,
             tag_len,
             ack_eliciting,
@@ -201,7 +202,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             partial_encode: PartialEncode::no_header(),
             ack_eliciting: true,
             exact_number: 0,
-            short_header: false,
+            can_coalesce: true,
             min_size: 0,
             tag_len: 0,
             _span: trace_span!("test").entered(),
@@ -375,7 +376,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         );
 
         let packet_len = self.buf.len() - encode_start;
-        trace!(size = %packet_len, short_header = %self.short_header, "wrote packet");
+        trace!(size = %packet_len, "wrote packet");
         self.qlog.finalize(packet_len);
         conn.qlog.emit_packet_sent(self.qlog, now);
         (packet_len, pad, self.sent_frames)

--- a/quinn-proto/src/packet.rs
+++ b/quinn-proto/src/packet.rs
@@ -464,6 +464,20 @@ impl Header {
         }
     }
 
+    /// Is this packet allowed to be coalesced with others?
+    ///
+    /// Ref <https://www.rfc-editor.org/rfc/rfc9000.html#name-coalescing-packets>
+    pub(crate) fn can_coalesce(&self) -> bool {
+        use Header::*;
+        match *self {
+            Initial(_) => true,
+            Long { .. } => true,
+            Retry { .. } => false,
+            Short { .. } => false,
+            VersionNegotiate { .. } => false,
+        }
+    }
+
     /// Whether the payload of this packet contains QUIC frames
     pub(crate) fn has_frames(&self) -> bool {
         use Header::*;


### PR DESCRIPTION
The short header check is not sufficient according to the RFC