### PR TITLE
fix(proto): Don't close paths from previous HP round we're still interested in

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -6290,6 +6290,7 @@ impl Connection {
                     *probe_port == port && probe_ip.to_canonical() == ip.to_canonical()
                 })
                 && !path.validated
+                && !self.abandoned_paths.contains(&path_id)
             {
                 trace!(%path_id, "closing path from previous round");
                 let _ = self.close_path(


### PR DESCRIPTION
## Description

We introduced some regressions in iroh main unit tests because we're getting stuck in a loop opening paths and closing them before they finish validating.

This adds a check to make sure we don't close paths from the last holepunching round that we're still interested in.

Fixes #337 

Also:
- Adds logs for some interesting events like when a path is abandoned.
- Changed 4-tuple logs from using src/dst to local/remote as discussed in https://github.com/n0-computer/quinn/pull/331/files#r2699312131
- Print a warning if closing an idle path fails updated the error code for that. This should now match the behavior on other paths.

## Notes & open questions

The `to_canonical` calls are somewhat annoying.
I wish we would clean up all of the IP addr canonicalization a bit. But I'd prefer to fix this bug first, then clean up? [Filed an issue](https://github.com/n0-computer/quinn/issues/342).

---

We should probably clear some timers in `close_path`, because otherwise we might trigger path timers that shouldn't trigger anymore. For some reason if I clear the `PathOpen` timer in `close_path` some tests fail?