### PR TITLE
refactor(docs): describe PathData vs PacketNumberSpace

### DIFF
--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -134,7 +134,31 @@ pub(super) struct SentChallengeInfo {
     pub(super) network_path: FourTuple,
 }
 
-/// Description of a particular network path
+/// State of particular network path 4-tuple within a [`PacketNumberSpace`].
+///
+/// With QUIC-Multipath a path is identified by a [`PathId`] and it is possible to have
+/// multiple paths on the same 4-tuple. Furthermore a single QUIC-Multipath path can migrate
+/// to a different 4-tuple, in a similar manner as an RFC9000 connection can use "path
+/// migration" to move to a different 4-tuple. There are thus two states we keep for paths:
+///
+/// - [`PacketNumberSpace`]: The state for a single packet number space, i.e. [`PathId`],
+///   which remains in place across path migrations to different 4-tuples.
+///
+///   This is stored in [`PacketSpace::number_spaces`] indexed on [`PathId`].
+///
+/// - [`PathData`]: The state we keep for each unique 4-tuple within a space. Of note is
+///   that a single [`PathData`] can never belong to a diffferent [`PacketNumberSpace`].
+///
+///   This is stored in [`Connection::paths`] indexed by the current [`PathId`] for which
+///   space it exists. Either as the primary 4-tuple or as the previous 4-tuple just after a
+///   migration.
+///
+/// It follows that there might be several [`PathData`] structs for the same 4-tuple if
+/// several spaces are sharing the same 4-tuple. Note that during the handshake, the
+/// Initial, Handshake and Data spaces for [`PathId::ZERO`] all share the same [`PathData`].
+///
+/// [`PacketSpace::number_spaces`]: super::spaces::PacketSpace::number_spaces
+/// [`Connection::paths`]: super::Connection::paths
 #[derive(Debug)]
 pub(super) struct PathData {
     pub(super) network_path: FourTuple,

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -147,7 +147,7 @@ pub(super) struct SentChallengeInfo {
 ///   This is stored in [`PacketSpace::number_spaces`] indexed on [`PathId`].
 ///
 /// - [`PathData`]: The state we keep for each unique 4-tuple within a space. Of note is
-///   that a single [`PathData`] can never belong to a diffferent [`PacketNumberSpace`].
+///   that a single [`PathData`] can never belong to a different [`PacketNumberSpace`].
 ///
 ///   This is stored in [`Connection::paths`] indexed by the current [`PathId`] for which
 ///   space it exists. Either as the primary 4-tuple or as the previous 4-tuple just after a

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -212,10 +212,19 @@ impl IndexMut<SpaceKind> for [PacketSpace; 3] {
     }
 }
 
-/// The per-path packet number space to support multipath.
+/// The state of a single packet number space.
 ///
-/// This contains the data specific to a per-path packet number space.  You should access
-/// this via [`PacketSpace::for_path`].
+/// In RFC9000 there are 3 packet number spaces: Initial, Handshake and Data. In QUIC
+/// Multipath there multiple packet number spaces for Data, each identified by a single
+/// [`PathId`].
+///
+/// This contains the state for a packet number space which is not specific to the 4-tuple
+/// this space is currently using. The 4-tuple specific state, like congestion controller,
+/// pacing, ECN, MTU etc, is stored in [`PathData`].
+///
+/// You should access this via [`PacketSpace::for_path`].
+///
+/// [`PathData`]: super::paths::PathData
 pub(super) struct PacketNumberSpace {
     /// Highest received packet number, if any
     pub(super) largest_received_packet_number: Option<u64>,

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -215,7 +215,7 @@ impl IndexMut<SpaceKind> for [PacketSpace; 3] {
 /// The state of a single packet number space.
 ///
 /// In RFC9000 there are 3 packet number spaces: Initial, Handshake and Data. In QUIC
-/// Multipath there multiple packet number spaces for Data, each identified by a single
+/// Multipath there are multiple packet number spaces for Data, each identified by a
 /// [`PathId`].
 ///
 /// This contains the state for a packet number space which is not specific to the 4-tuple


### PR DESCRIPTION
## Description

The careful reader will notice that fields are in the wrong
struct. This is natural because both of these are identified by PathId
and it is very confusing. Cleaning this up comes later.

## Breaking Changes

Not, yet.

## Notes & open questions

We have a lot of state in the wrong place:

- `PathData::off_path_challenges_unconfirmed` (the reason I'm here)
- `PathData::status`
- `PathData::open_status`
- `PathData::draining`
- `PacketNumberSpace::ecn_counters`
- `PacketNumberSpace::ecn_feedback`

I suggest we file issues for this, because I tried to move
`PathData::status` and it ends up moving so much code. End we get to
grapple with naming issues because e.g. `enum PathStatus` would then
be defined in a file called `spaces.rs`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.