### PR TITLE
feat(proto): Add `QuicServerConfig::set_alpn_protocols` in rustls feature

### DIFF
--- a/noq-proto/src/crypto/rustls.rs
+++ b/noq-proto/src/crypto/rustls.rs
@@ -345,7 +345,7 @@ impl QuicClientConfig {
         }
     }
 
-    /// Updates the set of ALPN protocols configured in the server config.
+    /// Updates the set of ALPN protocols configured in the client config.
     pub fn set_alpn_protocols(&mut self, alpn_protocols: Vec<Vec<u8>>) {
         let config = Arc::make_mut(&mut self.inner);
         config.alpn_protocols = alpn_protocols;


### PR DESCRIPTION
## Description

Constructing a `QuicServerConfig` is a fallible operation.
But setting the set of `alpns` is infallible.
This makes it possible to only do the fallible operation once, and then update the ALPNs each time we want to change them without fallibility.

Part of https://github.com/n0-computer/iroh/issues/3978

## Breaking Changes

None.

- Added `noq_proto::crypto::rustls::QuicServerConfig::add_alpn_protocols` function
- Added `noq_proto::crypto::rustls::QuicClientConfig::add_alpn_protocols` function