### PR TITLE
fix: CidQueue out of bounds panic

### DIFF
--- a/quinn-proto/src/cid_queue.rs
+++ b/quinn-proto/src/cid_queue.rs
@@ -496,4 +496,22 @@ mod tests {
         assert_eq!(q.active(), three.id);
         assert_eq!(q.next_reserved(), None);
     }
+
+    #[test]
+    fn reserve_many_next_clears_across_wraparound() {
+        let mut q = CidQueue::new(initial_cid());
+        for i in 1..CidQueue::LEN {
+            q.insert(cid(i as u64, 0)).unwrap();
+        }
+
+        for _ in 0..CidQueue::LEN - 2 {
+            assert!(q.next_reserved().is_some());
+        }
+
+        assert!(q.next().is_some());
+        q.insert(cid(CidQueue::LEN as u64, 0)).unwrap();
+        assert!(q.next_reserved().is_some());
+        q.insert(cid(CidQueue::LEN as u64 + 1, 0)).unwrap();
+        assert!(q.next().is_some());
+    }
 }


### PR DESCRIPTION
## Description

During testing of iroh-lan on my local network on two machines with artificial network degradation, I keep running into the following panic:

`thread 'tokio-runtime-worker' (4156734) panicked at /home/i3/.cargo/git/checkouts/quinn-ebe1807f230baad1/315f491/quinn-proto/src/cid_queue.rs:117:13:
index out of bounds: the len is 5 but the index is 5`

I am working on reproducing it without the requirement for two machines, but without a dedicated test that puts the `CidQueue` state into a specific scenario, it is hard to trigger, even with two docker instances.

I have not been able to reproduce the panic consistently with a realistic setup that doesn't involve two machines and I am still trying to understand what code path leads to this. It must be something in `quinn/quinn-proto/src/connection` -> `handle_network_change`, `process_payload` or how they interact when conditions are just right.

I am assuming that this

```rust
    pub(crate) fn next(&mut self) -> Option<(ResetToken, Range<u64>)> {
        let (i, cid_data) = self.iter_from_reserved().nth(1)?;
        let reserved = self.reserved_len();
        for j in 0..=reserved {
            self.buffer[self.cursor + j] = None;
        }
        let orig_offset = self.offset;
        self.offset += (i + reserved) as u64;
        self.cursor = (self.cursor_reserved + i) % Self::LEN;
        self.cursor_reserved = self.cursor;

        Some((cid_data.1.unwrap(), orig_offset..self.offset))
    }
```

should employ the same `% Self::LEN` modulo

```rust
    pub(crate) fn next(&mut self) -> Option<(ResetToken, Range<u64>)> {
        let (i, cid_data) = self.iter_from_reserved().nth(1)?;
        let reserved = self.reserved_len();
        for j in 0..=reserved {
            self.buffer[(self.cursor + j) % Self::LEN] = None;   // only this line changed
        }
        let orig_offset = self.offset;
        self.offset += (i + reserved) as u64;
        self.cursor = (self.cursor_reserved + i) % Self::LEN;
        self.cursor_reserved = self.cursor;

        Some((cid_data.1.unwrap(), orig_offset..self.offset))
    }
```
as all the other instances that index `CidQueue` buffer:
- [https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L76C13-L76C63]( https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L76C13-L76C63)
- [https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L80-L81](https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L80-L81)
- [https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L149-L150](https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L149-L150)
- [https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L163-L164](https://github.com/n0-computer/quinn/blob/ebbd7654658415a3c5e627f0c0113e6abc2ac020/quinn-proto/src/cid_queue.rs#L163-L164)

At least this fixed it for me. I can keep digging and put some more time into a "normal usage" reproduction test that demonstrates that this state can be reached clearly. But if this looks right to you and *should* in fact employ the `% Self::LEN`, then I will stop digging. If you would like a full demonstration, let me know and I will keep working on this and update this branch.

## Breaking Changes

n/a

## Notes & open questions

- What environment triggers this panic?
- What is the exact code path that puts `CidQueue` into a state where `self.cursor + j` is == 5 with `j = if self.cursor_reserved >= self.cursor {
            self.cursor_reserved - self.cursor
        } else {
            self.cursor_reserved + Self::LEN - self.cursor
        }` - 
- What should the unit test for this condition look like (I wrote one that trigger the panic, but I am not sure the unit tests arrive at the panic in a way the real code can)?