### PR TITLE
fix: emit correct frames in qlog for NewConnectionId/RetireConnectionId

### DIFF
--- a/quinn-proto/src/connection/qlog.rs
+++ b/quinn-proto/src/connection/qlog.rs
@@ -727,13 +727,24 @@ impl ToQlog for frame::MaxStreams {
 #[cfg(feature = "qlog")]
 impl ToQlog for frame::NewConnectionId {
     fn to_qlog(&self) -> QuicFrame {
-        QuicFrame::NewConnectionId {
-            sequence_number: self.sequence,
-            retire_prior_to: self.retire_prior_to,
-            connection_id_length: Some(self.id.len() as u8),
-            connection_id: self.id.to_string(),
-            stateless_reset_token: Some(self.reset_token.to_string()),
-            raw: None,
+        match self.path_id {
+            None => QuicFrame::NewConnectionId {
+                sequence_number: self.sequence,
+                retire_prior_to: self.retire_prior_to,
+                connection_id_length: Some(self.id.len() as u8),
+                connection_id: self.id.to_string(),
+                stateless_reset_token: Some(self.reset_token.to_string()),
+                raw: None,
+            },
+            Some(path_id) => QuicFrame::PathNewConnectionId {
+                path_id: path_id.0 as u64,
+                sequence_number: self.sequence,
+                retire_prior_to: self.retire_prior_to,
+                connection_id_length: Some(self.id.len() as u8),
+                connection_id: self.id.to_string(),
+                stateless_reset_token: Some(self.reset_token.to_string()),
+                raw: None,
+            },
         }
     }
 }
@@ -923,9 +934,16 @@ impl ToQlog for frame::StopSending {
 #[cfg(feature = "qlog")]
 impl ToQlog for frame::RetireConnectionId {
     fn to_qlog(&self) -> QuicFrame {
-        QuicFrame::RetireConnectionId {
-            sequence_number: self.sequence,
-            raw: None,
+        match self.path_id {
+            None => QuicFrame::RetireConnectionId {
+                sequence_number: self.sequence,
+                raw: None,
+            },
+            Some(path_id) => QuicFrame::PathRetireConnectionId {
+                path_id: path_id.0 as u64,
+                sequence_number: self.sequence,
+                raw: None,
+            },
         }
     }
 }


### PR DESCRIPTION
## Description

We never emit the PathNewConnectionId and PathRetireConnectionId variants. This was an oversight (we use the same Frame variant for both the regular and multipath variants and differ the frame type if the path is set), this PR fixes it.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->