### PR TITLE
fix(proto): prevent DoS via unbounded ACK ranges and packet number panic

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -6813,7 +6813,7 @@ impl Connection {
                 .largest_acked_packet
                 .unwrap_or(0),
         )
-        .len();
+        .map_or(4, PacketNumber::len);
 
         // 1 byte for flags
         1 + self

--- a/noq-proto/src/connection/packet_builder.rs
+++ b/noq-proto/src/connection/packet_builder.rs
@@ -95,10 +95,13 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
         let packet_number = space.for_path(path_id).get_tx_number(&mut conn.rng);
         let span = trace_span!("send", space = ?space_id, pn = packet_number, %path_id).entered();
 
-        let number = PacketNumber::new(
+        let Some(number) = PacketNumber::new(
             packet_number,
             space.for_path(path_id).largest_acked_packet.unwrap_or(0),
-        );
+        ) else {
+            debug!("packet number too large to encode");
+            return None;
+        };
         let header = match level {
             EncryptionLevel::OneRtt => Header::Short {
                 dst_cid,

--- a/noq-proto/src/frame.rs
+++ b/noq-proto/src/frame.rs
@@ -1757,9 +1757,17 @@ impl From<InvalidFrame> for TransportError {
 /// - ACK Ranges
 ///
 /// Ref <https://www.rfc-editor.org/rfc/rfc9000.html#name-ack-ranges>
+/// Maximum number of ACK ranges we accept per ACK frame. RFC 9000 does not mandate a specific
+/// limit, but an unbounded count allows a single small packet to cause near-infinite processing.
+/// 512 ranges is generous — legitimate peers rarely exceed a few dozen.
+const MAX_ACK_RANGES: u64 = 512;
+
 fn read_ack_blocks(buf: &mut Bytes, mut largest: u64) -> Result<ArrayRangeSet, IterErr> {
     // Ack Range Count
     let num_blocks = buf.get_var()?;
+    if num_blocks > MAX_ACK_RANGES {
+        return Err(IterErr::Malformed);
+    }
 
     let mut out = ArrayRangeSet::new();
     let mut block_to_block;

--- a/noq-proto/src/packet.rs
+++ b/noq-proto/src/packet.rs
@@ -1009,7 +1009,12 @@ mod tests {
     fn pn_expand_roundtrip() {
         for expected in 0..1024 {
             for actual in expected..1024 {
-                assert_eq!(actual, PacketNumber::new(actual, expected).unwrap().expand(expected));
+                assert_eq!(
+                    actual,
+                    PacketNumber::new(actual, expected)
+                        .unwrap()
+                        .expand(expected)
+                );
             }
         }
     }

--- a/noq-proto/src/packet.rs
+++ b/noq-proto/src/packet.rs
@@ -737,18 +737,18 @@ pub(crate) enum PacketNumber {
 }
 
 impl PacketNumber {
-    pub(crate) fn new(n: u64, largest_acked: u64) -> Self {
+    pub(crate) fn new(n: u64, largest_acked: u64) -> Option<Self> {
         let range = (n - largest_acked) * 2;
         if range < 1 << 8 {
-            Self::U8(n as u8)
+            Some(Self::U8(n as u8))
         } else if range < 1 << 16 {
-            Self::U16(n as u16)
+            Some(Self::U16(n as u16))
         } else if range < 1 << 24 {
-            Self::U24(n as u32)
+            Some(Self::U24(n as u32))
         } else if range < 1 << 32 {
-            Self::U32(n as u32)
+            Some(Self::U32(n as u32))
         } else {
-            panic!("packet number too large to encode")
+            None
         }
     }
 
@@ -1000,16 +1000,16 @@ mod tests {
 
     #[test]
     fn pn_encode() {
-        check_pn(PacketNumber::new(0x10, 0), &hex!("10"));
-        check_pn(PacketNumber::new(0x100, 0), &hex!("0100"));
-        check_pn(PacketNumber::new(0x10000, 0), &hex!("010000"));
+        check_pn(PacketNumber::new(0x10, 0).unwrap(), &hex!("10"));
+        check_pn(PacketNumber::new(0x100, 0).unwrap(), &hex!("0100"));
+        check_pn(PacketNumber::new(0x10000, 0).unwrap(), &hex!("010000"));
     }
 
     #[test]
     fn pn_expand_roundtrip() {
         for expected in 0..1024 {
             for actual in expected..1024 {
-                assert_eq!(actual, PacketNumber::new(actual, expected).expand(expected));
+                assert_eq!(actual, PacketNumber::new(actual, expected).unwrap().expand(expected));
             }
         }
     }


### PR DESCRIPTION
## Summary

Two security fixes for issues reachable from untrusted network input:

**1. Unbounded ACK range count → CPU exhaustion (Critical)**

`read_ack_blocks()` parsed the ACK Range Count field as a VarInt (max 2^62 − 1) with no upper bound, then looped that many times. A single ~100-byte malformed ACK frame could spin a connection handler for effectively forever.

Fix: cap at 512 ranges. RFC 9000 §19.3.1 does not mandate a specific limit; legitimate peers rarely exceed a few dozen ranges.

**2. `PacketNumber::new()` panic → process crash (Critical)**

The function panicked when the packet number range exceeded 2^32, which is reachable via crafted ACK data that shifts `largest_acked` far from the actual packet number. This crashes the entire process.

Fix: return `Option<PacketNumber>` instead of panicking. Callers handle `None` gracefully — `PacketBuilder` skips the packet, `predict_1rtt_overhead` falls back to max length (4 bytes).

## Test plan

- [x] `cargo check -p noq-proto` compiles
- [x] `cargo test -p noq-proto` — all 351 tests + 3 doctests pass
- [x] `cargo test -p noq --lib` — all 26 tests pass
- [ ] CI should pass with no regressions