### PR TITLE
fix: Do not send off-path data when closing

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -1091,8 +1091,8 @@ impl Connection {
         let mut congestion_blocked = false;
 
         for &path_id in &path_ids {
-            if let Some(transmit) = self.poll_transmit_off_path(now, buf, path_id)
-                && !connection_close_pending
+            if !connection_close_pending
+                && let Some(transmit) = self.poll_transmit_off_path(now, buf, path_id)
             {
                 return Some(transmit);
             }


### PR DESCRIPTION
## Description

When we are closing we're only supposed to send packets containing
CONNECTION_CLOSE and (PATH_)ACK frames. There is no need to continue
sending any off-path data.

We do have the option of sending a CONNECTION_CLOSE to the new
remote if we get an involuntary migration during close. But we'd
have to make sure not to exceed the anti-amplification limit
since we can no longer validate the path.

We are also allowed to simply discard packets from a migrated
peer during the closing state. Which is what we do.

## Breaking Changes

n/a

## Notes & open questions

Closes #357 

Note that the base is #338. I won't merge before that is merged so
it shows up as a separate commit because this was a pre-existing
bug.