### PR TITLE
feat(perf): add dhat heap allocation profiling support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn",
 ]
@@ -932,6 +932,22 @@ dependencies = [
  "rustc_version",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1679,7 +1695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -1785,6 +1801,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,7 +1867,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.10.0",
  "rcgen",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "sharded-slab",
  "smol",
@@ -1885,7 +1907,7 @@ dependencies = [
  "rand_pcg",
  "rcgen",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2041,6 +2063,7 @@ dependencies = [
  "bytes",
  "clap",
  "console-subscriber",
+ "dhat",
  "hdrhistogram",
  "noq",
  "noq-proto",
@@ -2385,6 +2408,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -2855,6 +2884,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "4.5", features = ["derive"] }
 crc = "3"
 criterion = { version = "0.7", default-features = false, features = ["async_tokio"] }
 derive_more = { version = "2.1.0", features = ["debug", "deref", "deref_mut", "display", "from", "add", "add_assign"] }
+dhat = "0.3"
 directories-next = "2"
 enum-assoc = "1.3.0"
 fastbloom = { version = "0.17", default-features = false }

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -23,12 +23,18 @@ qlog = ["noq/qlog"]
 # WARNING: it requires special compilation flags
 #    RUSTFLAGS="--cfg tokio_unstable" cargo build -r -p perf -F tokio-console
 tokio-console = ["console-subscriber"]
+# Enable heap allocation profiling via dhat
+#    cargo build -r -p perf -F dhat-heap
+# Run the resulting binary normally; on exit it writes dhat-heap.json
+# Visualize at https://nnethercote.github.io/dh_view/dh_view.html
+dhat-heap = ["dhat"]
 
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 console-subscriber = { version = "0.5.0", features = ["parking_lot"], optional = true }
+dhat = { workspace = true, optional = true }
 hdrhistogram = { workspace = true }
 noq = { package = "noq", path = "../noq" }
 noq-proto = { package = "noq-proto", path = "../noq-proto" }

--- a/perf/src/bin/perf.rs
+++ b/perf/src/bin/perf.rs
@@ -4,8 +4,15 @@ use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::Subs
 
 use perf::{client, server};
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _profiler = dhat::Profiler::new_heap();
+
     let opt = Cli::parse();
 
     let registry = tracing_subscriber::registry();


### PR DESCRIPTION
## Summary

- Add an optional `dhat-heap` feature flag to the perf binary for heap allocation profiling
- When enabled, instruments all allocations and writes `dhat-heap.json` on exit
- Profile can be visualized at https://nnethercote.github.io/dh_view/dh_view.html
- Zero cost when not enabled — entirely opt-in, follows the same pattern as the existing `tokio-console` feature

## Usage

```bash
# Build with profiling enabled
cargo build -r -p perf -F dhat-heap

# Run server and client as normal
./target/release/noq-perf server --listen [::]:4433 &
./target/release/noq-perf client localhost:4433 --download-size 100M

# dhat-heap.json is written on process exit
# Open it at https://nnethercote.github.io/dh_view/dh_view.html
```

## Motivation

The existing benchmarks measure throughput and latency at the application level, but there is currently no way to measure allocation rates or identify allocation hotspots in the receive/transmit paths. This makes it difficult to quantify the impact of allocation-reducing optimizations.

dhat provides per-callsite allocation counts, total bytes allocated, peak heap size, and allocation lifetimes — exactly what's needed to evaluate changes to buffer management and packet processing paths.

## Test plan

- [x] `cargo check -p perf` — default build unaffected
- [x] `cargo check -p perf -F dhat-heap` — feature build compiles cleanly
- [ ] Existing CI should pass (no changes to default feature set)