### PR TITLE
fix for double panic stemming from error during drain period

### DIFF
--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -285,7 +285,18 @@ impl Future for ConnectionDriver {
             return Poll::Pending;
         }
         if conn.error.is_none() {
-            unreachable!("drained connections always have an error");
+            // This condition should not normally occur, but has been observed in
+            // practice — a connection can reach the drained state without an error
+            // being set. Rather than panicking (which poisons the state mutex and
+            // causes a double-panic abort in ConnectionRef::drop), synthesize an
+            // internal error so the driver can shut down cleanly.
+            conn.terminate(
+                ConnectionError::TransportError(TransportError::new(
+                    TransportErrorCode::INTERNAL_ERROR,
+                    "drained connection had no error".to_string(),
+                )),
+                &self.0.shared,
+            );
         }
         Poll::Ready(Ok(()))
     }
@@ -1768,7 +1779,10 @@ impl Drop for State {
 
         if !self.on_closed.is_empty() {
             // Ensure that all on_closed oneshot senders are triggered before dropping.
-            let reason = self.error.as_ref().expect("closed without error reason");
+            let reason = match self.error.as_ref() {
+                Some(r) => r,
+                None => return, // No error set; nothing meaningful to send
+            };
             let stats = self.inner.stats();
             for tx in self.on_closed.drain(..) {
                 tx.send((reason.clone(), stats.clone())).ok();

--- a/noq/src/endpoint.rs
+++ b/noq/src/endpoint.rs
@@ -443,7 +443,9 @@ impl Future for EndpointDriver {
 
 impl Drop for EndpointDriver {
     fn drop(&mut self) {
-        let mut endpoint = self.0.state.lock().unwrap();
+        let mut endpoint = self.0.state.lock().unwrap_or_else(|poisoned| {
+            poisoned.into_inner()
+        });
         endpoint.driver_lost = true;
         self.0.shared.incoming.notify_waiters();
         // Drop all outgoing channels, signaling the termination of the endpoint to the associated
@@ -801,7 +803,9 @@ impl Clone for EndpointRef {
 
 impl Drop for EndpointRef {
     fn drop(&mut self) {
-        let endpoint = &mut *self.0.state.lock().unwrap();
+        let endpoint = &mut *self.0.state.lock().unwrap_or_else(|poisoned| {
+            poisoned.into_inner()
+        });
         if let Some(x) = endpoint.ref_count.checked_sub(1) {
             endpoint.ref_count = x;
             if x == 0 {

--- a/noq/src/mutex.rs
+++ b/noq/src/mutex.rs
@@ -45,7 +45,12 @@ mod tracking {
             // We don't bother dispatching through Runtime::now because they're pure performance
             // diagnostics.
             let now = Instant::now();
-            let guard = self.inner.lock().unwrap();
+            let guard = self.inner.lock().unwrap_or_else(|poisoned| {
+                // If the mutex was poisoned by a panic on another thread (or during
+                // unwind on this thread), recover the inner data rather than panicking
+                // again — a second panic during unwind causes a process abort.
+                poisoned.into_inner()
+            });
 
             let lock_time = Instant::now();
             let elapsed = lock_time.duration_since(now);
@@ -135,7 +140,12 @@ mod non_tracking {
         /// The purpose will be recorded in the list of last lock owners
         pub(crate) fn lock(&self, _purpose: &'static str) -> MutexGuard<'_, T> {
             MutexGuard {
-                guard: self.inner.lock().unwrap(),
+                guard: self.inner.lock().unwrap_or_else(|poisoned| {
+                    // If the mutex was poisoned by a panic on another thread (or during
+                    // unwind on this thread), recover the inner data rather than panicking
+                    // again — a second panic during unwind causes a process abort.
+                    poisoned.into_inner()
+                }),
             }
         }
     }


### PR DESCRIPTION
## Description

We're seeing a process abort caused by a double-panic in iroh-quinn 0.16.1 (via iroh 0.96.1). The first panic hits the `unreachable!()` in `connection.rs:288`. When things start unwinding, the `Drop` impl for `ConnectionRef` tries to acquire a mutex that was poisoned by the first panic, causing a second panic and thus a full abort.

This doesn't seem to be related to any specific action in the app [podping.alpha](https://github.com/Podcastindex-org/podping.alpha/pull/13) — it appears to be a race condition in connection lifecycle handling. It happens randomly during normal gossip network operation.  We only notice it when the gossips stop broadcasting and checking the server shows this error.

## Breaking Changes

There should not be any breaking changes with this patch.

## Notes & open questions

I'm not familiar with quinn beyond basic understanding of QUIC itself, so these changes seem reasonable since they only affect the teardown process and a panic would occur anyway.  If the mutex poisoning fix is too far reaching, at least the connection draining panic seems reasonable to me as I see no other downstream effects of that and it avoids a total process crash.

## Testing

These fixes seem hard to write unit tests for since it would require external manipulation of the network state to reproduce.  I'm happy to try though if you think it is necessary.