### PR TITLE
fix(proto): Avoid panicking in `Connection::pto_max_path`

### DIFF
--- a/quinn-proto/src/connection/mod.rs
+++ b/quinn-proto/src/connection/mod.rs
@@ -3137,8 +3137,8 @@ impl Connection {
     /// See [`Connection::pto`]
     fn max_pto_all_paths(&self, space: SpaceId) -> Duration {
         self.paths
-            .iter()
-            .map(|(path_id, _)| self.pto(space, *path_id))
+            .keys()
+            .map(|path_id| self.pto(space, *path_id))
             .max()
             .expect("there should be at least one path")
     }


### PR DESCRIPTION
## Description

We can't filter out unused branches in `is_closing`, otherwise we might get into a state where the we don't have any paths to consider for PTO, when the only path remaining is one that we didn't send/receive on yet.

Also: Rename `Connection::pto_max_path` to `Connection::max_pto_all_paths`.

This fixes the regression test introduced in https://github.com/n0-computer/quinn/pull/359

We need another strategy to solve slow connection closing: https://github.com/n0-computer/iroh/issues/3875 (this issue happens without this PR)
