### PR TITLE
test(proto): Fix packet direction log line

### DIFF
--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -178,7 +178,7 @@ impl Pair {
                     dst_ip: Some(packet.destination.ip()),
                 });
             } else {
-                debug!(?packet.destination, "no route from server to client for packet");
+                debug!(?packet.destination, "no route from client to server for packet");
             }
         }
     }


### PR DESCRIPTION
## Description

I keep fixing this locally, but then diagnose test issues forever without submitting this fix as a PR.
The log line had a copy-and-paste error where it said "from server to client" in both directions.
