### PR TITLE
deps(proto): Don't require ring in wasm builds

### DIFF
--- a/noq-proto/Cargo.toml
+++ b/noq-proto/Cargo.toml
@@ -77,7 +77,7 @@ enum-assoc = "1.3.0"
 # Feature flags & dependencies for wasm
 # wasm-bindgen is assumed for a wasm*-*-unknown target
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-ring = { workspace = true, features = ["wasm32_unknown_unknown_js"] }
+ring = { workspace = true, optional = true, features = ["wasm32_unknown_unknown_js"] }
 getrandom = { workspace = true, features = ["wasm_js"] }
 rustls-pki-types = { workspace = true, features = ["web"] } # only added as dependency to enforce the `web` feature for this target
 web-time = { workspace = true }


### PR DESCRIPTION
## Description

Make `ring` an optional dependency in `wasm32-unknown-unknown`, too.

It's pretty much the only practical crypto provider for Wasm at this time, but it's worth making it optional, too.
