### PR TITLE
feat(proto): Server sends NAT traversal probes with active CID

### DIFF
--- a/noq-proto/src/cid_queue.rs
+++ b/noq-proto/src/cid_queue.rs
@@ -136,6 +136,7 @@ impl CidQueue {
     }
 
     /// Returns the number of unused CIDs (neither active nor reserved).
+    #[allow(unused)]
     pub(crate) fn remaining(&self) -> usize {
         self.iter_from_reserved()
             .count()

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2089,7 +2089,7 @@ impl Connection {
             .get(&path_id)
             .map(|cid_queue| cid_queue.active())
         else {
-            error!("No CIDs for current path, can not send NAT traversal probe");
+            trace!(%path_id, "Not sending NAT traversal probe for path with no CIDs");
             return None;
         };
         let token = self.rng.random();

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2080,13 +2080,18 @@ impl Connection {
             return None;
         }
 
-        let remote_cids = self.remote_cids.get_mut(&path_id)?;
-        // Check if this path has enough CIDs to send a probe. One to be reserved, one in case the
-        // active CID needs to be retired.
-        if remote_cids.remaining() < 2 {
+        // TODO: Using the active CID here makes the paths linkable. This is a violation of
+        //    RFC9000 but something we want to accept in the short term. Eventually we aim
+        //    to fix up the supply of CIDs sufficiently so that we can keep paths unlinkable
+        //    again.
+        let Some(cid) = self
+            .remote_cids
+            .get(&path_id)
+            .map(|cid_queue| cid_queue.active())
+        else {
+            error!("No CIDs for current path, can not send NAT traversal probe");
             return None;
-        }
-        let cid = remote_cids.next_reserved()?;
+        };
         let token = self.rng.random();
 
         let frame = frame::PathChallenge(token);


### PR DESCRIPTION
## Description

This changes the server-side of the NAT traversal to always send path
challenges using the active CID. This means it does not skip probes
when there are no more CIDs (currently still limited to 5).

It does means the paths are linkable, and this is a violation of a
MUST in RFC9000. But this is the direction we want to take right now.

## Breaking Changes

Paths are now linkable.

## Notes & open questions

This is on the path towards #567.

Closes #574.

An attempt to replace #571 with something much simpler and without
design problems. If combined with increasing MAX_MULTIPATH_PATHS on
the iroh side I expect it to be similarly effective.