### PR TITLE
chore: add CI to ensure docs-rs publishing will work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,17 +225,20 @@ jobs:
     env:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
-      RUSTDOCFLAGS: --cfg docsrs
+      RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2025-10-09
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Docs
-        run: cargo doc --workspace --all-features --no-deps --document-private-items
+      - name: quinn docs
+        run: cargo docs-rs -p iroh-quinn
+      - name: quinn-proto docs
+        run: cargo docs-rs -p iroh-quinn-proto
+      - name: quinn-udp docs
+        run: cargo docs-rs -p iroh-quinn-udp
 
   clippy_check:
     timeout-minutes: 30

--- a/quinn-proto/Cargo.toml
+++ b/quinn-proto/Cargo.toml
@@ -93,4 +93,4 @@ workspace = true
 
 [package.metadata.docs.rs]
 # all non-default features except fips (cannot build on docs.rs environment)
-features = ["rustls-aws-lc-rs", "rustls-ring", "platform-verifier", "log", "rustls-log"]
+features = ["aws-lc-rs", "rustls-aws-lc-rs", "rustls-ring", "platform-verifier", "rustls-log", "qlog", "bench"]

--- a/quinn-proto/src/endpoint.rs
+++ b/quinn-proto/src/endpoint.rs
@@ -1232,8 +1232,6 @@ pub struct Incoming {
 
 impl Incoming {
     /// The local IP address which was used when the peer established the connection
-    ///
-    /// This has the same behavior as [`Connection::local_ip`].
     pub fn local_ip(&self) -> Option<IpAddr> {
         self.network_path.local_ip
     }


### PR DESCRIPTION
## Description

Also, removes "log" from list of features for `iroh-quinn-proto` to run with `docs-rs`, since it is not a feature `iroh-quinn-proto` has.