### PR TITLE
chore(docs): Improve docs of PacketNumberSpace vs PathData a little

### DIFF
--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -222,7 +222,7 @@ impl IndexMut<SpaceKind> for [PacketSpace; 3] {
 /// this space is currently using. The 4-tuple specific state, like congestion controller,
 /// pacing, ECN, MTU etc, is stored in [`PathData`].
 ///
-/// Note that the Initial, Handshake and Data(PathId(0)) space all share the same
+/// Note that the `Initial`, `Handshake` and `Data(PathId(0))` space all share the same
 /// [`PathData`].
 ///
 /// You should access this via [`PacketSpace::for_path`].

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -222,6 +222,9 @@ impl IndexMut<SpaceKind> for [PacketSpace; 3] {
 /// this space is currently using. The 4-tuple specific state, like congestion controller,
 /// pacing, ECN, MTU etc, is stored in [`PathData`].
 ///
+/// Note that the Initial, Handshake and Data(PathId(0)) space all share the same
+/// [`PathData`].
+///
 /// You should access this via [`PacketSpace::for_path`].
 ///
 /// [`PathData`]: super::paths::PathData


### PR DESCRIPTION
## Description

It was not made clear that the PathData stays the same for the
Initial, Handshake and Data(PathId::ZERO) spaces.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.