### PR TITLE
fix(proto): Gracefully handle invalid PATH_ACK frames

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4816,6 +4816,11 @@ impl Connection {
                     self.on_ack_received(now, SpaceId::Data, ack)?;
                 }
                 Frame::PathAck(ack) => {
+                    if !self.is_multipath_negotiated() {
+                        return Err(TransportError::PROTOCOL_VIOLATION(
+                            "received PATH_ACK frame when multipath was not negotiated",
+                        ));
+                    }
                     span.record("path", tracing::field::display(&ack.path_id));
                     self.on_path_ack_received(now, SpaceId::Data, ack)?;
                 }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2801,16 +2801,20 @@ impl Connection {
         path: PathId,
         ack: frame::Ack,
     ) -> Result<(), TransportError> {
-        if !self.spaces[space].number_spaces.contains_key(&path)
-            && self.abandoned_paths.contains(&path)
-        {
-            // See also
-            // https://www.ietf.org/archive/id/draft-ietf-quic-multipath-21.html#section-3.4.3-3
-            // > When an endpoint finally deletes all state associated with the path [...]
-            // > PATH_ACK frames received with an abandoned path ID are silently ignored,
-            // > as specified in Section 4.
-            trace!("silently ignoring PATH_ACK on discarded path");
-            return Ok(());
+        if !self.spaces[space].number_spaces.contains_key(&path) {
+            if self.abandoned_paths.contains(&path) {
+                // See also
+                // https://www.ietf.org/archive/id/draft-ietf-quic-multipath-21.html#section-3.4.3-3
+                // > When an endpoint finally deletes all state associated with the path [...]
+                // > PATH_ACK frames received with an abandoned path ID are silently ignored,
+                // > as specified in Section 4.
+                trace!("silently ignoring PATH_ACK on discarded path");
+                return Ok(());
+            } else {
+                return Err(TransportError::PROTOCOL_VIOLATION(
+                    "received PATH_ACK with path ID never used",
+                ));
+            }
         }
         if ack.largest >= self.spaces[space].for_path(path).next_packet_number {
             return Err(TransportError::PROTOCOL_VIOLATION("unsent packet acked"));


### PR DESCRIPTION
## Description

This fixes some bugs found via #585.

When a connection doesn't support multipath, or it receives a malicious or misconstructed PATH_ACK frame that has e.g. a `path_id` of `1`, which the current connection may not actually have any state for, this would previously cause us to panic.

With this change we exit out with a PROTOCOL_VIOLATION connection close instead.

## Notes & open questions

I don't have a regression test for this yet. It is generated in #585 and uses the test setup from #589, which both aren't merged yet.

I'll make sure to re-generate the regression test and add it in #585 once that's ready.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
