### PR TITLE
fix(ci): daily jobs deps

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -109,6 +109,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
+      - name: Setup Go (required for aws-lc-rs FIPS)
+        if: matrix.os == 'linux'
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
 
       - run: cargo hack check --feature-powerset --depth 3 --optional-deps --no-dev-deps --ignore-private --skip "${{env.SKIP_FEATURES}}"
 


### PR DESCRIPTION
## Description

Daily jobs were missing the go dependency installation and sometimes daily jobs trip up over it when they invoke a specific feature combo.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->