### PR TITLE
fix(proto): read network path before clearing local_ip in handle_network_change

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5458,11 +5458,13 @@ impl Connection {
             }
             open_paths += 1;
 
+            // Read the network path BEFORE clearing local_ip, so the hint can
+            // check which interface the path was using.
+            let network_path = path.data.network_path;
+
             // Clear the local address for it to be obtained from the socket again. This applies to
             // all paths, regardless of being considered recoverable or not
             path.data.network_path.local_ip = None;
-
-            let network_path = path.data.network_path;
             let remote = network_path.remote;
 
             // Without multipath, the connection tries to recover the single path, whereas with


### PR DESCRIPTION
## Description

`handle_network_change` cleared `local_ip` before the hint callback could check it, causing all paths to be marked recoverable regardless of interface state. Read the network path first so the hint sees the correct `local_ip`.

Split from #525.

Relates to #376