### PR TITLE
feat(tests): Add a router with NAT functionality to proto tests

### DIFF
--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -552,10 +552,9 @@ fn zero_rtt_happypath() {
         .close(pair.time, VarInt(0), [][..].into());
     pair.drive();
 
-    pair.client.addr = SocketAddr::new(
-        Ipv6Addr::LOCALHOST.into(),
-        CLIENT_PORTS.lock().unwrap().next().unwrap(),
-    );
+    pair.client.addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1);
+    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
+    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
     info!("resuming session");
     let client_ch = pair.begin_connect(config);
     assert!(pair.client_conn_mut(client_ch).has_0rtt());
@@ -733,10 +732,9 @@ fn test_zero_rtt_incoming_limit<F: FnOnce(&mut ServerConfig)>(configure_server: 
         .close(pair.time, VarInt(0), [][..].into());
     pair.drive();
 
-    pair.client.addr = SocketAddr::new(
-        Ipv6Addr::LOCALHOST.into(),
-        CLIENT_PORTS.lock().unwrap().next().unwrap(),
-    );
+    pair.client.addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1);
+    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
+    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
     info!("resuming session");
     pair.server.handle_incoming = Box::new(|_| IncomingConnectionBehavior::Wait);
     let client_ch = pair.begin_connect(config);
@@ -1342,10 +1340,9 @@ fn close_from_migrated_address() {
     pair.drive();
 
     // Change client address - server will see this as migration
-    pair.client.addr = SocketAddr::new(
-        Ipv4Addr::new(127, 0, 0, 1).into(),
-        CLIENT_PORTS.lock().unwrap().next().unwrap(),
-    );
+    pair.client.addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1);
+    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
+    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
 
     // Client closes connection from the NEW address.  The server will see the migration and
     // close the connection on the new address.
@@ -1397,10 +1394,9 @@ fn migration() {
 
     let client_stats_after_connect = pair.client_conn_mut(client_ch).stats();
 
-    pair.client.addr = SocketAddr::new(
-        Ipv4Addr::new(127, 0, 0, 1).into(),
-        CLIENT_PORTS.lock().unwrap().next().unwrap(),
-    );
+    pair.client.addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1);
+    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
+    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
     pair.client_conn_mut(client_ch).ping();
 
     // Assert that just receiving the ping message is accounted into the servers
@@ -2628,10 +2624,9 @@ fn migrate_detects_new_mtu_and_respects_original_peer_max_udp_payload_size() {
 
     // Migrate client to a different port (and simulate a higher path MTU)
     pair.mtu = 1500;
-    pair.client.addr = SocketAddr::new(
-        Ipv4Addr::new(127, 0, 0, 1).into(),
-        CLIENT_PORTS.lock().unwrap().next().unwrap(),
-    );
+    pair.client.addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1);
+    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
+    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
     pair.client_conn_mut(client_ch).ping();
     pair.drive();
 
@@ -3718,10 +3713,9 @@ fn address_discovery_zero_rtt_accepted() {
         .close(pair.time, VarInt(0), [][..].into());
     pair.drive();
 
-    pair.client.addr = SocketAddr::new(
-        Ipv6Addr::LOCALHOST.into(),
-        CLIENT_PORTS.lock().unwrap().next().unwrap(),
-    );
+    pair.client.addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1);
+    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
+    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
     info!("resuming session");
     let client_ch = pair.begin_connect(alt_client_cfg);
     assert!(pair.client_conn_mut(client_ch).has_0rtt());

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -16,10 +16,12 @@ use crate::{
     LOCAL_CID_COUNT, NetworkChangeHint, PathId, PathStatus, RandomConnectionIdGenerator,
     ServerConfig, Side::*, TransportConfig, cid_queue::CidQueue,
 };
-use crate::{ClosePathError, Dir, Event, PathAbandonReason, PathEvent, StreamEvent, TransportErrorCode};
+use crate::{
+    ClosePathError, Dir, Event, PathAbandonReason, PathEvent, StreamEvent, TransportErrorCode,
+};
 
 use super::util::{min_opt, subscribe};
-use super::{Pair, client_config, server_config};
+use super::{EndpointIndepedentNatRoutingTable, Pair, client_config, server_config};
 
 const MAX_PATHS: u32 = 3;
 
