### PR TITLE
fix(proto): Move `Connection::app_limited` to `PathData::app_limited`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
  "noq-proto",
  "noq-udp",
  "pin-project-lite",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen",
  "rustc-hash",
  "rustls",
@@ -1881,7 +1881,7 @@ dependencies = [
  "lru-slab",
  "n0-qlog",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_pcg",
  "rcgen",
  "ring",
@@ -2252,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1284,8 +1284,6 @@ impl Connection {
         scheduling_info: &PathSchedulingInfo,
         connection_close_pending: bool,
     ) -> Option<Transmit> {
-        // Unless we experience congestion, we'll be application limited.
-        self.path_data_mut(path_id).app_limited = true;
         // Check if there is at least one active CID to use for sending
         let Some(remote_cid) = self.remote_cids.get(&path_id).map(CidQueue::active) else {
             if !self.abandoned_paths.contains(&path_id) {
@@ -1368,9 +1366,8 @@ impl Connection {
             );
         }
 
-        if congestion_blocked {
-            self.path_data_mut(path_id).app_limited = true;
-        }
+        self.path_data_mut(path_id).app_limited =
+            last_packet_number.is_none() && !congestion_blocked;
 
         match last_packet_number {
             Some(last_packet_number) => {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1035,12 +1035,18 @@ impl Connection {
         // Check whether we need to send a close message
         let connection_close_pending = match self.state.as_type() {
             StateType::Drained => {
+                for path in self.paths.values_mut() {
+                    path.data.app_limited = true;
+                }
                 return None;
             }
             StateType::Draining | StateType::Closed => {
                 // self.connection_close_pending is only reset once the associated packet
                 // had been encoded successfully
                 if !self.connection_close_pending {
+                    for path in self.paths.values_mut() {
+                        path.data.app_limited = true;
+                    }
                     return None;
                 }
                 true

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1515,11 +1515,9 @@ impl Connection {
                         }
                     };
                 }
-            }
 
-            // If the datagram is full (or there never was one started), we need to start a
-            // new one.
-            if transmit.datagram_remaining_mut() == 0 {
+                // If the datagram is full (or there never was one started), we need to start a
+                // new one.
                 if transmit.num_datagrams() >= transmit.max_datagrams().get() {
                     // No more datagrams allowed.
                     // Previous iterations of this loop may have built packets already.
@@ -1536,28 +1534,27 @@ impl Connection {
                     };
                 }
 
-                match self.spaces[space_id].for_path(path_id).loss_probes {
-                    0 => transmit.start_new_datagram(),
-                    _ => {
-                        // We need something to send for a tail-loss probe.
-                        let request_immediate_ack =
-                            space_id == SpaceId::Data && self.peer_supports_ack_frequency();
-                        self.spaces[space_id].queue_tail_loss_probe(
-                            path_id,
-                            request_immediate_ack,
-                            &self.streams,
-                        );
+                if needs_loss_probe {
+                    // Ensure we have something to send for a tail-loss probe.
+                    let request_immediate_ack =
+                        space_id == SpaceId::Data && self.peer_supports_ack_frequency();
+                    self.spaces[space_id].queue_tail_loss_probe(
+                        path_id,
+                        request_immediate_ack,
+                        &self.streams,
+                    );
 
-                        self.spaces[space_id].for_path(path_id).loss_probes -= 1;
+                    self.spaces[space_id].for_path(path_id).loss_probes -= 1; // needs_loss_probe ensures loss_probes > 0
 
-                        // Clamp the datagram to at most the minimum MTU to ensure that loss
-                        // probes can get through and enable recovery even if the path MTU
-                        // has shrank unexpectedly.
-                        transmit.start_new_datagram_with_size(std::cmp::min(
-                            usize::from(INITIAL_MTU),
-                            transmit.segment_size(),
-                        ));
-                    }
+                    // Clamp the datagram to at most the minimum MTU to ensure that loss
+                    // probes can get through and enable recovery even if the path MTU
+                    // has shrank unexpectedly.
+                    transmit.start_new_datagram_with_size(std::cmp::min(
+                        usize::from(INITIAL_MTU),
+                        transmit.segment_size(),
+                    ));
+                } else {
+                    transmit.start_new_datagram();
                 }
                 trace!(count = transmit.num_datagrams(), "new datagram started");
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -230,9 +230,6 @@ pub struct Connection {
     receiving_ecn: bool,
     /// Number of packets authenticated
     total_authed_packets: u64,
-    /// Whether the last `poll_transmit` call yielded no data because there was
-    /// no outgoing application data.
-    app_limited: bool,
 
     //
     // ObservedAddr
@@ -405,7 +402,6 @@ impl Connection {
                 &TransportParameters::default(),
             )),
 
-            app_limited: false,
             receiving_ecn: false,
             total_authed_packets: 0,
 
@@ -1039,14 +1035,12 @@ impl Connection {
         // Check whether we need to send a close message
         let connection_close_pending = match self.state.as_type() {
             StateType::Drained => {
-                self.app_limited = true;
                 return None;
             }
             StateType::Draining | StateType::Closed => {
                 // self.connection_close_pending is only reset once the associated packet
                 // had been encoded successfully
                 if !self.connection_close_pending {
-                    self.app_limited = true;
                     return None;
                 }
                 true
@@ -1069,10 +1063,6 @@ impl Connection {
                 && self.peer_supports_ack_frequency();
         }
 
-        // If we end up not sending anything, we need to know if that was because there was
-        // nothing to send or because we were congestion blocked.
-        let mut congestion_blocked = false;
-
         let mut next_path_id = self.paths.first_entry().map(|e| *e.key());
         while let Some(path_id) = next_path_id {
             if !connection_close_pending
@@ -1082,7 +1072,7 @@ impl Connection {
             }
 
             let info = self.scheduling_info(path_id);
-            match self.poll_transmit_on_path(
+            if let Some(transmit) = self.poll_transmit_on_path(
                 now,
                 buf,
                 path_id,
@@ -1090,21 +1080,15 @@ impl Connection {
                 &info,
                 connection_close_pending,
             ) {
-                PollPathStatus::Send(transmit) => {
-                    return Some(transmit);
-                }
-                PollPathStatus::NothingToSend {
-                    congestion_blocked: cb,
-                } => {
-                    congestion_blocked |= cb;
-                    // Continue checking other paths, tail-loss probes may need to be sent
-                    // in all spaces.
-                    debug_assert!(
-                        buf.is_empty(),
-                        "nothing to send on path but buffer not empty"
-                    );
-                }
+                return Some(transmit);
             }
+
+            // Continue checking other paths, tail-loss probes may need to be sent
+            // in all spaces.
+            debug_assert!(
+                buf.is_empty(),
+                "nothing to send on path but buffer not empty"
+            );
 
             next_path_id = self.paths.keys().find(|i| **i > path_id).copied();
         }
@@ -1114,8 +1098,6 @@ impl Connection {
             buf.is_empty(),
             "there was data in the buffer, but it was not sent"
         );
-
-        self.app_limited = !congestion_blocked;
 
         if self.state.is_established() {
             // Try MTU probing now
@@ -1301,15 +1283,15 @@ impl Connection {
         max_datagrams: NonZeroUsize,
         scheduling_info: &PathSchedulingInfo,
         connection_close_pending: bool,
-    ) -> PollPathStatus {
+    ) -> Option<Transmit> {
+        // Unless we experience congestion, we'll be application limited.
+        self.path_data_mut(path_id).app_limited = true;
         // Check if there is at least one active CID to use for sending
         let Some(remote_cid) = self.remote_cids.get(&path_id).map(CidQueue::active) else {
             if !self.abandoned_paths.contains(&path_id) {
                 debug!(%path_id, "no remote CIDs for path");
             }
-            return PollPathStatus::NothingToSend {
-                congestion_blocked: false,
-            };
+            return None;
         };
 
         // Whether the last packet in the datagram must be padded so the datagram takes up
@@ -1386,6 +1368,10 @@ impl Connection {
             );
         }
 
+        if congestion_blocked {
+            self.path_data_mut(path_id).app_limited = true;
+        }
+
         match last_packet_number {
             Some(last_packet_number) => {
                 // Note that when sending in multiple spaces the last packet number will be
@@ -1395,9 +1381,9 @@ impl Connection {
                     transmit.len() as u64,
                     last_packet_number,
                 );
-                PollPathStatus::Send(self.build_transmit(path_id, transmit))
+                Some(self.build_transmit(path_id, transmit))
             }
-            None => PollPathStatus::NothingToSend { congestion_blocked },
+            None => None,
         }
     }
 
@@ -2899,8 +2885,8 @@ impl Connection {
         }
 
         let largest_ackd = self.spaces[space].for_path(path).largest_acked_packet;
-        let app_limited = self.app_limited;
         let path_data = self.path_data_mut(path);
+        let app_limited = path_data.app_limited;
         let in_flight = path_data.in_flight.bytes;
 
         path_data
@@ -3040,8 +3026,8 @@ impl Connection {
     // Not timing-aware, so it's safe to call this for inferred acks, such as arise from
     // high-latency handshakes
     fn on_packet_acked(&mut self, now: Instant, path_id: PathId, info: SentPacket) {
-        let app_limited = self.app_limited;
         let path = self.path_data_mut(path_id);
+        let app_limited = path.app_limited;
         path.remove_in_flight(&info);
         if info.ack_eliciting && info.path_generation == path.generation() {
             // Only pass ACKs to the congestion controller if it belongs to this exact
@@ -7125,18 +7111,6 @@ pub trait NetworkChangeHint: std::fmt::Debug + 'static {
     ///
     /// Paths that are deemed recoverable will simply be sent a PING for a liveness check.
     fn is_path_recoverable(&self, path_id: PathId, network_path: FourTuple) -> bool;
-}
-
-/// Return value for [`Connection::poll_transmit_on_path`].
-#[derive(Debug)]
-enum PollPathStatus {
-    /// Nothing to send on the path, nothing was written into the [`TransmitBuf`].
-    NothingToSend {
-        /// If true there was data to send but congestion control did not allow so.
-        congestion_blocked: bool,
-    },
-    /// The transmit is ready to be sent.
-    Send(Transmit),
 }
 
 /// Return value for [`Connection::poll_transmit_path_space`].

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -145,8 +145,17 @@ pub(super) struct PathData {
     pub(super) congestion: Box<dyn congestion::Controller>,
     /// Pacing state
     pub(super) pacing: Pacer,
-    /// Whether the last `poll_transmit` call yielded no data because there was
+    /// Whether the last `poll_transmit_on_path` call yielded no data because there was
     /// no outgoing application data.
+    ///
+    /// The RFC writes:
+    /// > When bytes in flight is smaller than the congestion window and sending is not pacing limited,
+    /// > the congestion window is underutilized. This can happen due to insufficient application data
+    /// > or flow control limits. When this occurs, the congestion window SHOULD NOT be increased in
+    /// > either slow start or congestion avoidance.
+    /// (RFC9002, section 7.8)
+    ///
+    /// I.e. when app_limited is true, the congestion controller doesn't increase the congestion window.
     pub(super) app_limited: bool,
 
     /// Path challenges sent (on the wire, on-path) that we didn't receive a path response for yet

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -145,6 +145,10 @@ pub(super) struct PathData {
     pub(super) congestion: Box<dyn congestion::Controller>,
     /// Pacing state
     pub(super) pacing: Pacer,
+    /// Whether the last `poll_transmit` call yielded no data because there was
+    /// no outgoing application data.
+    pub(super) app_limited: bool,
+
     /// Path challenges sent (on the wire, on-path) that we didn't receive a path response for yet
     on_path_challenges_unconfirmed: IntMap<u64, SentChallengeInfo>,
     /// Path challenges sent (on the wire, off-path) that we didn't receive a path response for yet
@@ -282,6 +286,7 @@ impl PathData {
                 now,
             ),
             congestion,
+            app_limited: false,
             on_path_challenges_unconfirmed: Default::default(),
             off_path_challenges_unconfirmed: Default::default(),
             pending_on_path_challenge: false,
@@ -339,6 +344,7 @@ impl PathData {
             pacing: Pacer::new(smoothed_rtt, congestion.window(), prev.current_mtu(), now),
             sending_ecn: true,
             congestion,
+            app_limited: false,
             on_path_challenges_unconfirmed: Default::default(),
             off_path_challenges_unconfirmed: Default::default(),
             pending_on_path_challenge: false,

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -153,6 +153,7 @@ pub(super) struct PathData {
     /// > the congestion window is underutilized. This can happen due to insufficient application data
     /// > or flow control limits. When this occurs, the congestion window SHOULD NOT be increased in
     /// > either slow start or congestion avoidance.
+    ///
     /// (RFC9002, section 7.8)
     ///
     /// I.e. when app_limited is true, the congestion controller doesn't increase the congestion window.


### PR DESCRIPTION
## Description

- Does what the PR title says
- Also some small cleanups in `poll_transmit_path_space`, if I may.

Context for what `app_limited` is:
> When bytes in flight is smaller than the congestion window and sending is not pacing limited, the congestion window is underutilized. This can happen due to insufficient application data or flow control limits. When this occurs, the congestion window SHOULD NOT be increased in either slow start or congestion avoidance.
https://www.rfc-editor.org/rfc/rfc9002.html#section-7.8

I.e. when `app_limited` is `true`, the congestion controller doesn't increase the congestion window.
You can see this in `Cubic::on_ack` where it outright immediately bails, doing nothing, when `app_limited` is `true`.

Because all paths have their own congestion window, they need to track whether they're application limited separately.
Otherwise it's possible that there's a situation where one path is never exercised fully (e.g. a backup path), while another path is saturated with application data. Previously, the application data path would set the connection-wide `app_limited` to `false`, causing the backup path (that never experiences congestion) to inflate its congestion window.

With this change, the backup path would know it's not application limited and pass that correct information to the congestion controller.
