### PR TITLE
refactor: remove redundant log message

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5723,7 +5723,6 @@ impl Connection {
             && let Some(token) = path.path_responses.pop_on_path(path.network_path)
         {
             let response = frame::PathResponse(token);
-            trace!(frame = %response);
             builder.write_frame(response, stats);
             builder.require_padding();
 


### PR DESCRIPTION
## Description

The packet builder now logs this already.

## Breaking Changes


## Notes & open questions

Another small tweak split out from #444.