@@ -545,10 +547,10 @@ fn open_path_ensure_after_abandon() -> TestResult {
     let mut second_server_addr = pair.server.addr;
     second_client_addr.set_port(second_client_addr.port() + 1);
     second_server_addr.set_port(second_server_addr.port() + 1);
-    pair.routes = Some(RoutingTable::simple_symmetric(
+    pair.routes = Some(Box::new(RoutingTable::simple_symmetric(
         [pair.client.addr, second_client_addr],
         [pair.server.addr, second_server_addr],
-    ));
+    )));
 
     let second_path = FourTuple {
         local_ip: Some(second_client_addr.ip()),
@@ -1425,10 +1427,10 @@ fn abandon_cycle() -> TestResult {
         sa.set_port(sa.port() + i);
         addrs_server.push(sa);
     }
-    pair.routes = Some(RoutingTable::simple_symmetric(
+    pair.routes = Some(Box::new(RoutingTable::simple_symmetric(
         addrs_client.clone(),
         addrs_server.clone(),
-    ));
+    )));
 
     // Cycle: open a second path, abandon path 0, verify cleanup, repeat with new paths.
     // Each cycle uses a fresh pair of addresses.
@@ -1623,6 +1625,30 @@ fn path_recovers_after_silent_gap_via_keepalive() -> TestResult {
         received_post_gap,
         "client should receive data after the gap recovers"
     );
+
+    Ok(())
+}
+
+/// Tests NAT traversal manages to open a 2nd path.
+///
+/// There is no NAT involved, all paths are open already.
+#[test]
+fn test_simple_nat_traveral_opens_path() -> TestResult {
+    let _guard = subscribe();
+    let mut pair = multipath_pair_with_nat_traversal(true);
+
+    info!("setting routes, adding addrs");
+    pair.routes = Some(Box::new(EndpointIndepedentNatRoutingTable::new()));
+    pair.add_nat_traversal_address(Server, EndpointIndepedentNatRoutingTable::SERVER_NAT)?;
+    pair.add_nat_traversal_address(Client, EndpointIndepedentNatRoutingTable::CLIENT_NAT)?;
+    pair.drive();
+
+    info!("init NAT traversal");
+    pair.initiate_nat_traversal_round(Client)?;
+
+    pair.drive();
+
+    // TODO
 
     Ok(())
 }

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1629,8 +1629,6 @@ fn path_recovers_after_silent_gap_via_keepalive() -> TestResult {
 }
 
 /// Tests NAT traversal manages to open a 2nd path.
-///
-/// There is no NAT involved, all paths are open already.
 #[test]
 fn test_simple_nat_traveral_opens_path() -> TestResult {
     let _guard = subscribe();

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 use super::util::{min_opt, subscribe};
-use super::{EndpointIndepedentNatRoutingTable, Pair, client_config, server_config};
+use super::{Pair, SimpleFirewallRoutingTable, client_config, server_config};
 
 const MAX_PATHS: u32 = 3;
 
@@ -1635,9 +1635,9 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     let mut pair = multipath_pair_with_nat_traversal(true);
 
     info!("setting routes, adding addrs");
-    pair.routes = Some(Box::new(EndpointIndepedentNatRoutingTable::new()));
-    pair.add_nat_traversal_address(Server, EndpointIndepedentNatRoutingTable::SERVER_NAT)?;
-    pair.add_nat_traversal_address(Client, EndpointIndepedentNatRoutingTable::CLIENT_NAT)?;
+    pair.routes = Some(Box::new(SimpleFirewallRoutingTable::new()));
+    pair.add_nat_traversal_address(Server, SimpleFirewallRoutingTable::SERVER_FW_ADDR)?;
+    pair.add_nat_traversal_address(Client, SimpleFirewallRoutingTable::CLIENT_FW_ADDR)?;
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -16,9 +16,7 @@ use crate::{
     LOCAL_CID_COUNT, NetworkChangeHint, PathId, PathStatus, RandomConnectionIdGenerator,
     ServerConfig, Side::*, TransportConfig, cid_queue::CidQueue,
 };
-use crate::{
-    ClosePathError, Dir, Event, PathAbandonReason, PathEvent, StreamEvent, TransportErrorCode,
-};
+use crate::{ClosePathError, Dir, Event, PathAbandonReason, PathEvent, StreamEvent, TransportErrorCode};
 
 use super::util::{min_opt, subscribe};
 use super::{EndpointIndepedentNatRoutingTable, Pair, client_config, server_config};

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -10,7 +10,7 @@ use testresult::TestResult;
 use tracing::info;
 
 use crate::tests::RoutingTable;
-use crate::tests::util::{CLIENT_PORTS, ConnPair, SERVER_PORTS};
+use crate::tests::util::ConnPair;
 use crate::{
     ClientConfig, ConnectionId, ConnectionIdGenerator, Endpoint, EndpointConfig, FourTuple,
     LOCAL_CID_COUNT, NetworkChangeHint, PathId, PathStatus, RandomConnectionIdGenerator,
@@ -476,12 +476,11 @@ fn open_path_validation_fails_server_side() -> TestResult {
     let mut pair = multipath_pair();
 
     let different_addr = FourTuple {
-        remote: SocketAddr::new(
-            [9, 8, 7, 6].into(),
-            SERVER_PORTS.lock()?.next().ok_or("no port")?,
-        ),
+        remote: SocketAddr::new([9, 8, 7, 6].into(), 5),
         local_ip: None,
     };
+    assert_ne!(different_addr.remote, Pair::SERVER_ADDR);
+    assert_ne!(different_addr.remote, Pair::CLIENT_ADDR);
     let path_id = pair.open_path(Client, different_addr, PathStatus::Available)?;
 
     // block the server from receiving anything
@@ -504,10 +503,9 @@ fn open_path_validation_fails_client_side() -> TestResult {
     let mut pair = multipath_pair();
 
     // make sure the new path cannot be validated using the existing path
-    pair.client.addr = SocketAddr::new(
-        [9, 8, 7, 6].into(),
-        CLIENT_PORTS.lock()?.next().ok_or("no port")?,
-    );
+    pair.client.addr = SocketAddr::new([9, 8, 7, 6].into(), 5);
+    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
+    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
 
     let addr = pair.server.addr;
     let network_path = FourTuple {

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -16,7 +16,10 @@ use crate::{
     LOCAL_CID_COUNT, NetworkChangeHint, PathId, PathStatus, RandomConnectionIdGenerator,
     ServerConfig, Side::*, TransportConfig, cid_queue::CidQueue,
 };
-use crate::{ClosePathError, Dir, Event, PathAbandonReason, PathEvent, StreamEvent, TransportErrorCode};
+use crate::{
+    ClosePathError, Dir, Event, PathAbandonReason, PathEvent, StreamEvent, TransportErrorCode,
+    n0_nat_traversal,
+};
 
 use super::util::{min_opt, subscribe};
 use super::{EndpointIndepedentNatRoutingTable, Pair, client_config, server_config};
@@ -1639,12 +1642,26 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     pair.add_nat_traversal_address(Client, EndpointIndepedentNatRoutingTable::CLIENT_NAT)?;
     pair.drive();
 
+    let event = pair.poll(Client).expect("should have event");
+    assert!(matches!(
+        event,
+        Event::NatTraversal(n0_nat_traversal::Event::AddressAdded(_))
+    ));
+
     info!("init NAT traversal");
     pair.initiate_nat_traversal_round(Client)?;
 
+    // Ensure we have no more events queued
+    assert!(pair.poll(Client).is_none());
+    assert!(pair.poll(Server).is_none());
+
     pair.drive();
 
-    // TODO
+    let event = pair.poll(Client).expect("should have event");
+    assert!(matches!(event, Event::Path(PathEvent::Opened { .. })));
+
+    let event = pair.poll(Server).expect("should have event");
+    assert!(matches!(event, Event::Path(PathEvent::Opened { .. })));
 
     Ok(())
 }

--- a/noq-proto/src/tests/proptests.rs
+++ b/noq-proto/src/tests/proptests.rs
@@ -68,7 +68,7 @@ fn setup_deterministic_with_multipath(
 
     pair.client.addr = routes.client_addr(0).unwrap();
     pair.server.addr = routes.server_addr(0).unwrap();
-    pair.routes = Some(routes);
+    pair.routes = Some(Box::new(routes));
     pair
 }
 

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -13,6 +13,8 @@ use crate::{
     tests::{Pair, TestEndpoint, client_config},
 };
 
+use super::RoutingTable;
+
 #[derive(Debug, Clone, Copy, Arbitrary)]
 pub(super) enum TestOp {
     /// Drive the endpoint on the given `side`, processing all pending I/O.
@@ -139,14 +141,16 @@ impl TestOp {
                 side: Side::Client,
                 addr_idx,
             } => {
-                let routes = pair.routes.as_mut()?;
+                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes = routes.downcast_mut::<RoutingTable>().unwrap();
                 routes.sim_client_migration(addr_idx, inc_last_addr_octet);
             }
             Self::PassiveMigration {
                 side: Side::Server,
                 addr_idx,
             } => {
-                let routes = pair.routes.as_mut()?;
+                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes = routes.downcast_mut::<RoutingTable>().unwrap();
                 routes.sim_server_migration(addr_idx, inc_last_addr_octet);
             }
             Self::OpenPath {
@@ -154,7 +158,8 @@ impl TestOp {
                 status,
                 addr_idx,
             } => {
-                let routes = pair.routes.as_ref()?;
+                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes = routes.downcast_ref::<RoutingTable>().unwrap();
                 let remote = match side {
                     Side::Client => routes.server_addr(addr_idx)?,
                     Side::Server => routes.client_addr(addr_idx)?,
@@ -218,7 +223,8 @@ impl TestOp {
                 conn.close(now, error_code.into(), Bytes::new());
             }
             Self::AddHpAddr { side, addr_idx } => {
-                let routes = pair.routes.as_ref()?;
+                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes = routes.downcast_ref::<RoutingTable>().unwrap();
                 let address = match side {
                     Side::Client => routes.client_addr(addr_idx)?,
                     Side::Server => routes.server_addr(addr_idx)?,

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -141,7 +141,7 @@ impl TestOp {
                 side: Side::Client,
                 addr_idx,
             } => {
-                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?.as_mut();
                 let routes = routes.downcast_mut::<RoutingTable>().unwrap();
                 routes.sim_client_migration(addr_idx, inc_last_addr_octet);
             }
@@ -149,7 +149,7 @@ impl TestOp {
                 side: Side::Server,
                 addr_idx,
             } => {
-                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?.as_mut();
                 let routes = routes.downcast_mut::<RoutingTable>().unwrap();
                 routes.sim_server_migration(addr_idx, inc_last_addr_octet);
             }
@@ -158,7 +158,7 @@ impl TestOp {
                 status,
                 addr_idx,
             } => {
-                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes: &dyn std::any::Any = pair.routes.as_ref()?.as_ref();
                 let routes = routes.downcast_ref::<RoutingTable>().unwrap();
                 let remote = match side {
                     Side::Client => routes.server_addr(addr_idx)?,
@@ -223,7 +223,7 @@ impl TestOp {
                 conn.close(now, error_code.into(), Bytes::new());
             }
             Self::AddHpAddr { side, addr_idx } => {
-                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?;
+                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?.as_mut();
                 let routes = routes.downcast_ref::<RoutingTable>().unwrap();
                 let address = match side {
                     Side::Client => routes.client_addr(addr_idx)?,

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -137,16 +137,14 @@ impl TestOp {
                 side: Side::Client,
                 addr_idx,
             } => {
-                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?.as_mut();
-                let routes = routes.downcast_mut::<RoutingTable>().unwrap();
+                let routes = pair.downcast_routes_mut::<RoutingTable>()?;
                 routes.sim_client_migration(addr_idx, inc_last_addr_octet);
             }
             Self::PassiveMigration {
                 side: Side::Server,
                 addr_idx,
             } => {
-                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?.as_mut();
-                let routes = routes.downcast_mut::<RoutingTable>().unwrap();
+                let routes = pair.downcast_routes_mut::<RoutingTable>()?;
                 routes.sim_server_migration(addr_idx, inc_last_addr_octet);
             }
             Self::OpenPath {
@@ -154,8 +152,7 @@ impl TestOp {
                 status,
                 addr_idx,
             } => {
-                let routes: &dyn std::any::Any = pair.routes.as_ref()?.as_ref();
-                let routes = routes.downcast_ref::<RoutingTable>().unwrap();
+                let routes = pair.downcast_routes_ref::<RoutingTable>()?;
                 let remote = match side {
                     Side::Client => routes.server_addr(addr_idx)?,
                     Side::Server => routes.client_addr(addr_idx)?,
@@ -219,8 +216,7 @@ impl TestOp {
                 conn.close(now, error_code.into(), Bytes::new());
             }
             Self::AddHpAddr { side, addr_idx } => {
-                let routes: &mut dyn std::any::Any = pair.routes.as_mut()?.as_mut();
-                let routes = routes.downcast_ref::<RoutingTable>().unwrap();
+                let routes = pair.downcast_routes_ref::<RoutingTable>()?;
                 let address = match side {
                     Side::Client => routes.client_addr(addr_idx)?,
                     Side::Server => routes.server_addr(addr_idx)?,

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1467,30 +1467,44 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         // destination.
         let link_src = if transmit.destination == Self::SERVER_DIRECT {
             Self::CLIENT_DIRECT
-        } else if transmit.destination == Self::SERVER_NAT && self.server_firewall_open {
-            Self::CLIENT_NAT
         } else if transmit.destination == Self::SERVER_NAT {
-            debug!(?transmit.destination, "NAT blocked");
-            if !self.client_firewall_open {
-                info!("client NAT opened");
-                self.client_firewall_open = true;
-            }
-            return None;
+            Self::CLIENT_NAT
         } else {
-            // There is no possible link to this destination.
+            debug!(
+                ?transmit.src_ip,
+                ?transmit.destination,
+                "transmit dropped: unknown destination (network unreachable)",
+            );
             return None;
         };
 
-        // Check if the datagram IS sent from that addr.
-        if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
-            if link_src == Self::CLIENT_NAT {
-                info!("client NAT opened");
-                self.client_firewall_open = true
-            }
-            Some(link_src)
-        } else {
-            None
+        // If the datagram is NOT sent from this source then it can't be sent.
+        if transmit.src_ip.unwrap_or_else(|| link_src.ip()) != link_src.ip() {
+            debug!(
+                ?transmit.src_ip,
+                ?transmit.destination,
+                "transmit dropped: sent from wrong source (network unreachable)",
+            );
+            return None;
         }
+
+        // Open the local firewall for outgoing packet.
+        if link_src == Self::CLIENT_NAT && !self.client_firewall_open {
+            info!("client firewall opened");
+            self.client_firewall_open = true;
+        }
+
+        if transmit.destination == Self::SERVER_NAT && !self.server_firewall_open {
+            debug!(
+                ?transmit.src_ip,
+                ?transmit.destination,
+                "transmit dropped: blocked by server firewall",
+            );
+            return None;
+        }
+
+        // Allow the datagram to be delivered.
+        Some(link_src)
     }
 
     /// Routes a datagram from server to client.
@@ -1506,29 +1520,43 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         // destination.
         let link_src = if transmit.destination == Self::CLIENT_DIRECT {
             Self::SERVER_DIRECT
-        } else if transmit.destination == Self::CLIENT_NAT && self.client_firewall_open {
+        } else if transmit.destination == Self::CLIENT_NAT {
             Self::SERVER_NAT
-        } else if transmit.destination == Self::SERVER_NAT {
-            debug!(?transmit.destination, "NAT blocked");
-            if !self.server_firewall_open {
-                info!("server NAT opened");
-                self.server_firewall_open = true;
-            }
-            return None;
         } else {
-            // There is no possible link to this destination.
+            debug!(
+                ?transmit.src_ip,
+                ?transmit.destination,
+                "transmit dropped: unknown destination (network unreachable)",
+            );
             return None;
         };
 
-        // Check if the datagram IS sent from that addr.
-        if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
-            if link_src == Self::SERVER_NAT {
-                info!("server NAT opened");
-                self.server_firewall_open = true;
-            }
-            Some(link_src)
-        } else {
-            None
+        // If the datagram is NOT sent from this source then it can't be sent.
+        if transmit.src_ip.unwrap_or_else(|| link_src.ip()) != link_src.ip() {
+            debug!(
+                ?transmit.src_ip,
+                ?transmit.destination,
+                "transmit dropped: sent from wrong source (network unreachable)",
+            );
+            return None;
         }
+
+        // Open the local firewall for outgoing packet.
+        if link_src == Self::SERVER_NAT && !self.server_firewall_open {
+            info!("server firewall opened");
+            self.server_firewall_open = true;
+        }
+
+        if transmit.destination == Self::CLIENT_NAT && !self.client_firewall_open {
+            debug!(
+                ?transmit.src_ip,
+                ?transmit.destination,
+                "transmit dropped: blocked by client firewall",
+            );
+            return None;
+        }
+
+        // Allow the datagram to be delivered.
+        Some(link_src)
     }
 }

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1362,32 +1362,6 @@ impl RoutingTable {
         }
     }
 
-    /// Returns the client address a server would see on an incoming packet if
-    /// sent to given server address.
-    ///
-    /// Returns none if the packet would not find a route and get lost.
-    fn resolve_client_to_server(&self, server_addr: SocketAddr) -> Option<SocketAddr> {
-        let (_, client_addr_idx) = self
-            .server_routes
-            .iter()
-            .find(|(addr, _)| *addr == server_addr)?;
-        let (client_addr, _) = self.client_routes.get(*client_addr_idx)?;
-        Some(*client_addr)
-    }
-
-    /// Returns the server address a client would see on an incoming packet if
-    /// sent to given client address.
-    ///
-    /// Returns none if the packet would not find a route and get lost.
-    fn resolve_server_to_client(&self, client_addr: SocketAddr) -> Option<SocketAddr> {
-        let (_, server_addr_idx) = self
-            .client_routes
-            .iter()
-            .find(|(addr, _)| *addr == client_addr)?;
-        let (server_addr, _) = self.server_routes.get(*server_addr_idx)?;
-        Some(*server_addr)
-    }
-
     /// Adds a new route from an existing server address (identified by index) to a new client address.
     pub(super) fn add_client_route(&mut self, client_addr: SocketAddr, server_addr_idx: usize) {
         assert!(server_addr_idx < self.server_routes.len());
@@ -1433,11 +1407,21 @@ impl RoutingTable {
 
 impl PairRoutingTable for RoutingTable {
     fn route_client_to_server(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
-        self.resolve_client_to_server(transmit.destination)
+        let (_, client_addr_idx) = self
+            .server_routes
+            .iter()
+            .find(|(addr, _)| *addr == transmit.destination)?;
+        let (client_addr, _) = self.client_routes.get(*client_addr_idx)?;
+        Some(*client_addr)
     }
 
     fn route_server_to_client(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
-        self.resolve_server_to_client(transmit.destination)
+        let (_, server_addr_idx) = self
+            .client_routes
+            .iter()
+            .find(|(addr, _)| *addr == transmit.destination)?;
+        let (server_addr, _) = self.server_routes.get(*server_addr_idx)?;
+        Some(*server_addr)
     }
 }
 

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -363,6 +363,26 @@ impl Pair {
             local_ip: Some(self.server.addr.ip()),
         }
     }
+
+    /// Helper to get access to the test-specific routing table.
+    pub(super) fn downcast_routes_ref<T: PairRoutingTable>(&self) -> Option<&T> {
+        let routes: &dyn std::any::Any = self.routes.as_ref()?.as_ref();
+        Some(
+            routes
+                .downcast_ref::<T>()
+                .expect("downcast type does not match"),
+        )
+    }
+
+    /// Helper to get mutable access to the test-specific routing table.
+    pub(super) fn downcast_routes_mut<T: PairRoutingTable>(&mut self) -> Option<&mut T> {
+        let routes: &mut dyn std::any::Any = self.routes.as_mut()?.as_mut();
+        Some(
+            routes
+                .downcast_mut::<T>()
+                .expect("downcast type does not match"),
+        )
+    }
 }
 
 /// Wrapper to a [`Pair`] which keeps handles to the client and server connections.

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1428,10 +1428,6 @@ impl PairRoutingTable for RoutingTable {
 /// of the destination IP then a transmit is dropped.
 #[derive(Debug)]
 pub(super) struct EndpointIndepedentNatRoutingTable {
-    client_direct: SocketAddr,
-    server_direct: SocketAddr,
-    client_nat: SocketAddr,
-    server_nat: SocketAddr,
     /// Whether the client has sent a packet from `client_nat` to `server_nat`.
     ///
     /// If so packets from `server_nat` to `client_nat` will be allowed. If not they will be
@@ -1442,10 +1438,6 @@ pub(super) struct EndpointIndepedentNatRoutingTable {
 }
 
 impl EndpointIndepedentNatRoutingTable {
-    // pub(super) const CLIENT_DIRECT: SocketAddr =
-    //     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 1, 1)), 1);
-    // pub(super) const SERVER_DIRECT: SocketAddr =
-    //     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 2, 1)), 1);
     pub(super) const CLIENT_DIRECT: SocketAddr = Pair::CLIENT_ADDR;
     pub(super) const SERVER_DIRECT: SocketAddr = Pair::SERVER_ADDR;
     pub(super) const CLIENT_NAT: SocketAddr =
@@ -1455,10 +1447,6 @@ impl EndpointIndepedentNatRoutingTable {
 
     pub(super) fn new() -> Self {
         Self {
-            client_direct: Self::CLIENT_DIRECT,
-            server_direct: Self::SERVER_DIRECT,
-            client_nat: Self::CLIENT_NAT,
-            server_nat: Self::SERVER_NAT,
             client_firewall_open: false,
             server_firewall_open: false,
         }
@@ -1477,11 +1465,11 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
     fn route_client_to_server(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
         // Find the address this datagram SHOULD have been sent on to be able to reach the
         // destination.
-        let link_src = if transmit.destination == self.server_direct {
-            self.client_direct
-        } else if transmit.destination == self.server_nat && self.server_firewall_open {
-            self.client_nat
-        } else if transmit.destination == self.server_nat {
+        let link_src = if transmit.destination == Self::SERVER_DIRECT {
+            Self::CLIENT_DIRECT
+        } else if transmit.destination == Self::SERVER_NAT && self.server_firewall_open {
+            Self::CLIENT_NAT
+        } else if transmit.destination == Self::SERVER_NAT {
             debug!(?transmit.destination, "NAT blocked");
             if !self.client_firewall_open {
                 info!("client NAT opened");
@@ -1495,7 +1483,7 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
 
         // Check if the datagram IS sent from that addr.
         if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
-            if link_src == self.client_nat {
+            if link_src == Self::CLIENT_NAT {
                 info!("client NAT opened");
                 self.client_firewall_open = true
             }
@@ -1516,11 +1504,11 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
     fn route_server_to_client(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
         // Find the address this datagram SHOULD have been sent on to be able to reach the
         // destination.
-        let link_src = if transmit.destination == self.client_direct {
-            self.server_direct
-        } else if transmit.destination == self.client_nat && self.client_firewall_open {
-            self.server_nat
-        } else if transmit.destination == self.server_nat {
+        let link_src = if transmit.destination == Self::CLIENT_DIRECT {
+            Self::SERVER_DIRECT
+        } else if transmit.destination == Self::CLIENT_NAT && self.client_firewall_open {
+            Self::SERVER_NAT
+        } else if transmit.destination == Self::SERVER_NAT {
             debug!(?transmit.destination, "NAT blocked");
             if !self.server_firewall_open {
                 info!("server NAT opened");
@@ -1534,7 +1522,7 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
 
         // Check if the datagram IS sent from that addr.
         if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
-            if link_src == self.server_nat {
+            if link_src == Self::SERVER_NAT {
                 info!("server NAT opened");
                 self.server_firewall_open = true;
             }

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -43,11 +43,16 @@ pub(super) struct Pair {
     pub(super) spins: u64,
     /// The routing table used for resolving addresses observed for incoming packets
     /// and determining whether they should get lost.
-    pub(super) routes: Option<RoutingTable>,
+    pub(super) routes: Option<Box<dyn PairRoutingTable>>,
     last_spin: bool,
 }
 
 impl Pair {
+    pub(super) const CLIENT_ADDR: SocketAddr =
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 1, 1)), 1);
+    pub(super) const SERVER_ADDR: SocketAddr =
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 2, 1)), 1);
+
     /// Creates an endpoint pair that'll run deterministically with hardcoded addresses.
     pub(super) fn seeded(seed: [u8; 32]) -> Self {
         let mut rng = StdRng::from_seed(seed);
@@ -102,18 +107,10 @@ impl Pair {
     }
 
     pub(super) fn new_from_endpoint(client: Endpoint, server: Endpoint) -> Self {
-        let server_addr = SocketAddr::new(
-            Ipv6Addr::LOCALHOST.into(),
-            SERVER_PORTS.lock().unwrap().next().unwrap(),
-        );
-        let client_addr = SocketAddr::new(
-            Ipv6Addr::LOCALHOST.into(),
-            CLIENT_PORTS.lock().unwrap().next().unwrap(),
-        );
         let now = Instant::now();
         Self {
-            server: TestEndpoint::new(server, server_addr),
-            client: TestEndpoint::new(client, client_addr),
+            server: TestEndpoint::new(server, Self::SERVER_ADDR),
+            client: TestEndpoint::new(client, Self::CLIENT_ADDR),
             epoch: now,
             time: now,
             mtu: DEFAULT_MTU,
@@ -128,6 +125,29 @@ impl Pair {
     /// Returns whether the connection is not idle
     pub(super) fn step(&mut self) -> bool {
         self.blackhole_step(false, false)
+    }
+
+    /// Drive both endpoints once, optionally preventing them from receiving traffic.
+    ///
+    /// Returns `false` if the connection is idle after the step.
+    pub(super) fn blackhole_step(
+        &mut self,
+        server_blackhole: bool,
+        client_blackhole: bool,
+    ) -> bool {
+        self.drive_client();
+        if server_blackhole {
+            self.server.inbound.clear();
+        }
+        self.drive_server();
+        if client_blackhole {
+            self.client.inbound.clear();
+        }
+        if self.client.is_idle() && self.server.is_idle() {
+            return false;
+        }
+
+        self.advance_time()
     }
 
     /// Advance time until both connections are idle
@@ -164,8 +184,8 @@ impl Pair {
                 self.spins += (spin == self.last_spin) as u64;
                 self.last_spin = spin;
             }
-            let client_addr = match &self.routes {
-                Some(table) => table.resolve_client_to_server(packet.destination),
+            let client_addr = match self.routes.as_mut() {
+                Some(table) => table.route_client_to_server(&packet),
                 None => (self.server.addr == packet.destination).then_some(self.client.addr),
             };
             if let Some(client_addr) = client_addr {
@@ -193,8 +213,8 @@ impl Pair {
                 info!(packet_size, "dropping packet (max size exceeded)");
                 continue;
             }
-            let server_addr = match &self.routes {
-                Some(table) => table.resolve_server_to_client(packet.destination),
+            let server_addr = match self.routes.as_mut() {
+                Some(table) => table.route_server_to_client(&packet),
                 None => (self.client.addr == packet.destination).then_some(self.server.addr),
             };
             if let Some(server_addr) = server_addr {
@@ -210,29 +230,6 @@ impl Pair {
                 debug!(?packet.destination, "no route from server to client for packet");
             }
         }
-    }
-
-    /// Drive both endpoints once, optionally preventing them from receiving traffic.
-    ///
-    /// Returns `false` if the connection is idle after the step.
-    pub(super) fn blackhole_step(
-        &mut self,
-        server_blackhole: bool,
-        client_blackhole: bool,
-    ) -> bool {
-        self.drive_client();
-        if server_blackhole {
-            self.server.inbound.clear();
-        }
-        self.drive_server();
-        if client_blackhole {
-            self.client.inbound.clear();
-        }
-        if self.client.is_idle() && self.server.is_idle() {
-            return false;
-        }
-
-        self.advance_time()
     }
 
     pub(super) fn advance_time(&mut self) -> bool {
@@ -1265,6 +1262,22 @@ impl TokenLog for SimpleTokenLog {
     }
 }
 
+/// Generic router interface for the [`Pair::routes`].
+///
+/// This allows implementing different routing strategies.
+pub(super) trait PairRoutingTable: std::any::Any {
+    /// Routes a datagram from client to server.
+    ///
+    /// Returns the address the server will observe as the sender of the datagram. Or `None`
+    /// if there is no open link.
+    fn route_client_to_server(&mut self, transmit: &Transmit) -> Option<SocketAddr>;
+    /// Routes a datagram from server to client.
+    ///
+    /// Returns the address the client will observe as the sender of the datagram. Or `None`
+    /// if there is no open link.
+    fn route_server_to_client(&mut self, transmit: &Transmit) -> Option<SocketAddr>;
+}
+
 /// Set of uni-directional links between interfaces of a client and server.
 ///
 /// Each entry on the client or server side represents a single interface in a /32
@@ -1390,5 +1403,149 @@ impl RoutingTable {
         let route = self.server_routes.get_mut(route_idx)?;
         route.0 = modify_fn(route.0);
         Some(route.0)
+    }
+}
+
+impl PairRoutingTable for RoutingTable {
+    fn route_client_to_server(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
+        self.resolve_client_to_server(transmit.destination)
+    }
+
+    fn route_server_to_client(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
+        self.resolve_server_to_client(transmit.destination)
+    }
+}
+
+/// A routing table that simulates an Endpoint Independent NAT for both endpoints.
+///
+/// This is pretty simplistic, but tests the basics.
+///
+/// The client and server both have 2 interfaces:
+///
+/// 1. One "direct" interface, which has a link to the peer's "direct" interface.
+/// 2. One "nat" interface, which has a link to the peer's "nat" interface. This link
+///    however does not allow an incoming packet unless it has seen an outgoing packet
+///    first.
+///
+/// When an outgoing transmit has no `src_ip` is set, the source IP is set based on the
+/// destination. This is the same as the kernel selecting the correct outbound interface. If
+/// an outgoing transmit has an `src_ip` of an interface that is not linked to the interface
+/// of the destination IP then a transmit is dropped.
+#[derive(Debug)]
+pub(super) struct EndpointIndepedentNatRoutingTable {
+    client_direct: SocketAddr,
+    server_direct: SocketAddr,
+    client_nat: SocketAddr,
+    server_nat: SocketAddr,
+    /// Whether the client has sent a packet from `client_nat` to `server_nat`.
+    ///
+    /// If so packets from `server_nat` to `client_nat` will be allowed. If not they will be
+    /// dropped.
+    client_nat_open: bool,
+    /// Whether the server has sent a packet from `server_nat` to `client_nat`.
+    server_nat_open: bool,
+}
+
+impl EndpointIndepedentNatRoutingTable {
+    // pub(super) const CLIENT_DIRECT: SocketAddr =
+    //     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 1, 1)), 1);
+    // pub(super) const SERVER_DIRECT: SocketAddr =
+    //     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 2, 1)), 1);
+    pub(super) const CLIENT_DIRECT: SocketAddr = Pair::CLIENT_ADDR;
+    pub(super) const SERVER_DIRECT: SocketAddr = Pair::SERVER_ADDR;
+    pub(super) const CLIENT_NAT: SocketAddr =
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 1, 2)), 1);
+    pub(super) const SERVER_NAT: SocketAddr =
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 2, 2)), 1);
+
+    pub(super) fn new() -> Self {
+        Self {
+            client_direct: Self::CLIENT_DIRECT,
+            server_direct: Self::SERVER_DIRECT,
+            client_nat: Self::CLIENT_NAT,
+            server_nat: Self::SERVER_NAT,
+            client_nat_open: false,
+            server_nat_open: false,
+        }
+    }
+}
+
+impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
+    /// Routes a datagram from client to server.
+    ///
+    /// Returns the address the server will observe as the sender of the datagram. Or `None`
+    /// if there is no open link.
+    ///
+    /// If there is no [`Transmit::src_ip`] then this routing table selects one based on the
+    /// destination, if reachable. Otherwise if the `src_ip` does not match an open link the
+    /// datagram is blocked.
+    fn route_client_to_server(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
+        // Find the address this datagram SHOULD have been sent on to be able to reach the
+        // destination.
+        let link_src = if transmit.destination == self.server_direct {
+            self.client_direct
+        } else if transmit.destination == self.server_nat && self.server_nat_open {
+            self.client_nat
+        } else if transmit.destination == self.server_nat {
+            debug!(?transmit.destination, "NAT blocked");
+            if !self.client_nat_open {
+                info!("client NAT opened");
+                self.client_nat_open = true;
+            }
+            return None;
+        } else {
+            // There is no possible link to this destination.
+            return None;
+        };
+
+        // Check if the datagram IS sent from that addr.
+        if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
+            if link_src == self.client_nat {
+                info!("client NAT opened");
+                self.client_nat_open = true
+            }
+            Some(link_src)
+        } else {
+            None
+        }
+    }
+
+    /// Routes a datagram from server to client.
+    ///
+    /// Returns the address the client will observe as the sender of the datagram. Or `None`
+    /// if there is no open link.
+    ///
+    /// If there is no [`Transmit::src_ip`] then this routing table selects one based on the
+    /// destination, if reachable. Otherwise if the `src_ip` does not match an open link the
+    /// datagram is blocked.
+    fn route_server_to_client(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
+        // Find the address this datagram SHOULD have been sent on to be able to reach the
+        // destination.
+        let link_src = if transmit.destination == self.client_direct {
+            self.server_direct
+        } else if transmit.destination == self.client_nat && self.client_nat_open {
+            self.server_nat
+        } else if transmit.destination == self.server_nat {
+            debug!(?transmit.destination, "NAT blocked");
+            if !self.server_nat_open {
+                info!("server NAT opened");
+                self.server_nat_open = true;
+            }
+            return None;
+        } else {
+            // There is no possible link to this destination.
+            return None;
+        };
+
+        // Check if the datagram IS sent from that addr.
+        if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
+            if link_src == self.server_nat {
+                info!("server NAT opened");
+                self.server_nat_open = true;
+            }
+            Some(link_src)
+        } else {
+            None
+        }
     }
 }

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -5,7 +5,6 @@ use std::{
     mem,
     net::{Ipv6Addr, SocketAddr},
     num::{NonZeroU32, NonZeroUsize},
-    ops::RangeFrom,
     str,
     sync::{Arc, LazyLock, Mutex},
 };
@@ -1237,10 +1236,6 @@ fn set_congestion_experienced(
     })
 }
 
-pub(crate) static SERVER_PORTS: LazyLock<Mutex<RangeFrom<u16>>> =
-    LazyLock::new(|| Mutex::new(4433..));
-pub(crate) static CLIENT_PORTS: LazyLock<Mutex<RangeFrom<u16>>> =
-    LazyLock::new(|| Mutex::new(44433..));
 pub(crate) static CERTIFIED_KEY: LazyLock<rcgen::CertifiedKey<rcgen::KeyPair>> =
     LazyLock::new(|| rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap());
 

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1436,9 +1436,9 @@ pub(super) struct EndpointIndepedentNatRoutingTable {
     ///
     /// If so packets from `server_nat` to `client_nat` will be allowed. If not they will be
     /// dropped.
-    client_nat_open: bool,
+    client_firewall_open: bool,
     /// Whether the server has sent a packet from `server_nat` to `client_nat`.
-    server_nat_open: bool,
+    server_firewall_open: bool,
 }
 
 impl EndpointIndepedentNatRoutingTable {
@@ -1459,8 +1459,8 @@ impl EndpointIndepedentNatRoutingTable {
             server_direct: Self::SERVER_DIRECT,
             client_nat: Self::CLIENT_NAT,
             server_nat: Self::SERVER_NAT,
-            client_nat_open: false,
-            server_nat_open: false,
+            client_firewall_open: false,
+            server_firewall_open: false,
         }
     }
 }
@@ -1479,13 +1479,13 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         // destination.
         let link_src = if transmit.destination == self.server_direct {
             self.client_direct
-        } else if transmit.destination == self.server_nat && self.server_nat_open {
+        } else if transmit.destination == self.server_nat && self.server_firewall_open {
             self.client_nat
         } else if transmit.destination == self.server_nat {
             debug!(?transmit.destination, "NAT blocked");
-            if !self.client_nat_open {
+            if !self.client_firewall_open {
                 info!("client NAT opened");
-                self.client_nat_open = true;
+                self.client_firewall_open = true;
             }
             return None;
         } else {
@@ -1497,7 +1497,7 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
             if link_src == self.client_nat {
                 info!("client NAT opened");
-                self.client_nat_open = true
+                self.client_firewall_open = true
             }
             Some(link_src)
         } else {
@@ -1518,13 +1518,13 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         // destination.
         let link_src = if transmit.destination == self.client_direct {
             self.server_direct
-        } else if transmit.destination == self.client_nat && self.client_nat_open {
+        } else if transmit.destination == self.client_nat && self.client_firewall_open {
             self.server_nat
         } else if transmit.destination == self.server_nat {
             debug!(?transmit.destination, "NAT blocked");
-            if !self.server_nat_open {
+            if !self.server_firewall_open {
                 info!("server NAT opened");
-                self.server_nat_open = true;
+                self.server_firewall_open = true;
             }
             return None;
         } else {
@@ -1536,7 +1536,7 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         if transmit.src_ip.unwrap_or_else(|| link_src.ip()) == link_src.ip() {
             if link_src == self.server_nat {
                 info!("server NAT opened");
-                self.server_nat_open = true;
+                self.server_firewall_open = true;
             }
             Some(link_src)
         } else {

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -47,8 +47,18 @@ pub(super) struct Pair {
 }
 
 impl Pair {
+    /// The default client address of the pair.
+    ///
+    /// IPv6 address `::1:1`. This is a normal unicast address.
+    /// - `::1:1` is for the first client address.
+    /// - `::1:0/112` is the subnet used for all client addresses.
     pub(super) const CLIENT_ADDR: SocketAddr =
         SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 1, 1)), 1);
+    /// The default server address of the pair.
+    ///
+    /// IPv6 address `::2:1`. This is a normal unicast address.
+    /// - `::2:1` is for the first server address.
+    /// - `::2:0/112` is the subnet used for all server addresses.
     pub(super) const SERVER_ADDR: SocketAddr =
         SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 2, 1)), 1);
 
@@ -1431,7 +1441,10 @@ impl PairRoutingTable for RoutingTable {
     }
 }
 
-/// A routing table that simulates an Endpoint Independent NAT for both endpoints.
+/// A routing table with one open and one firewalled interface.
+///
+/// This essentially behaves like a Destination Endpoint Independent NAT with address and
+/// port filtering. But without having to simulate the public side of the network.
 ///
 /// This is pretty simplistic, but tests the basics.
 ///
@@ -1447,7 +1460,7 @@ impl PairRoutingTable for RoutingTable {
 /// an outgoing transmit has an `src_ip` of an interface that is not linked to the interface
 /// of the destination IP then a transmit is dropped.
 #[derive(Debug)]
-pub(super) struct EndpointIndepedentNatRoutingTable {
+pub(super) struct SimpleFirewallRoutingTable {
     /// Whether the client has sent a packet from `client_nat` to `server_nat`.
     ///
     /// If so packets from `server_nat` to `client_nat` will be allowed. If not they will be
@@ -1457,12 +1470,32 @@ pub(super) struct EndpointIndepedentNatRoutingTable {
     server_firewall_open: bool,
 }
 
-impl EndpointIndepedentNatRoutingTable {
-    pub(super) const CLIENT_DIRECT: SocketAddr = Pair::CLIENT_ADDR;
-    pub(super) const SERVER_DIRECT: SocketAddr = Pair::SERVER_ADDR;
-    pub(super) const CLIENT_NAT: SocketAddr =
+impl SimpleFirewallRoutingTable {
+    /// The address of the client's non-firewalled interface.
+    ///
+    /// IPv6 address `::1:1`. This is a normal unicast address.
+    /// - `::1:1` is for the first client address.
+    /// - `::1:0/112` is the subnet used for all client addresses.
+    pub(super) const CLIENT_DIRECT_ADDR: SocketAddr = Pair::CLIENT_ADDR;
+    /// The address of the server's non-firewalled interface.
+    ///
+    /// IPv6 address `::2:1`. This is a normal unicast address.
+    /// - `::2:1` is for the first server address.
+    /// - `::2:0/112` is the subnet used for all server addresses.
+    pub(super) const SERVER_DIRECT_ADDR: SocketAddr = Pair::SERVER_ADDR;
+    /// The address of the client's firewalled interface.
+    ///
+    /// IPv6 address `::1:2`. This is a normal IPv6 unicast address.
+    /// - `::1:2` is for the second client address.
+    /// - `::1:0/112` is the subnet used for all client addresses.
+    pub(super) const CLIENT_FW_ADDR: SocketAddr =
         SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 1, 2)), 1);
-    pub(super) const SERVER_NAT: SocketAddr =
+    /// The address of the server's firewalled interface.
+    ///
+    /// IPv6 address `::2:2`. This is a normal IPv6 unicast address.
+    /// - `::2:1` is for the second server address.
+    /// - `::2:0/112` is the subnet used for all server addresses.
+    pub(super) const SERVER_FW_ADDR: SocketAddr =
         SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 2, 2)), 1);
 
     pub(super) fn new() -> Self {
@@ -1473,7 +1506,7 @@ impl EndpointIndepedentNatRoutingTable {
     }
 }
 
-impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
+impl PairRoutingTable for SimpleFirewallRoutingTable {
     /// Routes a datagram from client to server.
     ///
     /// Returns the address the server will observe as the sender of the datagram. Or `None`
@@ -1485,10 +1518,10 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
     fn route_client_to_server(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
         // Find the address this datagram SHOULD have been sent on to be able to reach the
         // destination.
-        let link_src = if transmit.destination == Self::SERVER_DIRECT {
-            Self::CLIENT_DIRECT
-        } else if transmit.destination == Self::SERVER_NAT {
-            Self::CLIENT_NAT
+        let link_src = if transmit.destination == Self::SERVER_DIRECT_ADDR {
+            Self::CLIENT_DIRECT_ADDR
+        } else if transmit.destination == Self::SERVER_FW_ADDR {
+            Self::CLIENT_FW_ADDR
         } else {
             debug!(
                 ?transmit.src_ip,
@@ -1509,12 +1542,12 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         }
 
         // Open the local firewall for outgoing packet.
-        if link_src == Self::CLIENT_NAT && !self.client_firewall_open {
+        if link_src == Self::CLIENT_FW_ADDR && !self.client_firewall_open {
             info!("client firewall opened");
             self.client_firewall_open = true;
         }
 
-        if transmit.destination == Self::SERVER_NAT && !self.server_firewall_open {
+        if transmit.destination == Self::SERVER_FW_ADDR && !self.server_firewall_open {
             debug!(
                 ?transmit.src_ip,
                 ?transmit.destination,
@@ -1538,10 +1571,10 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
     fn route_server_to_client(&mut self, transmit: &Transmit) -> Option<SocketAddr> {
         // Find the address this datagram SHOULD have been sent on to be able to reach the
         // destination.
-        let link_src = if transmit.destination == Self::CLIENT_DIRECT {
-            Self::SERVER_DIRECT
-        } else if transmit.destination == Self::CLIENT_NAT {
-            Self::SERVER_NAT
+        let link_src = if transmit.destination == Self::CLIENT_DIRECT_ADDR {
+            Self::SERVER_DIRECT_ADDR
+        } else if transmit.destination == Self::CLIENT_FW_ADDR {
+            Self::SERVER_FW_ADDR
         } else {
             debug!(
                 ?transmit.src_ip,
@@ -1562,12 +1595,12 @@ impl PairRoutingTable for EndpointIndepedentNatRoutingTable {
         }
 
         // Open the local firewall for outgoing packet.
-        if link_src == Self::SERVER_NAT && !self.server_firewall_open {
+        if link_src == Self::SERVER_FW_ADDR && !self.server_firewall_open {
             info!("server firewall opened");
             self.server_firewall_open = true;
         }
 
-        if transmit.destination == Self::CLIENT_NAT && !self.client_firewall_open {
+        if transmit.destination == Self::CLIENT_FW_ADDR && !self.client_firewall_open {
             debug!(
                 ?transmit.src_ip,
                 ?transmit.destination,


### PR DESCRIPTION
## Description

This introduces a new router that simulates a very basic NAT
traversal. Both client and server are behind a NAT that needs to be
opened first.

It makes the Pair have fixed SocketAddr for the client and server
TestEndpoints. These SocketAddrs are never bound so we may as well
keep them consistent and follow an easy pattern.

It introduces a trait for the routing table, so as to not interfere
with the routing table from the proptests. I did not know how to turn
that routing table into NAT router that would be
comprehensible. Creating a new one seemed the easier solution. We can
now add more specific routers as well which could be handy.

Finally it cleans up the CLIENT_PORTS, SERVER_PORTS globals, they
really were a left over from the real socket binding functionality
removed in #537.

## Breaking Changes

n/a

## Notes & open questions

The newly added test currently only demonstrates this. It does not yet
do anything useful. It should probably be removed and be part of the
follow up PR I will make that builds on this. But I thought it would
be better to split off this functionality into its own PR.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->