### PR TITLE
refactor(proto)!: Remove excessive `Arc`-wrapping

### DIFF
--- a/noq-proto/src/crypto.rs
+++ b/noq-proto/src/crypto.rs
@@ -8,7 +8,7 @@
 //! Note that usage of any protocol (version) other than TLS 1.3 does not conform to any
 //! published versions of the specification, and will not be supported in QUIC v1.
 
-use std::{any::Any, str, sync::Arc};
+use std::{any::Any, str};
 
 use bytes::BytesMut;
 
@@ -127,7 +127,7 @@ impl Keys {
 pub trait ClientConfig: Send + Sync {
     /// Start a client session with this configuration
     fn start_session(
-        self: Arc<Self>,
+        &self,
         version: u32,
         server_name: &str,
         params: &TransportParameters,
@@ -150,11 +150,7 @@ pub trait ServerConfig: Send + Sync {
     /// Start a server session with this configuration
     ///
     /// Never called if `initial_keys` rejected `version`.
-    fn start_session(
-        self: Arc<Self>,
-        version: u32,
-        params: &TransportParameters,
-    ) -> Box<dyn Session>;
+    fn start_session(&self, version: u32, params: &TransportParameters) -> Box<dyn Session>;
 }
 
 /// Keys used to protect packet payloads

--- a/noq-proto/src/crypto/rustls.rs
+++ b/noq-proto/src/crypto/rustls.rs
@@ -287,6 +287,7 @@ pub struct HandshakeData {
 ///
 /// [root_certs]: crate::config::ClientConfig::with_root_certificates()
 /// [platform]: crate::config::ClientConfig::try_with_platform_verifier()
+#[derive(Clone)] // cheap clone: Only one arc clone and some copied pointers
 pub struct QuicClientConfig {
     pub(crate) inner: Arc<rustls::ClientConfig>,
     initial: Suite,
@@ -361,7 +362,7 @@ impl QuicClientConfig {
 
 impl crypto::ClientConfig for QuicClientConfig {
     fn start_session(
-        self: Arc<Self>,
+        &self,
         version: u32,
         server_name: &str,
         params: &TransportParameters,
@@ -443,6 +444,7 @@ impl std::error::Error for NoInitialCipherSuite {}
 /// - The `rustls::ServerConfig` must have TLS 1.3 support enabled for conversion to succeed.
 ///
 /// [single]: crate::config::ServerConfig::with_single_cert()
+#[derive(Clone)] // clone is cheap: Just an Arc clone and some copied pointers
 pub struct QuicServerConfig {
     inner: Arc<rustls::ServerConfig>,
     initial: Suite,
@@ -519,7 +521,7 @@ impl TryFrom<Arc<rustls::ServerConfig>> for QuicServerConfig {
 
 impl crypto::ServerConfig for QuicServerConfig {
     fn start_session(
-        self: Arc<Self>,
+        &self,
         version: u32,
         params: &TransportParameters,
     ) -> Box<dyn crypto::Session> {

--- a/noq-proto/src/endpoint.rs
+++ b/noq-proto/src/endpoint.rs
@@ -630,7 +630,7 @@ impl Endpoint {
             });
         }
 
-        let tls = server_config.crypto.clone().start_session(version, &params);
+        let tls = server_config.crypto.start_session(version, &params);
         let transport_config = server_config.transport.clone();
         let mut conn = self.add_connection(
             ch,

--- a/perf/src/client.rs
+++ b/perf/src/client.rs
@@ -126,10 +126,10 @@ pub async fn run(opt: Opt) -> Result<()> {
         "perf-client",
     )?;
 
-    let crypto = Arc::new(QuicClientConfig::try_from(crypto)?);
+    let crypto = QuicClientConfig::try_from(crypto)?;
     let mut config = noq::ClientConfig::new(match opt.common.no_protection {
         true => Arc::new(NoProtectionClientConfig::new(crypto)),
-        false => crypto,
+        false => Arc::new(crypto),
     });
     config.transport_config(Arc::new(transport));
 

--- a/perf/src/noprotection.rs
+++ b/perf/src/noprotection.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use bytes::BytesMut;
 
 use noq_proto::{
@@ -42,22 +40,24 @@ impl NoProtectionPacketKey {
     }
 }
 
+#[derive(Clone)]
 pub struct NoProtectionClientConfig {
-    inner: Arc<QuicClientConfig>,
+    inner: QuicClientConfig,
 }
 
 impl NoProtectionClientConfig {
-    pub fn new(config: Arc<QuicClientConfig>) -> Self {
+    pub fn new(config: QuicClientConfig) -> Self {
         Self { inner: config }
     }
 }
 
+#[derive(Clone)]
 pub struct NoProtectionServerConfig {
-    inner: Arc<QuicServerConfig>,
+    inner: QuicServerConfig,
 }
 
 impl NoProtectionServerConfig {
-    pub fn new(config: Arc<QuicServerConfig>) -> Self {
+    pub fn new(config: QuicServerConfig) -> Self {
         Self { inner: config }
     }
 }
@@ -131,7 +131,7 @@ impl crypto::Session for NoProtectionSession {
 
 impl crypto::ClientConfig for NoProtectionClientConfig {
     fn start_session(
-        self: std::sync::Arc<Self>,
+        &self,
         version: u32,
         server_name: &str,
         params: &transport_parameters::TransportParameters,
@@ -159,11 +159,11 @@ impl crypto::ServerConfig for NoProtectionServerConfig {
     }
 
     fn start_session(
-        self: Arc<Self>,
+        &self,
         version: u32,
         params: &transport_parameters::TransportParameters,
     ) -> Box<dyn crypto::Session> {
-        let tls = self.inner.clone().start_session(version, params);
+        let tls = self.inner.start_session(version, params);
 
         Box::new(NoProtectionSession::new(tls))
     }

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -67,10 +67,10 @@ pub async fn run(opt: Opt) -> Result<()> {
         "perf-server",
     )?;
 
-    let crypto = Arc::new(QuicServerConfig::try_from(crypto)?);
+    let crypto = QuicServerConfig::try_from(crypto)?;
     let mut config = noq::ServerConfig::with_crypto(match opt.common.no_protection {
         true => Arc::new(NoProtectionServerConfig::new(crypto)),
-        false => crypto,
+        false => Arc::new(crypto),
     });
     config.transport_config(Arc::new(transport));
 


### PR DESCRIPTION
## Description

Removes the excessive wrapping of `QuicClientConfig` and `QuicServerConfig` being wrapped in `Arc`s when that's just not needed.

## Breaking Changes

- `noq_proto::crypto::ClientConfig::start_session` and `noq_proto::crypto::ServerConfig::start_session` now take `&self` instead of `self: Arc<Self>` as arguments

## Notes & open questions

The plan is that this opens up some further future improvements that allow to e.g. `set_alpn` without needing to reconstruct the whole `rustls::ServerConfig`.