### PR TITLE
fix(proto): tail-loss probes should always be ack-eliciting

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7007,7 +7007,7 @@ impl Connection {
 
     /// Whether the handshake is considered **confirmed**.
     ///
-    /// https://www.rfc-editor.org/rfc/rfc9001#section-4.1.2 defines a handshake to be
+    /// <https://www.rfc-editor.org/rfc/rfc9001#section-4.1.2> defines a handshake to be
     /// confirmed when you know the peer successfully received and successfully processed
     /// your TLS Finished message.
     ///

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1929,7 +1929,8 @@ impl Connection {
         }
 
         // Pacing check.
-        if let Some(resume_time) = self.path_data_mut(path_id).pacing_delay(bytes_to_send, now) {
+        if let Some(delay) = self.path_data_mut(path_id).pacing_delay(bytes_to_send, now) {
+            let resume_time = now + delay;
             self.timers.set(
                 Timer::PerPath(path_id, PathTimer::Pacing),
                 resume_time,
@@ -1937,7 +1938,7 @@ impl Connection {
             );
             // Loss probes and CONNECTION_CLOSE should be subject to pacing, even though
             // they are not congestion controlled.
-            trace!(?space_id, %path_id, delay = ?(resume_time - now), "blocked by pacing");
+            trace!(?space_id, %path_id, ?delay, "blocked by pacing");
             return PathBlocked::Pacing;
         }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7007,17 +7007,14 @@ impl Connection {
 
     /// Whether the handshake is considered **confirmed**.
     ///
-    /// The handshake is **completed** when the 1-RTT crypto keys are available. However it
-    /// is only **confirmed** once the peer's TLS Finish message is received and validated.
+    /// https://www.rfc-editor.org/rfc/rfc9001#section-4.1.2 defines a handshake to be
+    /// confirmed when you know the peer successfully received and successfully processed
+    /// your TLS Finished message.
+    ///
+    /// Implementation-wise this is the point at which the handshake crypto keys are
+    /// discarded. So we can use this to know if the handshake is confirmed.
     fn is_handshake_confirmed(&self) -> bool {
-        if self.side() == Side::Server {
-            // On the server completed and confirmed are different times. So we look for the
-            // handshake keys being gone.
-            !self.is_handshaking() && !self.crypto_state.has_keys(EncryptionLevel::Handshake)
-        } else {
-            // The client is confirmed as soon at it managed to compute 1-RTT keys.
-            self.crypto_state.has_keys(EncryptionLevel::OneRtt)
-        }
+        !self.is_handshaking() && !self.crypto_state.has_keys(EncryptionLevel::Handshake)
     }
 }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1580,15 +1580,9 @@ impl Connection {
                 prev.update_unacked = false;
             }
 
-            let Some(mut builder) = PacketBuilder::new(
-                now,
-                space_id,
-                path_id,
-                remote_cid,
-                transmit,
-                can_send.is_ack_eliciting(),
-                self,
-            ) else {
+            let Some(mut builder) =
+                PacketBuilder::new(now, space_id, path_id, remote_cid, transmit, self)
+            else {
                 // Confidentiality limit is exceeded and the connection has been killed. We
                 // should not send any other packets. This works in a roundabout way: We
                 // have started a datagram but not written anything into it. So even if we
@@ -1802,15 +1796,8 @@ impl Connection {
         let mut transmit = TransmitBuf::new(buf, NonZeroUsize::MIN, probe_size as usize);
         transmit.start_new_datagram_with_size(probe_size as usize);
 
-        let mut builder = PacketBuilder::new(
-            now,
-            SpaceId::Data,
-            path_id,
-            active_cid,
-            &mut transmit,
-            true,
-            self,
-        )?;
+        let mut builder =
+            PacketBuilder::new(now, SpaceId::Data, path_id, active_cid, &mut transmit, self)?;
 
         // We implement MTU probes as ping packets padded up to the probe size
         trace!(?probe_size, "writing MTUD probe");
@@ -1991,8 +1978,7 @@ impl Connection {
         // sent once, immediately after migration, when the CID is known to be valid. Even
         // if a post-migration packet caused the CID to be retired, it's fair to pretend
         // this is sent first.
-        let mut builder =
-            PacketBuilder::new(now, SpaceId::Data, path_id, *prev_cid, buf, false, self)?;
+        let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, *prev_cid, buf, self)?;
         let challenge = frame::PathChallenge(token);
         let stats = &mut self.path_stats.for_path(path_id).frame_tx;
         builder.write_frame_with_log_msg(challenge, stats, Some("validating previous path"));
@@ -2039,7 +2025,7 @@ impl Connection {
         let buf = &mut TransmitBuf::new(buf, NonZeroUsize::MIN, MIN_INITIAL_SIZE.into());
         buf.start_new_datagram();
 
-        let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, cid, buf, false, self)?;
+        let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, cid, buf, self)?;
         let stats = &mut self.path_stats.for_path(path_id).frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(off-path)"));
         // Off-path: not tracked in congestion control. The packet is sent to a
@@ -2094,8 +2080,7 @@ impl Connection {
         let mut buf = TransmitBuf::new(buf, NonZeroUsize::MIN, MIN_INITIAL_SIZE.into());
         buf.start_new_datagram();
 
-        let mut builder =
-            PacketBuilder::new(now, SpaceId::Data, path_id, cid, &mut buf, false, self)?;
+        let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, cid, &mut buf, self)?;
         let stats = &mut self.path_stats.for_path(path_id).frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(nat-traversal)"));
         // Off-path: not tracked in congestion control. The packet is sent to a

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1929,15 +1929,15 @@ impl Connection {
         }
 
         // Pacing check.
-        if let Some(delay) = self.path_data_mut(path_id).pacing_delay(bytes_to_send, now) {
+        if let Some(resume_time) = self.path_data_mut(path_id).pacing_delay(bytes_to_send, now) {
             self.timers.set(
                 Timer::PerPath(path_id, PathTimer::Pacing),
-                delay,
+                resume_time,
                 self.qlog.with_time(now),
             );
             // Loss probes and CONNECTION_CLOSE should be subject to pacing, even though
             // they are not congestion controlled.
-            trace!(?space_id, %path_id, "blocked by pacing");
+            trace!(?space_id, %path_id, delay = ?(resume_time - now), "blocked by pacing");
             return PathBlocked::Pacing;
         }
 
@@ -2592,8 +2592,11 @@ impl Connection {
 
     /// Whether the connection is in the process of being established
     ///
-    /// If this returns `false`, the connection may be either established or closed, signaled by the
-    /// emission of a `Connected` or `ConnectionLost` message respectively.
+    /// If this returns `false`, the connection may be either established or closed,
+    /// signaled by the emission of a `Connected` or `ConnectionLost` message respectively.
+    ///
+    /// For an established connection this essentially means the handshake is **completed**,
+    /// but not necessarily yet confirmed.
     pub fn is_handshaking(&self) -> bool {
         self.state.is_handshake()
     }
@@ -3449,6 +3452,13 @@ impl Connection {
                 continue;
             };
 
+            if space == SpaceId::Data && !self.is_handshake_confirmed() {
+                // https://www.rfc-editor.org/rfc/rfc9002.html#section-6.2.1-7:
+                // An endpoint MUST NOT set its PTO timer for the Application Data packet
+                // number space until the handshake is confirmed.
+                continue;
+            }
+
             if !pns.has_in_flight() {
                 continue;
             }
@@ -3458,12 +3468,12 @@ impl Connection {
             // rather iterate through the probes to compute the capped increment for an
             // exponential backoff at each step.
             let duration = {
-                let pto_base = path.rtt.pto_base()
-                    + if space == SpaceId::Data {
-                        self.ack_frequency.max_ack_delay_for_pto()
-                    } else {
-                        Duration::ZERO
-                    };
+                let max_ack_delay = if space == SpaceId::Data {
+                    self.ack_frequency.max_ack_delay_for_pto()
+                } else {
+                    Duration::ZERO
+                };
+                let pto_base = path.rtt.pto_base() + max_ack_delay;
                 let mut duration = pto_base;
                 for i in 1..=pto_count {
                     let exponential_duration = pto_base * 2u32.pow(i.min(MAX_BACKOFF_EXPONENT));
@@ -6991,6 +7001,21 @@ impl Connection {
                 client_state.report_in_continuation(id, e);
                 Some(false)
             }
+        }
+    }
+
+    /// Whether the handshake is considered **confirmed**.
+    ///
+    /// The handshake is **completed** when the 1-RTT crypto keys are available. However it
+    /// is only **confirmed** once the peer's TLS Finish message is received and validated.
+    fn is_handshake_confirmed(&self) -> bool {
+        if self.side() == Side::Server {
+            // On the server completed and confirmed are different times. So we look for the
+            // handshake keys being gone.
+            !self.is_handshaking() && !self.crypto_state.has_keys(EncryptionLevel::Handshake)
+        } else {
+            // The client is confirmed as soon at it managed to compute 1-RTT keys.
+            self.crypto_state.has_keys(EncryptionLevel::OneRtt)
         }
     }
 }

--- a/noq-proto/src/connection/pacing.rs
+++ b/noq-proto/src/connection/pacing.rs
@@ -39,13 +39,14 @@ impl Pacer {
         self.tokens = self.tokens.saturating_sub(packet_length.into())
     }
 
-    /// Return how long we need to wait before sending `bytes_to_send`
+    /// Return how long we need to wait before sending `bytes_to_send`.
     ///
-    /// If we can send a packet right away, this returns `None`. Otherwise, returns `Some(d)`,
-    /// where `d` is the time before this function should be called again.
+    /// If we can send a packet right away, this returns `None`. Otherwise, returns
+    /// `Some(d)`, where `d` is the duration after which this function should be called
+    /// again.
     ///
-    /// The 5/4 ratio used here comes from the suggestion that N = 1.25 in the draft IETF RFC for
-    /// QUIC.
+    /// The 5/4 ratio used here comes from the suggestion that N = 1.25 in the draft IETF
+    /// RFC for QUIC.
     pub(super) fn delay(
         &mut self,
         smoothed_rtt: Duration,
@@ -53,7 +54,7 @@ impl Pacer {
         mtu: u16,
         window: u64,
         now: Instant,
-    ) -> Option<Instant> {
+    ) -> Option<Duration> {
         debug_assert_ne!(
             window, 0,
             "zero-sized congestion control window is nonsense"
@@ -111,7 +112,7 @@ impl Pacer {
 
         // divisions come before multiplications to prevent overflow
         // this is the time at which the pacing window becomes empty
-        Some(now + (unscaled_delay / 5) * 4)
+        Some((unscaled_delay / 5) * 4)
     }
 }
 
@@ -276,8 +277,7 @@ mod tests {
 
         let actual_delay = pacer
             .delay(rtt, mtu as u64, mtu, window, old_instant)
-            .expect("Send must be delayed")
-            .duration_since(old_instant);
+            .expect("Send must be delayed");
 
         let diff = actual_delay.abs_diff(pace_duration);
 

--- a/noq-proto/src/connection/packet_builder.rs
+++ b/noq-proto/src/connection/packet_builder.rs
@@ -49,7 +49,6 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         path_id: PathId,
         dst_cid: ConnectionId,
         buffer: &'a mut TransmitBuf<'b>,
-        ack_eliciting: bool,
         conn: &mut Connection,
     ) -> Option<Self>
     where
@@ -171,7 +170,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             min_size,
             tag_len,
             level,
-            ack_eliciting,
+            ack_eliciting: false,
             qlog,
             sent_frames: SentFrames::default(),
             _span: span,
@@ -241,6 +240,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
     ) {
         let frame = frame.into();
         frame.encode(&mut self.frame_space_mut());
+        self.ack_eliciting |= frame.is_ack_eliciting();
         stats.record(frame.get_type());
         self.qlog.record(&frame);
         match msg {
@@ -255,7 +255,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
     /// The [`BufMut::remaining_mut`] call on the returned buffer indicates the amount of
     /// space available to write QUIC frames into.
     // In rust 1.82 we can use `-> impl BufMut + use<'_, 'a, 'b>`
-    pub(super) fn frame_space_mut(&mut self) -> bytes::buf::Limit<&mut TransmitBuf<'b>> {
+    fn frame_space_mut(&mut self) -> bytes::buf::Limit<&mut TransmitBuf<'b>> {
         self.buf.limit(self.frame_space_remaining())
     }
 

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -556,7 +556,7 @@ impl PathData {
     /// Return how long we need to wait before sending `bytes_to_send`
     ///
     /// See [`Pacer::delay`].
-    pub(super) fn pacing_delay(&mut self, bytes_to_send: u64, now: Instant) -> Option<Instant> {
+    pub(super) fn pacing_delay(&mut self, bytes_to_send: u64, now: Instant) -> Option<Duration> {
         let smoothed_rtt = self.rtt.get();
         self.pacing.delay(
             smoothed_rtt,

--- a/noq-proto/src/frame.rs
+++ b/noq-proto/src/frame.rs
@@ -218,6 +218,42 @@ pub(super) enum EncodableFrame<'a> {
     MaxStreams(MaxStreams),
 }
 
+impl<'a> EncodableFrame<'a> {
+    /// Whether this is an ACK-eliciting frame.
+    pub(crate) fn is_ack_eliciting(&self) -> bool {
+        match self {
+            EncodableFrame::PathAck(_) | EncodableFrame::Ack(_) | EncodableFrame::Close(_) => false,
+            EncodableFrame::PathResponse(_)
+            | EncodableFrame::HandshakeDone(_)
+            | EncodableFrame::ReachOut(_)
+            | EncodableFrame::ObservedAddr(_)
+            | EncodableFrame::Ping(_)
+            | EncodableFrame::ImmediateAck(_)
+            | EncodableFrame::AckFrequency(_)
+            | EncodableFrame::PathChallenge(_)
+            | EncodableFrame::Crypto(_)
+            | EncodableFrame::PathAbandon(_)
+            | EncodableFrame::PathStatusAvailable(_)
+            | EncodableFrame::PathStatusBackup(_)
+            | EncodableFrame::MaxPathId(_)
+            | EncodableFrame::PathsBlocked(_)
+            | EncodableFrame::PathCidsBlocked(_)
+            | EncodableFrame::ResetStream(_)
+            | EncodableFrame::StopSending(_)
+            | EncodableFrame::NewConnectionId(_)
+            | EncodableFrame::RetireConnectionId(_)
+            | EncodableFrame::Datagram(_)
+            | EncodableFrame::NewToken(_)
+            | EncodableFrame::AddAddress(_)
+            | EncodableFrame::RemoveAddress(_)
+            | EncodableFrame::StreamMeta(_)
+            | EncodableFrame::MaxData(_)
+            | EncodableFrame::MaxStreamData(_)
+            | EncodableFrame::MaxStreams(_) => true,
+        }
+    }
+}
+
 impl<'a> Encodable for EncodableFrame<'a> {
     fn encode<B: BufMut>(&self, buf: &mut B) {
         self.encode_inner(buf)

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -746,6 +746,7 @@ fn test_zero_rtt_incoming_limit<F: FnOnce(&mut ServerConfig)>(configure_server: 
         .write(&vec![0; CLIENT_WRITES])
         .unwrap();
     pair.drive();
+    info!("accepting connection");
     let incoming = pair.server.waiting_incoming.pop().unwrap();
     assert!(pair.server.waiting_incoming.is_empty());
     let _ = pair.server.try_accept(incoming, pair.time);


### PR DESCRIPTION
## Description

The PacketBuilder gets is_ack_eliciting from the SendableFrames, but
that is empty if data had to be queued especially for the probe. This
would mean that the PacketBuilder::finish_and_track did not note the
correct number of in-flight bytes for the congestion controller and
also did not update the
PacketNumberSpace::time_of_last_ack_eliciting_packet. That field in
turn is used by the PTO calculation as time from which to arm the next
PTO timeout.

To fix this we add information about all frames on whether they are
ack-eliciting or not. And if any ack-eliciting frame is written by the
PacketBuilder it keeps track of this internally.

Tail-loss probes should also not happen for the Data spaces as long as
the handshake has not yet been confirmed. During this time the Initial
and Handshake spaces' tail-loss probes are the ones that drive the
connection forward. And sending tail-loss probes on the Data space already
consumes congestion controller window and pacing tokens. Also you
don't even know if the peer has keys to decrypt them. 

## Breaking Changes

n/a

## Notes & open questions

n/a