### PR TITLE
fix: don't track off-path probes in congestion control

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1995,8 +1995,7 @@ impl Connection {
         let stats = &mut self.stats.frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(off-path)"));
         // Off-path: not tracked in congestion control. The packet is sent to a
-        // different destination than path_id's network path, so ACKs for this
-        // packet number won't arrive on path_id.
+        // different destination than path_id's network path.
         builder.pad_to(MIN_INITIAL_SIZE);
         builder.finish(self, now);
 
@@ -2057,8 +2056,7 @@ impl Connection {
         let stats = &mut self.stats.frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(nat-traversal)"));
         // Off-path: not tracked in congestion control. The packet is sent to a
-        // different destination than path_id's network path, so ACKs for this
-        // packet number won't arrive on path_id.
+        // different destination than path_id's network path.
         builder.pad_to(MIN_INITIAL_SIZE);
         builder.finish(self, now);
 


### PR DESCRIPTION
## Description

Off-path NAT traversal probes (PATH_CHALLENGE) and off-path responses (PATH_RESPONSE) are sent to a different destination than path_id's network path. ACKs for these packet numbers won't arrive on path_id, so tracking them in path_id's in_flight permanently inflates the congestion state.

This caused the relay path to become congestion-blocked after repeated NAT traversal probing, preventing REACH_OUT and ADD_ADDRESS frames from being sent — breaking holepunching after network changes.

Use builder.finish() (no tracking) instead of finish_and_track(), matching the existing send_prev_path_challenge() which already does this correctly.


## Notes

- Is this the right solution? 
- This does fix actual tests, the full combined fixes now pass the `switch_uplink_ipv6` and `switch_uplink` tests from patchbay