### PR TITLE
fix: avoid lock re-entry in open_path_ensure and add regression test

### DIFF
--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -422,7 +422,9 @@ impl Connection {
         state.wake();
         match open_res {
             Ok((path_id, existed)) if existed => {
-                match state.open_path.get(&path_id).map(|tx| tx.subscribe()) {
+                let recv = state.open_path.get(&path_id).map(|tx| tx.subscribe());
+                drop(state);
+                match recv {
                     Some(recv) => OpenPath::new(path_id, recv, self.0.clone()),
                     None => OpenPath::ready(path_id, self.0.clone()),
                 }


### PR DESCRIPTION
## Description

Fixes a lock re-entry issue in `Connection::open_path_ensure` when the path already exists.

- In the `existed` branch, collect the watcher receiver and drop the state lock before cloning `ConnectionRef`.
- Add a regression test (`test_open_path_ensure_existing_path`) that verifies `open_path_ensure` on an existing path resolves promptly and returns consistent path information.