### PR TITLE
test(proto): Never allow constructing empty packets

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7575,6 +7575,11 @@ impl SentFrames {
             && self.retransmits.is_empty(streams)
     }
 
+    /// Returns whether the packet contains any frames at all
+    fn is_empty(&self, streams: &StreamsState) -> bool {
+        !self.non_retransmits && self.stream_frames.is_empty() && self.retransmits.is_empty(streams)
+    }
+
     fn retransmits_mut(&mut self) -> &mut Retransmits {
         self.retransmits.get_or_create()
     }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7644,6 +7644,11 @@ impl SentFrames {
             && self.retransmits.is_empty(streams)
     }
 
+    /// Returns whether the packet contains any frames at all
+    fn is_empty(&self, streams: &StreamsState) -> bool {
+        !self.non_retransmits && self.stream_frames.is_empty() && self.retransmits.is_empty(streams)
+    }
+
     fn retransmits_mut(&mut self) -> &mut Retransmits {
         self.retransmits.get_or_create()
     }

--- a/noq-proto/src/connection/packet_builder.rs
+++ b/noq-proto/src/connection/packet_builder.rs
@@ -327,6 +327,10 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             self.buf.len() <= self.buf.datagram_max_offset() - self.tag_len,
             "packet exceeds maximum size"
         );
+        debug_assert!(
+            !self.sent_frames.is_empty(&conn.streams),
+            "constructed empty packet"
+        );
         let pad = self.buf.len() < self.min_size;
         if pad {
             let padding = self.min_size - self.buf.len();

--- a/noq-proto/src/connection/packet_builder.rs
+++ b/noq-proto/src/connection/packet_builder.rs
@@ -331,6 +331,10 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             self.buf.len() <= self.buf.datagram_max_offset() - self.tag_len,
             "packet exceeds maximum size"
         );
+        debug_assert!(
+            !self.sent_frames.is_empty(&conn.streams),
+            "constructed empty packet"
+        );
         let pad = self.buf.len() < self.min_size;
         if pad {
             let padding = self.min_size - self.buf.len();


### PR DESCRIPTION
## Description

Adds a `debug_assert!` that checks for the case in #176 

This allows us to generate minimal proptest failures (and other test failures) for when this happens.

This happens *all the time*.

## Notes & open questions

This PR doesn't fix this problem yet. Just adds a test case. Thus draft.

There might be a better/easier/more correct way to check this than what I'm doing here with checking `SentFrames`, and instead somehow look at whether bytes were written to `PacketBuilder::buf`, but I admit I don't understand what's going on with the buffer and all the offsets enough to make the correct check for this possible.