### PR TITLE
wip: client does not open path for nat traversal

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -6980,7 +6980,6 @@ impl Connection {
             new_round,
             reach_out_at,
             addresses_to_probe,
-            prev_round_path_ids,
         } = client_state.initiate_nat_traversal_round(ipv6)?;
 
         trace!(%new_round, reach_out=reach_out_at.len(), to_probe=addresses_to_probe.len(),
@@ -6988,38 +6987,14 @@ impl Connection {
 
         self.spaces[SpaceId::Data].pending.reach_out = Some((new_round, reach_out_at));
 
-        for path_id in prev_round_path_ids {
-            let Some(path) = self.path(path_id) else {
-                continue;
-            };
-            let ip = path.network_path.remote.ip();
-            let port = path.network_path.remote.port();
-
-            // We only close paths that aren't validated (thus are working) that we opened
-            // in a previous round.
-            // And we only close paths that we don't want to probe anyways.
-            if !addresses_to_probe
-                .iter()
-                .any(|(_, probe)| *probe == (ip, port))
-                && !path.validated
-                && !self.abandoned_paths.contains(&path_id)
-            {
-                trace!(%path_id, "closing path from previous round");
-                let _ =
-                    self.close_path_inner(now, path_id, PathAbandonReason::NatTraversalRoundEnded);
-            }
-        }
-
         let mut err = None;
 
-        let mut path_ids = Vec::with_capacity(addresses_to_probe.len());
         let mut probed_addresses = Vec::with_capacity(addresses_to_probe.len());
 
         for (id, address) in addresses_to_probe {
             match self.open_nat_traversal_path(now, address) {
                 Ok(None) => {}
-                Ok(Some((path_id, remote))) => {
-                    path_ids.push(path_id);
+                Ok(Some((_path_id, remote))) => {
                     probed_addresses.push(remote);
                 }
                 Err(e) => {
@@ -7039,11 +7014,6 @@ impl Connection {
             }
         }
 
-        self.n0_nat_traversal
-            .client_side_mut()
-            .expect("connection side validated")
-            .set_round_path_ids(path_ids);
-
         Ok(probed_addresses)
     }
 
@@ -7059,10 +7029,7 @@ impl Connection {
         let client_state = self.n0_nat_traversal.client_side_mut().expect("validated");
         match open_result {
             Ok(None) => Some(true),
-            Ok(Some((path_id, _remote))) => {
-                client_state.add_round_path_id(path_id);
-                Some(true)
-            }
+            Ok(Some(_)) => Some(true),
             Err(e) => {
                 client_state.report_in_continuation(id, e);
                 Some(false)

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -9,7 +9,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::trace;
 
 use crate::{
-    PathId, Side, VarInt,
+    Side, VarInt,
     frame::{AddAddress, ReachOut, RemoveAddress},
 };
 
@@ -50,8 +50,6 @@ pub(crate) struct NatTraversalRound {
     ///
     /// These are filtered and mapped to the IP family the local socket supports.
     pub(crate) addresses_to_probe: Vec<(VarInt, IpPort)>,
-    /// [`PathId`]s of the cancelled round.
-    pub(crate) prev_round_path_ids: Vec<PathId>,
 }
 
 /// Event emitted when the client receives ADD_ADDRESS or REMOVE_ADDRESS frames.
@@ -93,8 +91,6 @@ pub(crate) struct ClientState {
     local_addresses: FxHashSet<IpPort>,
     /// Current nat traversal round.
     round: VarInt,
-    /// [`PathId`]s used to probe remotes assigned to this round.
-    round_path_ids: Vec<PathId>,
 }
 
 impl ClientState {
@@ -105,7 +101,6 @@ impl ClientState {
             remote_addresses: Default::default(),
             local_addresses: Default::default(),
             round: Default::default(),
-            round_path_ids: Default::default(),
         }
     }
 
@@ -145,7 +140,6 @@ impl ClientState {
             return Err(Error::NotEnoughAddresses);
         }
 
-        let prev_round_path_ids = std::mem::take(&mut self.round_path_ids);
         self.round = self.round.saturating_add(1u8);
         let mut addresses_to_probe = Vec::with_capacity(self.remote_addresses.len());
         for (id, ((ip, port), report_in_continuation)) in self.remote_addresses.iter_mut() {
@@ -162,7 +156,6 @@ impl ClientState {
             new_round: self.round,
             reach_out_at: self.local_addresses.iter().copied().collect(),
             addresses_to_probe,
-            prev_round_path_ids,
         })
     }
 
@@ -208,18 +201,6 @@ impl ClientState {
             .next()?;
         *report_in_continuation = false;
         Some((id, address))
-    }
-
-    /// Add a [`PathId`] as part of the current attempts to create paths based on the server's
-    /// advertised addresses.
-    pub(crate) fn set_round_path_ids(&mut self, path_ids: Vec<PathId>) {
-        self.round_path_ids = path_ids;
-    }
-
-    /// Add a [`PathId`] as part of the current attempts to create paths based on the server's
-    /// advertised addresses.
-    pub(crate) fn add_round_path_id(&mut self, path_id: PathId) {
-        self.round_path_ids.push(path_id);
     }
 
     /// Adds an address to the remote set


### PR DESCRIPTION
- **refactor(proto): Move FrameStats into PathStats (#521)**
- **fix(proto): accept remote PATH_ABANDON for last path (#522)**
- **test(proto): Set an idle timeout for paths in multipath proptests (#538)**
- **fix: revalidate existing paths during NAT traversal rounds (#531)**
- **fix: Ensure hole punching related frames don't get stuck (#540)**
- **test(proto): Fix packet direction log line (#543)**
- **fix(proto): read network path before clearing local_ip in handle_network_change (#546)**
- **fix(proto): re-arm PathIdle timer when idle timeout is changed (#544)**
- **deps: Hide the tokio streams behind simple newtype wrappers (#547)**
- **feat(noq): unify waking the state (#541)**
- **test(proto): Add test for sending path abandon on path itself (#549)**
- **fix(proto): reset PTO backoff for recoverable paths on network change (#545)**
- **fix(proto): prioritise ADD_ADDRESS and REMOVE_ADDRESS before STREAM (#550)**
- **test(proto): Test closing while the client migrates (#552)**
- **fix(proto): cap PTO backoff at 2 seconds post-handshake (#523)**
- **fix(proto): display for CONNECTION_CLOSE frame (#554)**
- **test(proto): Stop driving the connection before a path idle timer fires (#557)**
- **refactor(proto): Rename `maybe_queue_probe` to `queue_tail_loss_probe` (#558)**
- **feat(proto): add lost_packets and lost_bytes to the ConnectionStats (#560)**
- **noq-proto: fix CID exhaustion check overflow on 32-bit targets (#564)**
- **refactor: remove poll_read_buf from public api (#548)**
- **fix(proto): retry off-path NAT traversal probes and retire stale CIDs (#524)**
- **refactor(proto): Only emit handshake confirmed event for the first `HandshakeDone` frame (#566)**
- **do not keep track of used PathIds for nat traversal rounds**
