### PR TITLE
chore(clippy): Fix clippy and cargo-deny for new rust release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -2481,9 +2481,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,7 @@
 [advisories]
 ignore = [
+    # gcc is only included as a minimal-versions workaround, not actually used
+    "RUSTSEC-2025-0121",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ allow = [
     "ISC",
     "MIT",
     "NCSA",
+    "OpenSSL",
     "Unicode-3.0",
     "Zlib", # foldhash, dependency of fastbloom
 ]
@@ -22,6 +23,7 @@ private = { ignore = true }
 multiple-versions = "warn"
 skip = [
     # hdrhistogram uses base64 0.21, newer crates use 0.22
+-    { crate = "base64", reason = "hdrhistogram uses 0.21, newer crates use 0.22" },
     { crate = "cpufeatures", reason = "rand 0.10 pulls in newer chacha (which depends on this), but aes-gcm hasn't updated yet" },
     # ring uses getrandom 0.2, newer crates use 0.3
     { crate = "getrandom", reason = "ring depends on 0.2, newer ecosystem uses 0.3" },

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,5 @@
 [advisories]
 ignore = [
-    # gcc is only included as a minimal-versions workaround, not actually used
-    "RUSTSEC-2025-0121",
 ]
 
 [licenses]
@@ -13,7 +11,6 @@ allow = [
     "ISC",
     "MIT",
     "NCSA",
-    "OpenSSL",
     "Unicode-3.0",
     "Zlib", # foldhash, dependency of fastbloom
 ]
@@ -23,7 +20,6 @@ private = { ignore = true }
 multiple-versions = "warn"
 skip = [
     # hdrhistogram uses base64 0.21, newer crates use 0.22
-    { crate = "base64", reason = "hdrhistogram uses 0.21, newer crates use 0.22" },
     { crate = "cpufeatures", reason = "rand 0.10 pulls in newer chacha (which depends on this), but aes-gcm hasn't updated yet" },
     # ring uses getrandom 0.2, newer crates use 0.3
     { crate = "getrandom", reason = "ring depends on 0.2, newer ecosystem uses 0.3" },

--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,7 @@ private = { ignore = true }
 multiple-versions = "warn"
 skip = [
     # hdrhistogram uses base64 0.21, newer crates use 0.22
--    { crate = "base64", reason = "hdrhistogram uses 0.21, newer crates use 0.22" },
+    { crate = "base64", reason = "hdrhistogram uses 0.21, newer crates use 0.22" },
     { crate = "cpufeatures", reason = "rand 0.10 pulls in newer chacha (which depends on this), but aes-gcm hasn't updated yet" },
     # ring uses getrandom 0.2, newer crates use 0.3
     { crate = "getrandom", reason = "ring depends on 0.2, newer ecosystem uses 0.3" },

--- a/noq-udp/src/unix.rs
+++ b/noq-udp/src/unix.rs
@@ -760,7 +760,7 @@ fn decode_recv<M: cmsg::MsgHdr<ControlMessage = libc::cmsghdr>>(
             (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
                 let pktinfo = unsafe { cmsg::decode::<libc::in6_pktinfo, libc::cmsghdr>(cmsg) };
                 dst_ip = Some(IpAddr::V6(Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr)));
-                interface_index = Some(pktinfo.ipi6_ifindex as u32);
+                interface_index = Some(pktinfo.ipi6_ifindex);
             }
             #[cfg(any(target_os = "linux", target_os = "android"))]
             (libc::SOL_UDP, libc::UDP_GRO) => unsafe {

--- a/noq-udp/src/unix.rs
+++ b/noq-udp/src/unix.rs
@@ -760,7 +760,10 @@ fn decode_recv<M: cmsg::MsgHdr<ControlMessage = libc::cmsghdr>>(
             (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => {
                 let pktinfo = unsafe { cmsg::decode::<libc::in6_pktinfo, libc::cmsghdr>(cmsg) };
                 dst_ip = Some(IpAddr::V6(Ipv6Addr::from(pktinfo.ipi6_addr.s6_addr)));
-                interface_index = Some(pktinfo.ipi6_ifindex);
+                #[cfg_attr(not(target_os = "android"), expect(clippy::unnecessary_cast))]
+                {
+                    interface_index = Some(pktinfo.ipi6_ifindex as u32);
+                }
             }
             #[cfg(any(target_os = "linux", target_os = "android"))]
             (libc::SOL_UDP, libc::UDP_GRO) => unsafe {


### PR DESCRIPTION
## Description

New rust release, new clippy lints!

Also fix cargo-deny by upgrading rustls-webpki.

And clean up the cargo-deny config by removing unused exceptions.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.