### PR TITLE
tests: Skip proptests and do not fail fast in the default nextest profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,24 @@
+# Be aware that all profils inherit from the default profile unless
+# explicitly set to a different profile.
+
 [profile.default]
 slow-timeout = { period = "2s", terminate-after = 3 }
+fail-fast = false
+
+# Do not run proptests by default. Use --ignore-default-filter to run these anyway.
+# To give proptests a proper spin run:
+#    cargo nextest run --ignore-default-filter -E 'test(~proptest::)'
+# Or use the proptests profile below which has a longer slow-timeout:
+#    PROPTEST_CASES=10000 cargo nextest run -P proptests
+default-filter = 'not test(~proptest::)'
+
+[profile.proptests]
+# Select this profile with -P proptests
+# To give proptests a proper spin, run with PROPTEST_CASES=10000
+slow-timeout = '300s'
+default-filter = 'test(~proptest::)'
 
 [profile.ci]
 slow-timeout = { period = "5s", terminate-after = 3 }
 fail-fast = false
+default-filter = 'all()'


### PR DESCRIPTION
## Description

We run with --profile ci on CI, so this still runs the proptests on CI
every time. Also includes clear instructions on how to run the
proptests.

Additionally uses --no-fail-fast by default.

## Breaking Changes

n/a

## Notes & open questions

This is somewhat opinionated. But the default slow-tests is already so
and hasn't yet been a stumbling block for a while now.