### PR TITLE
fix: open_path_ensure deadlock

### DIFF
--- a/quinn/src/connection.rs
+++ b/quinn/src/connection.rs
@@ -426,11 +426,11 @@ impl Connection {
                     Some(recv) => {
                         drop(state);
                         OpenPath::new(path_id, recv, self.0.clone())
-                    },
+                    }
                     None => {
                         drop(state);
                         OpenPath::ready(path_id, self.0.clone())
-                    },
+                    }
                 }
             }
             Ok((path_id, _)) => {


### PR DESCRIPTION
## Description

This fixes a deadlock in `quinn/quinn/src/connection.rs -> fn open_path_ensure`

I noticed during testing in iroh-lan that my tokio runtime would randomly freeze on heavy network degradation.
After a bunch of digging, I found a deadlock that gets triggered when I hammer one connection with about as many `open_path_ensure` calls as runtime workers and those calls land around the same time. I added two repro modes for it, one uses a `Barrier` to line up the calls and one does repeated “waves” of calls.

Tokio runtime freeze is diagnosed by running a spawned tokio task that writes current time as u64 ticker every second:

```rust
let tick = Arc::new(AtomicU64::new(now()));
let tick_watch = tick.clone();
tokio::spawn(async move {
    loop {
        tick.store(now(), Ordering::Relaxed);
        tokio::time::sleep(Duration::from_secs(1)).await;
    }
});
```

and a "watch dog" native thread (that will not stall with the tokio runtime) that checks every second when the tokio task last updated the ticker:

```rust
std::thread::spawn(move || {
    loop {
        std::thread::sleep(Duration::from_secs(2));
        let ago = now().saturating_sub(tick_watch.load(Ordering::Relaxed));
        eprintln!("[WATCHDOG] tokio_tick={}s_ago", ago);
        if ago > 8 {
            eprintln!(
                "\n[ONECALL REPRO] runtime stalled (mode={}) while driving open_path_ensure waves",
                mode.label(),
            );
            std::process::exit(99);
        }
    }
});
```

When you run the repro on branch `open_path_ensure-deadlock-demonstration` you will see the tokio_tick count up the seconds until it hits > 8 and with the added `drop(state);` fix (this PR) on the `open_path_ensure-deadlock-demonstration-fix` branch the error goes away.

*(please excuse the random namings, I have been iterating on this for a while, if needed I can clean up the naming and prints a bit, hope this is understandable)*

---

**Reproduced:**
[https://github.com/rustonbsd/quinn/tree/open_path_ensure-deadlock-demonstration](https://github.com/rustonbsd/quinn/tree/open_path_ensure-deadlock-demonstration)

I added a folder called [open_path_ensure_trigger](https://github.com/rustonbsd/quinn/tree/open_path_ensure-deadlock-demonstration/open_path_ensure_trigger)

```sh
# to reproduce run this:

git clone https://github.com/rustonbsd/quinn
cd quinn
git checkout open_path_ensure-deadlock-demonstration
cd open_path_ensure_trigger

make repro-waves
# or 
make repro-barrier
```

---

**Reproduced +fix:**
[https://github.com/rustonbsd/quinn/blob/open_path_ensure-deadlock-demonstration-fix/open_path_ensure_trigger](https://github.com/rustonbsd/quinn/blob/open_path_ensure-deadlock-demonstration-fix/open_path_ensure_trigger)

This is the same as **Reproduced** but with the `drop(state);` deadlock fix added in `quinn/quinn/src/connection.rs`

```sh
# to reproduce with fix run this:

git clone https://github.com/rustonbsd/quinn
cd quinn
git checkout open_path_ensure-deadlock-demonstration-fix
cd open_path_ensure_trigger

make repro-waves
# or 
make repro-barrier
```

## Breaking Changes

none

## Notes & open questions

My theory is that `open_path_ensure` can lock `state` and then reach another code path that tries to lock the same `state` mutex again before the first lock is released. 

First lock: [https://github.com/n0-computer/quinn/blob/4f8afee29ff86cd5f6c4fe5567ea182d5af6eef7/quinn/src/connection.rs#L386](https://github.com/n0-computer/quinn/blob/4f8afee29ff86cd5f6c4fe5567ea182d5af6eef7/quinn/src/connection.rs#L386) 

Second lock: [https://github.com/n0-computer/quinn/blob/4f8afee29ff86cd5f6c4fe5567ea182d5af6eef7/quinn/src/connection.rs#L426-L427](https://github.com/n0-computer/quinn/blob/4f8afee29ff86cd5f6c4fe5567ea182d5af6eef7/quinn/src/connection.rs#L426-L427)

It is late here so I will go offline but if you have any questions or trouble reproducing the behaviour, let me know either here or on discord and I will get back to you as soon as possible.