### PR TITLE
ci: Build on RISC-V espidf to check that we properly use portable_atomic and don't use advanced posix features.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,13 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
       RUSTFLAGS: "-Dwarnings --cfg posix_minimal"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build and test noq-udp (posix_minimal)
         run: cargo test --locked -p noq-udp
 
@@ -64,12 +66,15 @@ jobs:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
-      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Check noq for ESP32-C3
         run: cargo check -Z build-std=std,panic_abort --target riscv32imc-esp-espidf -p noq -p noq-proto -p noq-udp --no-default-features
 


### PR DESCRIPTION
## Description

Build on RISC-V espidf to check that we properly use portable_atomic and don't use advanced posix features.
This just builds but does not run tests.

## Breaking Changes

None

## Notes & open questions

Note: I tested this by intentionally breaking esp32. You get missing symbol errors in libc, as expected:

```
error[E0425]: cannot find function, tuple struct or tuple variant `CMSG_FIRSTHDR` in crate `libc`
  --> noq-udp/src/cmsg/unix.rs:14:24
   |
14 |         unsafe { libc::CMSG_FIRSTHDR(self) }
   |                        ^^^^^^^^^^^^^ not found in `libc`

error[E0425]: cannot find function, tuple struct or tuple variant `CMSG_NXTHDR` in crate `libc`
  --> noq-udp/src/cmsg/unix.rs:18:24
   |
18 |         unsafe { libc::CMSG_NXTHDR(self, cmsg) }
   |                        ^^^^^^^^^^^ not found in `libc`

error[E0425]: cannot find function, tuple struct or tuple variant `CMSG_LEN` in crate `libc`
   --> noq-udp/src/cmsg/unix.rs:61:24
    |
 61 |         unsafe { libc::CMSG_LEN(length as _) as usize }
    |                        ^^^^^^^^ not found in `libc`
```