### PR TITLE
fix(proto): prioritise ADD_ADDRESS and REMOVE_ADDRESS before STREAM

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -6195,15 +6195,6 @@ impl Connection {
             }
         }
 
-        // STREAM
-        if !scheduling_info.is_abandoned
-            && scheduling_info.may_send_data
-            && space_id == SpaceId::Data
-        {
-            self.streams
-                .write_stream_frames(builder, self.config.send_fairness, stats);
-        }
-
         // ADD_ADDRESS
         while space_id == SpaceId::Data
             && !scheduling_info.is_abandoned
@@ -6228,6 +6219,15 @@ impl Connection {
             } else {
                 break;
             }
+        }
+
+        // STREAM
+        if !scheduling_info.is_abandoned
+            && scheduling_info.may_send_data
+            && space_id == SpaceId::Data
+        {
+            self.streams
+                .write_stream_frames(builder, self.config.send_fairness, stats);
         }
     }
 


### PR DESCRIPTION
## Description

The STREAM frames can easily take up the entire remainder of a
datagram. We need to make sure that ADD_ADDRESS and REMOVE_ADDRESS
frames are sent before we start building STREAM frames. They are also
higher priority than application data.

## Breaking Changes

n/a

## Notes & open questions

Replaces #526.