### PR TITLE
fix(proto): Do not ignore ACKs for abandoned paths

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2711,9 +2711,10 @@ impl Connection {
             && self.abandoned_paths.contains(&path)
         {
             // See also
-            // https://www.ietf.org/archive/id/draft-ietf-quic-multipath-17.html#section-3.4.3-3
-            // > PATH_ACK frames received with an abandoned path ID are silently ignored, as
-            // specified in Section 4.
+            // https://www.ietf.org/archive/id/draft-ietf-quic-multipath-21.html#section-3.4.3-3
+            // > When an endpoint finally deletes all state associated with the path [...]
+            // > PATH_ACK frames received with an abandoned path ID are silently ignored,
+            // > as specified in Section 4.
             trace!("silently ignoring PATH_ACK on discarded path");
             return Ok(());
         }


### PR DESCRIPTION
## Description

We need to accept in-flight acks from an abandoned path, otherwise we
will be retransmitting data that we know the peer already received.

Only ignore the ACKs if we already discarded the path state, in this
case we'll already have marked all the data for retransmission when
the path state was discarded.

## Breaking Changes

n/a

## Notes & open questions

n/a