### PR TITLE
chore: fix advisory RUSTSEC 2026 0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,9 +461,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"


### PR DESCRIPTION

## Description

updates bytes to address advisory RUSTSEC-2026-0007

## Breaking Changes

n/a

## Notes & open questions

n/a
