### PR TITLE
perf: reuse response_buffer across datagrams in recv loop

### DIFF
--- a/noq/src/endpoint.rs
+++ b/noq/src/endpoint.rs
@@ -864,6 +864,7 @@ impl RecvState {
         now: Instant,
     ) -> Result<PollProgress, io::Error> {
         let mut received_connection_packet = false;
+        let mut response_buffer = Vec::new();
         let mut metas = [RecvMeta::default(); BATCH_SIZE];
         let mut iovs: [IoSliceMut<'_>; BATCH_SIZE] = {
             let mut bufs = self
@@ -884,7 +885,7 @@ impl RecvState {
                         let mut data: BytesMut = buf[0..meta.len].into();
                         while !data.is_empty() {
                             let buf = data.split_to(meta.stride.min(data.len()));
-                            let mut response_buffer = Vec::new();
+                            response_buffer.clear();
                             let addresses = FourTuple::new(meta.addr, meta.dst_ip);
                             match endpoint.handle(
                                 now,


### PR DESCRIPTION
## Summary

- Move `response_buffer` `Vec` allocation out of the innermost per-datagram-stride loop in `RecvState::poll_socket` and reuse it via `clear()`
- Previously a new `Vec` was heap-allocated for every single datagram stride processed in the receive hot path
- With `recvmmsg` batching up to 32 datagrams per syscall and GRO potentially coalescing further, this eliminates one allocation per datagram

The proto layer writes fresh data into the buffer on each `endpoint.handle()` call, so reuse via `clear()` is safe — the buffer contents from a previous iteration are never read.

## Test plan

- [x] `cargo check -p noq` passes
- [x] `cargo test -p noq --lib` — all 26 tests pass
- [ ] Existing CI benchmarks should show no regression