### PR TITLE
chore: Add more cargo-make targets and update CI template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,17 @@
 
 ## Notes & open questions
 
-<!-- Any notes, remarks or open questions you have to make about the PR. -->
+<!-- Any notes, remarks or open questions you have to make about the -->
+<!-- PR. -->
+
+## Change checklist
+<!-- Remove any that are not relevant. -->
+- [ ] Self-review.
+- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
+- [ ] Tests if relevant.
+- [ ] All breaking changes documented.
+
+<!--
+tip:
+   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
+-->

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,26 @@
 # Use cargo-make to run tasks here: https://crates.io/crates/cargo-make
 
+[config]
+skip_core_tasks = true
+default_to_workspace = false
+
+[tasks.default]
+alias = "dev-flow"
+
+[tasks.dev-flow]
+description = "Fast local sub-set of all CI checks"
+dependencies = [
+     "format-check",
+     "check",
+     "clippy",
+     "doc",
+     "test",
+     "proptests-extralight",
+]
+
+
 [tasks.format]
-workspace = false
+description = "Format the rust files following style rules"
 command = "cargo"
 args = [
      "fmt",
@@ -14,7 +33,7 @@ args = [
 ]
 
 [tasks.format-check]
-workspace = false
+description = "Check the rust files for formatting style"
 command = "cargo"
 args = [
      "fmt",
@@ -27,18 +46,49 @@ args = [
      "imports_granularity=Crate,group_imports=Preserve,reorder_imports=false,format_code_in_doc_comments=true",
 ]
 
+[tasks.check]
+description = "Run cargo-check for entire project"
+command = "cargo"
+args = ["check", "--workspace", "--all-features", "--all-targets"]
+
+[tasks.clippy]
+description = "Run cargo-clippy for entire project"
+command = "cargo"
+args = ["clippy", "--workspace", "--all-features", "--all-targets"]
+
+[tasks.doc]
+description = "Check the documentation build"
+command = "cargo"
+args = ["doc", "--workspace", "--all-features", "--no-deps", "--document-private-items"]
+
+[tasks.test]
+description = "Run unit tests"
+command = "cargo"
+args = [
+     "nextest",
+     "run",
+     "--workspace",
+     "--all-features",
+     "--exclude=fuzz",
+     "--lib",
+     "--bins",
+     "--tests",
+     "--no-fail-fast",
+]
+
 [tasks.proptests-long]
-# Run proptests with high case count (runs for ~10 minutes)
-# Usage: cargo make proptests-long
-workspace = false
+description = "Run proptests with high case count (runs for ~10 minutes)"
 command = "cargo"
 args = ["nextest", "run", "-P", "proptests", "--no-fail-fast"]
 env = { "PROPTEST_CASES" = "100000" }
 
 [tasks.proptests-light]
-# Run proptests for CI (~1 minute)
-# Usage: cargo make proptests-light
-workspace = false
+description = "Run proptests for CI (~1 minute)"
 command = "cargo"
 args = ["nextest", "run", "-P", "proptests", "--no-fail-fast"]
 env = { "PROPTEST_CASES" = "10000" }
+
+[tasks.proptests-extralight]
+description = "Run proptests in regression-only mode (runs for <5 seconds)"
+command = "cargo"
+args = ["nextest", "run", "-P", "proptests", "--no-fail-fast"]

--- a/noq/src/event_stream.rs
+++ b/noq/src/event_stream.rs
@@ -9,8 +9,8 @@ use proto::PathEvent;
 use proto::n0_nat_traversal;
 use thiserror::Error;
 use tokio::sync::{broadcast, watch};
-use tokio_stream::wrappers::{BroadcastStream, WatchStream, errors::BroadcastStreamRecvError};
 use tokio_stream::Stream;
+use tokio_stream::wrappers::{BroadcastStream, WatchStream, errors::BroadcastStreamRecvError};
 
 /// The receiver lagged too far behind.
 ///

--- a/noq/src/lib.rs
+++ b/noq/src/lib.rs
@@ -79,8 +79,8 @@ pub use crate::connection::{
     AcceptBi, AcceptUni, Connecting, Connection, OnClosed, OpenBi, OpenUni, ReadDatagram,
     SendDatagram, SendDatagramError, WeakConnectionHandle, ZeroRttAccepted,
 };
-pub use crate::event_stream::{ObservedExternalAddr, Lagged, NatTraversalUpdates, PathEvents};
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};
+pub use crate::event_stream::{Lagged, NatTraversalUpdates, ObservedExternalAddr, PathEvents};
 pub use crate::incoming::{Incoming, IncomingFuture, RetryError};
 pub use crate::path::{AddressDiscovery, OpenPath, Path, WeakPathHandle};
 pub use crate::recv_stream::{


### PR DESCRIPTION
## Description

- More cargo-make targets:
  - Disable all the built-in targets
  - Add steps that will otherwise fail on CI
- Add checklist to PR template
  - Also point to cargo-make

## Breaking Changes

n/a

## Notes & open questions

I'm not sure if the pointer to cargo-make is clear enough. I
considered making it a checkbox but that probably also gets annoying
for frequent contributors.