### PR TITLE
fix(proto): handle stale endpoint events after Drained without panicking

### DIFF
--- a/noq-proto/src/endpoint.rs
+++ b/noq-proto/src/endpoint.rs
@@ -96,15 +96,28 @@ impl Endpoint {
         event: EndpointEvent,
     ) -> Option<ConnectionEvent> {
         use EndpointEventInner::*;
+        let stale_event = |event_name: &str| {
+            // Endpoint events can race with cleanup; stale events should be ignored.
+            debug!(
+                id = ch.0,
+                event = event_name,
+                "ignoring stale endpoint event"
+            );
+        };
         match event.0 {
             NeedIdentifiers(path_id, now, n) => {
+                if !self.connections.contains(ch.0) {
+                    stale_event("NeedIdentifiers");
+                    return None;
+                }
                 return Some(self.send_new_identifiers(path_id, now, ch, n));
             }
             ResetToken(path_id, remote, token) => {
-                if let Some(old) = self.connections[ch]
-                    .reset_token
-                    .insert(path_id, (remote, token))
-                {
+                let Some(conn) = self.connections.get_mut(ch.0) else {
+                    stale_event("ResetToken");
+                    return None;
+                };
+                if let Some(old) = conn.reset_token.insert(path_id, (remote, token)) {
                     self.index.connection_reset_tokens.remove(old.0, old.1);
                 }
                 if self.index.connection_reset_tokens.insert(remote, token, ch) {
@@ -112,12 +125,20 @@ impl Endpoint {
                 }
             }
             RetireResetToken(path_id) => {
-                if let Some(old) = self.connections[ch].reset_token.remove(&path_id) {
+                let Some(conn) = self.connections.get_mut(ch.0) else {
+                    stale_event("RetireResetToken");
+                    return None;
+                };
+                if let Some(old) = conn.reset_token.remove(&path_id) {
                     self.index.connection_reset_tokens.remove(old.0, old.1);
                 }
             }
             RetireConnectionId(now, path_id, seq, allow_more_cids) => {
-                if let Some(cid) = self.connections[ch]
+                let Some(conn) = self.connections.get_mut(ch.0) else {
+                    stale_event("RetireConnectionId");
+                    return None;
+                };
+                if let Some(cid) = conn
                     .local_cids
                     .get_mut(&path_id)
                     .and_then(|pcid| pcid.cids.remove(&seq))

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2,6 +2,7 @@ use std::{
     convert::TryInto,
     mem,
     net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    panic::{AssertUnwindSafe, catch_unwind},
     sync::{Arc, Mutex},
 };
 
@@ -31,6 +32,7 @@ use crate::{
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     crypto::rustls::QuicServerConfig,
     frame::FrameStruct,
+    shared::EndpointEventInner,
     transport_parameters::TransportParameters,
 };
 mod util;
@@ -155,6 +157,56 @@ fn lifecycle() {
     assert_eq!(pair.client.known_cids(), 0);
     assert_eq!(pair.server.known_connections(), 0);
     assert_eq!(pair.server.known_cids(), 0);
+}
+
+#[test]
+fn endpoint_ignores_stale_non_drained_events_after_drained() {
+    let _guard = subscribe();
+    let remote = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 4433);
+    let mut endpoint = Endpoint::new(Default::default(), None, true);
+    let now = Instant::now();
+    let (ch, _conn) = endpoint
+        .connect(now, client_config(), remote, "localhost")
+        .unwrap();
+
+    endpoint.handle_event(ch, EndpointEvent(EndpointEventInner::Drained));
+    assert_eq!(endpoint.known_connections(), 0);
+
+    let stale_events: Vec<(&str, EndpointEvent)> = vec![
+        (
+            "NeedIdentifiers",
+            EndpointEvent(EndpointEventInner::NeedIdentifiers(PathId::ZERO, now, 1)),
+        ),
+        (
+            "ResetToken",
+            EndpointEvent(EndpointEventInner::ResetToken(
+                PathId::ZERO,
+                remote,
+                [0u8; 16].into(),
+            )),
+        ),
+        (
+            "RetireResetToken",
+            EndpointEvent(EndpointEventInner::RetireResetToken(PathId::ZERO)),
+        ),
+        (
+            "RetireConnectionId",
+            EndpointEvent(EndpointEventInner::RetireConnectionId(
+                now,
+                PathId::ZERO,
+                0,
+                false,
+            )),
+        ),
+    ];
+
+    for (name, event) in stale_events {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            endpoint.handle_event(ch, event);
+        }));
+        assert!(result.is_ok(), "stale {name} after Drained must not panic");
+        assert_eq!(endpoint.known_connections(), 0);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `Endpoint::handle_event` now gracefully ignores events for connection handles that were already removed by a prior `Drained` event, instead of panicking with `invalid key` on the slab index.
- All four non-`Drained` `EndpointEventInner` variants (`NeedIdentifiers`, `ResetToken`, `RetireResetToken`, `RetireConnectionId`) are guarded; stale events are logged at `debug!` level and return `None`.
- Adds a test exercising all four variants against a drained handle.

## Context

Observed in production (iroh-quinn 0.16.1): when a non-`Drained` endpoint event is processed for a connection handle that was already removed by `Drained`, the direct slab index (`self.connections[ch]`) panics with `invalid key`. Cleanup then hits a poisoned mutex and the process aborts.

The proto-level `Connection` already ensures `Drained` is the last event it emits (timers are cleared via `close_common()` before any drain transition). The proto test harness in `tests/util.rs` also already guards against this pattern. This change brings `Endpoint::handle_event` in line with that defensive approach — a public API accepting a `ConnectionHandle` (plain `usize`) should not panic on stale input.

Closes #465

## Test plan

- [x] New test `endpoint_ignores_stale_non_drained_events_after_drained` covers all four non-`Drained` variants
- [x] Full `noq-proto` test suite passes (333 tests)