### PR TITLE
refactor: rename pending to tx_queue

### DIFF
--- a/quinn-proto/src/tests/mod.rs
+++ b/quinn-proto/src/tests/mod.rs
@@ -1303,7 +1303,7 @@ fn connection_close_sends_acks() {
     let client_acks_2 = pair.client_conn_mut(client_ch).stats().frame_rx.acks;
     assert!(
         client_acks_2 > client_acks,
-        "Connection close should send pending ACKs"
+        "Connection close should send queued ACKs"
     );
 }
 

--- a/quinn-proto/src/tests/proptest.rs
+++ b/quinn-proto/src/tests/proptest.rs
@@ -807,8 +807,8 @@ fn regression_peer_ignored_path_abandon() {
 /// >  network_path=(local: ::ffff:1.1.1.2, remote: [::ffff:2.2.2.0]:4433)
 /// >  expected=(local: ::ffff:1.1.1.1, remote: [::ffff:2.2.2.0]:4433)
 ///
-/// The client will then never clear out the PATH_CHALLENGE from the "pending"
-/// challenges, and so it will never fully clear the path challenge timer.
+/// The client will then never clear out the PATH_CHALLENGE from the challenges queued for
+/// transmission, and so it will never fully clear the path challenge timer.
 ///
 /// This issue was fixed by making sure to clear out challenges that were probing
 /// 4-tuples that are different from the current network path.

--- a/quinn-proto/src/tests/util.rs
+++ b/quinn-proto/src/tests/util.rs
@@ -635,8 +635,8 @@ impl ConnPair {
         self.conn(side).has_0rtt()
     }
 
-    pub(super) fn has_pending_retransmits(&self, side: Side) -> bool {
-        self.conn(side).has_pending_retransmits()
+    pub(super) fn has_queued_retransmits(&self, side: Side) -> bool {
+        self.conn(side).has_queued_retransmits()
     }
 
     pub(super) fn path_observed_address(


### PR DESCRIPTION
## Description

Pending keeps confusing people which results in ever new attempts to
use different nameds for it. So attempt to rename all pending usages
to tx_queue.

## Breaking Changes

Not even sure if this affects the public API. There are just so many
changes.

## Notes & open questions

I have to admit I kind of despise this. The naming was very consistent
beforehand. This touches so much code that I've never even looked at
that I really don't know if it achieves the level of
consistency. Please review very carefully for this.