### PR TITLE
chore: disable solaris tests in daily CI as they hang

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -44,13 +44,14 @@ jobs:
             freebsd-version
             cargo build --locked --all-targets && cargo test --locked && cargo test --locked -- --ignored stress && cargo test --locked -p iroh-quinn-udp --benches
 
-  test-solaris:
+  build-solaris:
+    # Tests disabled - too many hang in poll() on Solaris
     timeout-minutes: 45
-    name: test on solaris
+    name: build on solaris
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: test on Solaris
+      - name: build on Solaris
         uses: vmactions/solaris-vm@v1
         with:
           release: "11.4-gcc"
@@ -63,12 +64,11 @@ jobs:
             rustc --version
             echo "~~~~ Solaris-version ~~~~"
             uname -a
-          # Unlike others, don't un-ignore stress tests, because they hang on Solaris
           run: |
             export PATH=$HOME/.rust_solaris/bin:$PATH
             # Workaround for https://github.com/quinn-rs/quinn/issues/2218
             export CARGO_HTTP_MULTIPLEXING=false
-            cargo build --locked --all-targets && cargo test --locked && cargo test --locked -p iroh-quinn-udp --benches
+            cargo build --locked --all-targets
 
   test-illumos:
     timeout-minutes: 45
@@ -114,7 +114,7 @@ jobs:
 
   notify:
     timeout-minutes: 45
-    needs: [test-freebsd, test-solaris, test-illumos, features]
+    needs: [test-freebsd, build-solaris, test-illumos, features]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -123,7 +123,7 @@ jobs:
           printf '${{ toJSON(needs) }}\n'
 
           freebsd_result=$(echo '${{ toJSON(needs) }}' | jq -r '.["test-freebsd"].result')
-          solaris_result=$(echo '${{ toJSON(needs) }}' | jq -r '.["test-solaris"].result')
+          solaris_result=$(echo '${{ toJSON(needs) }}' | jq -r '.["build-solaris"].result')
           illumos_result=$(echo '${{ toJSON(needs) }}' | jq -r '.["test-illumos"].result')
           features_result=$(echo '${{ toJSON(needs) }}' | jq -r '.features.result')
 
@@ -137,7 +137,7 @@ jobs:
           # Build failure details
           details=""
           [ "$freebsd_result" = "failure" ] && details="${details}- FreeBSD tests failed\n"
-          [ "$solaris_result" = "failure" ] && details="${details}- Solaris tests failed\n"
+          [ "$solaris_result" = "failure" ] && details="${details}- Solaris build failed\n"
           [ "$illumos_result" = "failure" ] && details="${details}- Illumos tests failed\n"
           [ "$features_result" = "failure" ] && details="${details}- Feature powerset check failed\n"
 


### PR DESCRIPTION
## Description

Solaris hangs on many poll invocations and renders most tests we write useless and continuously needs to be marked as ignored for solaris. We're reducing this to just a build check and skipping tests until we work out a better strategy for this.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->