### PR TITLE
Revert "fix(udp): propagate network-unreachable send errors instead of swallowing them"

### DIFF
--- a/noq-udp/src/posix_minimal.rs
+++ b/noq-udp/src/posix_minimal.rs
@@ -40,19 +40,9 @@ impl UdpSocketState {
         match send(socket, transmit) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
-            Err(e)
-                if e.raw_os_error() == Some(libc::ENETUNREACH)
-                    || e.raw_os_error() == Some(libc::EHOSTUNREACH)
-                    || e.raw_os_error() == Some(libc::EADDRNOTAVAIL)
-                    || e.raw_os_error() == Some(libc::ENETDOWN) =>
-            {
-                Err(io::Error::new(
-                    io::ErrorKind::NetworkUnreachable,
-                    "destination unreachable",
-                ))
-            }
             Err(e) => {
                 log_sendmsg_error(&self.last_send_error, e, transmit);
+
                 Ok(())
             }
         }

--- a/noq-udp/src/unix.rs
+++ b/noq-udp/src/unix.rs
@@ -212,21 +212,9 @@ impl UdpSocketState {
             // - EMSGSIZE is expected for MTU probes. Future work might be able to avoid
             //   these by automatically clamping the MTUD upper bound to the interface MTU.
             Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => Ok(()),
-            // Propagate network-unreachable errors so the QUIC stack can
-            // back off instead of retransmitting into a dead path.
-            Err(e)
-                if e.raw_os_error() == Some(libc::ENETUNREACH)
-                    || e.raw_os_error() == Some(libc::EHOSTUNREACH)
-                    || e.raw_os_error() == Some(libc::EADDRNOTAVAIL)
-                    || e.raw_os_error() == Some(libc::ENETDOWN) =>
-            {
-                Err(io::Error::new(
-                    io::ErrorKind::NetworkUnreachable,
-                    "destination unreachable",
-                ))
-            }
             Err(e) => {
                 log_sendmsg_error(&self.last_send_error, e, transmit);
+
                 Ok(())
             }
         }

--- a/noq-udp/src/windows.rs
+++ b/noq-udp/src/windows.rs
@@ -229,22 +229,6 @@ impl UdpSocketState {
         match send(self, socket, transmit) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
-            Err(e)
-                if matches!(
-                    e.raw_os_error(),
-                    Some(
-                        WinSock::WSAENETUNREACH
-                            | WinSock::WSAEHOSTUNREACH
-                            | WinSock::WSAEADDRNOTAVAIL
-                            | WinSock::WSAENETDOWN
-                    )
-                ) =>
-            {
-                Err(io::Error::new(
-                    io::ErrorKind::NetworkUnreachable,
-                    "destination unreachable",
-                ))
-            }
             Err(e) => {
                 log_sendmsg_error(&self.last_send_error, e, transmit);
 

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1456,11 +1456,6 @@ impl State {
                     self.buffered_transmit = Some(t);
                     return Ok(false);
                 }
-                Poll::Ready(Err(e)) if e.kind() == io::ErrorKind::NetworkUnreachable => {
-                    // Drop the datagram — retrying immediately would just fail
-                    // again. Return true to re-poll for packets to other paths.
-                    return Ok(true);
-                }
                 Poll::Ready(Err(e)) => return Err(e),
                 Poll::Ready(Ok(())) => {}
             }


### PR DESCRIPTION
Reverts n0-computer/noq#527

Fixes #533. Should have thought of this revert button first.

/cc @dignifiedquire 