### PR TITLE
refactor(proto): Spell out packet number

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3696,8 +3696,8 @@ impl Connection {
         let space = self.spaces[space_id].for_path(path_id);
 
         space.pending_acks.insert_one(packet_number, now);
-        if packet_number >= space.rx_packet_number.unwrap_or_default() {
-            space.rx_packet_number = Some(packet_number);
+        if packet_number >= space.largest_received_packet_number.unwrap_or_default() {
+            space.largest_received_packet_number = Some(packet_number);
 
             // Update outgoing spin bit for on-path packets, inverting iff we're the client
             if is_on_path {
@@ -5464,7 +5464,7 @@ impl Connection {
         if Some(number)
             == self.spaces[SpaceId::Data]
                 .for_path(path_id)
-                .rx_packet_number
+                .largest_received_packet_number
             && !is_probing_packet
             && network_path != self.path_data(path_id).network_path
         {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3684,8 +3684,8 @@ impl Connection {
         }
         let space = self.spaces[space_id].for_path(path_id);
         space.pending_acks.insert_one(packet, now);
-        if packet >= space.rx_packet.unwrap_or_default() {
-            space.rx_packet = Some(packet);
+        if packet >= space.rx_packet_number.unwrap_or_default() {
+            space.rx_packet_number = Some(packet);
             // Update outgoing spin bit, inverting iff we're the client
             self.spin = self.side.is_client() ^ spin;
         }
@@ -5444,7 +5444,10 @@ impl Connection {
             self.connection_close_pending = true;
         }
 
-        if Some(number) == self.spaces[SpaceId::Data].for_path(path_id).rx_packet
+        if Some(number)
+            == self.spaces[SpaceId::Data]
+                .for_path(path_id)
+                .rx_packet_number
             && !is_probing_packet
             && network_path != self.path_data(path_id).network_path
         {
@@ -6536,18 +6539,18 @@ impl Connection {
         if result.outgoing_key_update_acked
             && let Some(prev) = self.crypto_state.prev_crypto.as_mut()
         {
-            prev.end_packet = Some((result.number, now));
+            prev.end_packet = Some((result.packet_number, now));
             self.set_key_discard_timer(now, packet.header.space());
         }
 
         if result.incoming_key_update {
             trace!("key update authenticated");
             self.crypto_state
-                .update_keys(Some((result.number, now)), true);
+                .update_keys(Some((result.packet_number, now)), true);
             self.set_key_discard_timer(now, packet.header.space());
         }
 
-        Ok(Some(result.number))
+        Ok(Some(result.packet_number))
     }
 
     fn peer_supports_ack_frequency(&self) -> bool {

--- a/noq-proto/src/connection/packet_crypto.rs
+++ b/noq-proto/src/connection/packet_crypto.rs
@@ -31,7 +31,7 @@ pub(super) struct UnprotectHeaderResult {
 
 pub(super) struct DecryptPacketResult {
     /// The packet number
-    pub(super) number: u64,
+    pub(super) packet_number: u64,
     /// Whether a locally initiated key update has been acknowledged by the peer
     pub(super) outgoing_key_update_acked: bool,
     /// Whether the peer has initiated a key update
@@ -200,12 +200,14 @@ impl CryptoState {
         // Packets that do not belong to known path ids are valid as long as they can be decrypted.
         // If we didn't have a path, that's for the purposes of this function equivalent to not
         // having received packets on that path yet. So both of these cases are represented by `None`.
-        let rx_packet = spaces[space].path_space(path_id).and_then(|s| s.rx_packet);
-        let number = packet
+        let rx_packet_number = spaces[space]
+            .path_space(path_id)
+            .and_then(|s| s.rx_packet_number);
+        let packet_number = packet
             .header
             .number()
             .ok_or(None)?
-            .expand(rx_packet.map(|n| n + 1).unwrap_or_default());
+            .expand(rx_packet_number.map(|n| n + 1).unwrap_or_default());
         let packet_key_phase = packet.header.key_phase();
 
         let mut crypto_update = false;
@@ -217,7 +219,7 @@ impl CryptoState {
             packet
         } else if let Some(prev) = self.prev_crypto.as_ref().and_then(|crypto| {
             // If this packet comes prior to acknowledgment of the key update by the peer,
-            if crypto.end_packet.is_none_or(|(pn, _)| number < pn) {
+            if crypto.end_packet.is_none_or(|(pn, _)| packet_number < pn) {
                 // use the previous keys.
                 Some(crypto)
             } else {
@@ -237,9 +239,14 @@ impl CryptoState {
         };
 
         crypto
-            .decrypt(path_id, number, &packet.header_data, &mut packet.payload)
+            .decrypt(
+                path_id,
+                packet_number,
+                &packet.header_data,
+                &mut packet.payload,
+            )
             .map_err(|_| {
-                trace!("decryption failed with packet number {}", number);
+                trace!("decryption failed with packet number {}", packet_number);
                 None
             })?;
 
@@ -262,16 +269,17 @@ impl CryptoState {
             // If `rx_packet` is `None`, then either the path is entirely new, or we haven't received
             // any packets on this path yet. In that case, having the first packet be a crypto update
             // is fine.
-            let invalid_packet_number = rx_packet.is_some_and(|rx_packet| number <= rx_packet);
+            let invalid_packet_number =
+                rx_packet_number.is_some_and(|rx_packet| packet_number <= rx_packet);
             if invalid_packet_number || self.prev_crypto.as_ref().is_some_and(|x| x.update_unacked)
             {
-                trace!(?number, ?rx_packet, %path_id, "crypto update failed");
+                trace!(?packet_number, ?rx_packet_number, %path_id, "crypto update failed");
                 return Err(Some(TransportError::KEY_UPDATE_ERROR("")));
             }
         }
 
         Ok(Some(DecryptPacketResult {
-            number,
+            packet_number,
             outgoing_key_update_acked,
             incoming_key_update: crypto_update,
         }))

--- a/noq-proto/src/connection/packet_crypto.rs
+++ b/noq-proto/src/connection/packet_crypto.rs
@@ -202,7 +202,7 @@ impl CryptoState {
         // having received packets on that path yet. So both of these cases are represented by `None`.
         let rx_packet_number = spaces[space]
             .path_space(path_id)
-            .and_then(|s| s.rx_packet_number);
+            .and_then(|s| s.largest_received_packet_number);
         let packet_number = packet
             .header
             .number()

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -218,7 +218,7 @@ impl IndexMut<SpaceKind> for [PacketSpace; 3] {
 /// this via [`PacketSpace::for_path`].
 pub(super) struct PacketNumberSpace {
     /// Highest received packet number, if any
-    pub(super) rx_packet_number: Option<u64>,
+    pub(super) largest_received_packet_number: Option<u64>,
     /// The packet number of the next packet that will be sent, if any. In the Data space, the
     /// packet number stored here is sometimes skipped by [`PacketNumberFilter`] logic.
     pub(super) next_packet_number: u64,
@@ -278,7 +278,7 @@ impl PacketNumberSpace {
             SpaceId::Data => Some(PacketNumberFilter::new(rng)),
         };
         Self {
-            rx_packet_number: None,
+            largest_received_packet_number: None,
             next_packet_number: 0,
             largest_acked_packet: None,
             largest_acked_packet_sent: now,
@@ -306,7 +306,7 @@ impl PacketNumberSpace {
             SpaceId::Data => Some(PacketNumberFilter::disabled()),
         };
         Self {
-            rx_packet_number: None,
+            largest_received_packet_number: None,
             next_packet_number: 0,
             largest_acked_packet: None,
             largest_acked_packet_sent: now,

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -218,7 +218,7 @@ impl IndexMut<SpaceKind> for [PacketSpace; 3] {
 /// this via [`PacketSpace::for_path`].
 pub(super) struct PacketNumberSpace {
     /// Highest received packet number, if any
-    pub(super) rx_packet: Option<u64>,
+    pub(super) rx_packet_number: Option<u64>,
     /// The packet number of the next packet that will be sent, if any. In the Data space, the
     /// packet number stored here is sometimes skipped by [`PacketNumberFilter`] logic.
     pub(super) next_packet_number: u64,
@@ -278,7 +278,7 @@ impl PacketNumberSpace {
             SpaceId::Data => Some(PacketNumberFilter::new(rng)),
         };
         Self {
-            rx_packet: None,
+            rx_packet_number: None,
             next_packet_number: 0,
             largest_acked_packet: None,
             largest_acked_packet_sent: now,
@@ -306,7 +306,7 @@ impl PacketNumberSpace {
             SpaceId::Data => Some(PacketNumberFilter::disabled()),
         };
         Self {
-            rx_packet: None,
+            rx_packet_number: None,
             next_packet_number: 0,
             largest_acked_packet: None,
             largest_acked_packet_sent: now,


### PR DESCRIPTION
## Description

I got really annoyed at the weird variables trying to convey they are
representing the packet number in my last PR. Any many times
before. Finally fix this lazy naming.

## Breaking Changes

n/a

## Notes & open questions

If there is some logic behind the previous naming I failed to grasp
feel free to push back.