### PR TITLE
feat(proto): Client-side off-path nat traversal

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5568,8 +5568,8 @@ impl Connection {
         while let Some(network_path) = self
             .n0_nat_traversal
             .client_side_mut()
-            .map(|s| s.pop_pending_path_open())
-            .unwrap_or_default()
+            .ok()
+            .and_then(|s| s.pop_pending_path_open())
         {
             match self.open_path_ensure(network_path, PathStatus::Backup, now) {
                 Ok((path_id, already_existed)) => {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -6071,16 +6071,6 @@ impl Connection {
                         self.qlog.with_time(now),
                     );
                 }
-                // The path open status was informed before, we just want to revalidate again.
-                // For that, we want to make sure we set the PathOpenFailed timer again.
-                paths::OpenStatus::Revalidating => {
-                    path.open_status = paths::OpenStatus::Informed;
-                    self.timers.set(
-                        Timer::PerPath(path_id, PathTimer::AbandonFromValidation),
-                        now + 3 * pto,
-                        self.qlog.with_time(now),
-                    );
-                }
             }
 
             self.timers.set(

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4914,8 +4914,9 @@ impl Connection {
                 }
                 Frame::PathResponse(response) => {
                     // First try to see if this is a NAT probe response.
-                    if let Ok(nat_state) = self.n0_nat_traversal.server_side_mut()
-                        && nat_state.handle_path_response(network_path, response.0)
+                    if self
+                        .n0_nat_traversal
+                        .handle_path_response(network_path, response.0)
                     {
                         trace!(
                             src = ?network_path,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, VecDeque, btree_map},
     convert::TryFrom,
     fmt, io, mem,
-    net::{IpAddr, SocketAddr},
+    net::SocketAddr,
     num::{NonZeroU32, NonZeroUsize},
     sync::Arc,
 };
@@ -4914,15 +4914,49 @@ impl Connection {
                 }
                 Frame::PathResponse(response) => {
                     // First try to see if this is a NAT probe response.
-                    if self
+                    if let Some(network_path) = self
                         .n0_nat_traversal
                         .handle_path_response(network_path, response.0)
                     {
                         trace!(
-                            src = ?network_path,
+                            ?network_path,
                             challenge = response.0,
                             "Received valid NAT traversal probe response"
                         );
+                        if self.side.is_client() {
+                            match self.open_path_ensure(network_path, PathStatus::Backup, now) {
+                                Ok((path_id, already_existed)) => {
+                                    debug!(
+                                        %path_id,
+                                        ?network_path,
+                                        new_path=!already_existed,
+                                        "Opened NAT traversal path",
+                                    );
+                                }
+                                Err(err) => match err {
+                                    PathError::MultipathNotNegotiated
+                                    | PathError::ServerSideNotAllowed
+                                    | PathError::ValidationFailed
+                                    | PathError::InvalidRemoteAddress(_) => {
+                                        error!(
+                                            ?err,
+                                            ?network_path,
+                                            "Failed to open path after NAT traversal"
+                                        );
+                                    }
+                                    PathError::MaxPathIdReached
+                                    | PathError::RemoteCidsExhausted => {
+                                        // This is a temporary failure, enqueue this.
+                                        debug!(
+                                            ?err,
+                                            ?network_path,
+                                            "Blocked opening NAT traversal path"
+                                        );
+                                        // TODO(flub): do this.
+                                    }
+                                },
+                            }
+                        }
                         // Server-side: nothing else to do.
                     } else {
                         // Try to see if this is a response to an on-path PATH_CHALLENGE.
@@ -7033,62 +7067,6 @@ impl Connection {
             .n0_nat_traversal
             .client_side()?
             .get_remote_nat_traversal_addresses())
-    }
-
-    /// Attempts to open a path for nat traversal.
-    ///
-    /// On success returns the [`PathId`] and remote address of the path.
-    fn open_nat_traversal_path(
-        &mut self,
-        now: Instant,
-        ip_port: (IpAddr, u16),
-    ) -> Result<Option<(PathId, SocketAddr)>, PathError> {
-        let remote = ip_port.into();
-        // TODO(matheus23): Probe the correct 4-tuple, instead of only a remote address?
-        // By specifying None for `local_ip`, we do two things: 1. open_path_ensure won't
-        // generate two paths to the same remote and 2. we let the OS choose which
-        // interface to use for sending on that path.
-        let network_path = FourTuple {
-            remote,
-            local_ip: None,
-        };
-        match self.open_path_ensure(network_path, PathStatus::Backup, now) {
-            Ok((path_id, path_was_known)) => {
-                if path_was_known {
-                    trace!(%path_id, %remote, "nat traversal: path existed for remote, revalidating");
-                    if let Some(path) = self.paths.get_mut(&path_id) {
-                        use paths::OpenStatus::*;
-
-                        path.data.pending_on_path_challenge = true;
-                        path.data.open_status = match path.data.open_status {
-                            // If we just opened the path and have never sent a `PATH_CHALLENGE` yet,
-                            // then we need to keep it at pending, to ensure that
-                            // 1. The PathOpenFailed timer for stopping the PathChallengeLost retries will be set.
-                            // 2. When validation eventually succeeds, then we inform the application layer about this path opening.
-                            Pending => Pending,
-                            // If we had already sent a path challenge in the past, but it hasn't been validated yet (and also not
-                            // failed via the PathOpenFailed timer yet), then we need to go back to pending, to ensure we properly
-                            // re-arm the `PathOpenFailed` timer again.
-                            Sent => Pending,
-                            // If we're already revalidating this path, but haven't sent a `PATH_CHALLENGE` yet, then we just keep
-                            // that state.
-                            Revalidating => Revalidating,
-                            // If we've informed the application layer about the path opening in the past, but we now re-send
-                            // PATH_CHALLENGEs for validation, then using this we ensure:
-                            // 1. The PathOpenFailed timer for stopping the PathChallengeLost retries will be set.
-                            // 2. When validation eventually succeeds, we *don't* inform the application layer about the path
-                            //    opening again.
-                            Informed => Revalidating,
-                        }
-                    }
-                }
-                Ok(Some((path_id, remote)))
-            }
-            Err(e) => {
-                debug!(%remote, %e, "nat traversal: failed to probe remote");
-                Err(e)
-            }
-        }
     }
 
     /// Initiates a new nat traversal round

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5354,8 +5354,8 @@ impl Connection {
                     if path_id > self.remote_max_path_id {
                         self.remote_max_path_id = path_id;
                         self.issue_first_path_cids(now);
+                        self.open_nat_traversed_paths(now);
                     }
-                    self.open_nat_traversed_paths(now);
                 }
                 Frame::PathsBlocked(frame::PathsBlocked(max_path_id)) => {
                     // Receipt of a value of Maximum Path Identifier or Path Identifier that is higher than the local maximum value MUST

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1987,6 +1987,12 @@ impl Connection {
             .udp_tx
             .on_sent(1, buf.len());
 
+        trace!(
+            dst = ?network_path.remote,
+            src = ?network_path.local_ip,
+            len = buf.len(),
+            "sending prev_path off-path challenge",
+        );
         Some(Transmit {
             destination: network_path.remote,
             size: buf.len(),
@@ -2026,8 +2032,14 @@ impl Connection {
         builder.finish(self, now);
 
         let size = buf.len();
-
         self.path_stats.for_path(path_id).udp_tx.on_sent(1, size);
+
+        trace!(
+            dst = ?network_path.remote,
+            src = ?network_path.local_ip,
+            len = buf.len(),
+            "sending off-path PATH_RESPONSE",
+        );
         Some(Transmit {
             destination: network_path.remote,
             size,
@@ -2044,11 +2056,7 @@ impl Connection {
         buf: &mut Vec<u8>,
         path_id: PathId,
     ) -> Option<Transmit> {
-        let remote = self
-            .n0_nat_traversal
-            .server_side_mut()
-            .ok()?
-            .next_probe_addr()?;
+        let remote = self.n0_nat_traversal.next_probe_addr()?;
 
         if !self.paths.get(&path_id)?.data.validated {
             // Path is not usable for probing
@@ -2082,14 +2090,13 @@ impl Connection {
         builder.finish(self, now);
 
         // Mark as sent after packet build succeeds.
-        if let Ok(server_state) = self.n0_nat_traversal.server_side_mut() {
-            server_state.mark_probe_sent((remote.ip(), remote.port()), token);
-        }
+        self.n0_nat_traversal
+            .mark_probe_sent((remote.ip(), remote.port()), token);
 
         let size = buf.len();
-
         self.path_stats.for_path(path_id).udp_tx.on_sent(1, size);
 
+        trace!(dst = ?remote, len = buf.len(), "sending off-path NAT probe");
         Some(Transmit {
             destination: remote,
             size,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -81,7 +81,7 @@ use paths::{PathData, PathState};
 pub(crate) mod qlog;
 pub(crate) mod send_buffer;
 
-mod spaces;
+pub(crate) mod spaces;
 #[cfg(fuzzing)]
 pub use spaces::Retransmits;
 #[cfg(not(fuzzing))]
@@ -5112,13 +5112,6 @@ impl Connection {
 
                     use crate::cid_queue::InsertError;
                     match remote_cids.insert(frame) {
-                        Ok(None) if self.path(path_id).is_none() => {
-                            // TODO(flub): Once the client does off-path NAT probes as well
-                            //    we should remove this.
-                            // If this gives us CIDs to open a new path and a nat traversal attempt
-                            // is underway we could try to probe a pending remote
-                            self.continue_nat_traversal_round(now);
-                        }
                         Ok(None) => {}
                         Ok(Some((retired, reset_token))) => {
                             let pending_retired =
@@ -5355,10 +5348,6 @@ impl Connection {
                     if path_id > self.remote_max_path_id {
                         self.remote_max_path_id = path_id;
                         self.issue_first_path_cids(now);
-                        // TODO(flub): Once the client sends off-path NAT probes this is no
-                        //    longer needed. But new paths that need to be opened may need
-                        //    to be notified.
-                        while let Some(true) = self.continue_nat_traversal_round(now) {}
                     }
                 }
                 Frame::PathsBlocked(frame::PathsBlocked(max_path_id)) => {
@@ -6112,23 +6101,14 @@ impl Connection {
         }
 
         // REACH_OUT
-        if !scheduling_info.is_abandoned
+        while !scheduling_info.is_abandoned
             && scheduling_info.may_send_data
-            && let Some((round, addresses)) = space.pending.reach_out.as_mut()
+            && let Some(reach_out) = space
+                .pending
+                .reach_out
+                .pop_if(|frame| builder.frame_space_remaining() >= frame.size())
         {
-            while let Some(local_addr) = addresses.iter().next().copied() {
-                let local_addr = addresses.take(&local_addr).expect("found from iter");
-                let reach_out = frame::ReachOut::new(*round, local_addr);
-                if builder.frame_space_remaining() > reach_out.size() {
-                    builder.write_frame(reach_out, stats);
-                } else {
-                    addresses.insert(local_addr);
-                    break;
-                }
-            }
-            if addresses.is_empty() {
-                space.pending.reach_out = None;
-            }
+            builder.write_frame(reach_out, stats);
         }
 
         // PATH_ABANDON
@@ -7124,98 +7104,23 @@ impl Connection {
 
         let ipv6 = self.is_ipv6();
         let client_state = self.n0_nat_traversal.client_side_mut()?;
-        let n0_nat_traversal::NatTraversalRound {
-            new_round,
-            reach_out_at,
-            addresses_to_probe,
-            prev_round_path_ids,
-        } = client_state.initiate_nat_traversal_round(ipv6)?;
-
-        trace!(%new_round, reach_out=reach_out_at.len(), to_probe=addresses_to_probe.len(),
-            "initiating nat traversal round");
-
-        self.spaces[SpaceId::Data].pending.reach_out = Some((new_round, reach_out_at));
-
-        for path_id in prev_round_path_ids {
-            let Some(path) = self.path(path_id) else {
-                continue;
-            };
-            let ip = path.network_path.remote.ip();
-            let port = path.network_path.remote.port();
-
-            // We only close paths that aren't validated (thus are working) that we opened
-            // in a previous round.
-            // And we only close paths that we don't want to probe anyways.
-            if !addresses_to_probe
-                .iter()
-                .any(|(_, probe)| *probe == (ip, port))
-                && !path.validated
-                && !self.abandoned_paths.contains(&path_id)
-            {
-                trace!(%path_id, "closing path from previous round");
-                let _ =
-                    self.close_path_inner(now, path_id, PathAbandonReason::NatTraversalRoundEnded);
-            }
+        let (mut reach_out_frames, probed_addrs) =
+            client_state.initiate_nat_traversal_round(ipv6)?;
+        if !probed_addrs.is_empty() {
+            let delay = RttEstimator::new(self.config.initial_rtt).pto_base() * 2 / 3;
+            self.timers.set(
+                Timer::Conn(ConnTimer::NatTraversalProbeRetry),
+                now + delay,
+                self.qlog.with_time(now),
+            );
         }
 
-        let mut err = None;
+        self.spaces[SpaceId::Data]
+            .pending
+            .reach_out
+            .append(&mut reach_out_frames);
 
-        let mut path_ids = Vec::with_capacity(addresses_to_probe.len());
-        let mut probed_addresses = Vec::with_capacity(addresses_to_probe.len());
-
-        for (id, address) in addresses_to_probe {
-            match self.open_nat_traversal_path(now, address) {
-                Ok(None) => {}
-                Ok(Some((path_id, remote))) => {
-                    path_ids.push(path_id);
-                    probed_addresses.push(remote);
-                }
-                Err(e) => {
-                    self.n0_nat_traversal
-                        .client_side_mut()
-                        .expect("validated")
-                        .report_in_continuation(id, e);
-                    err.get_or_insert(e);
-                }
-            }
-        }
-
-        if let Some(err) = err {
-            // We failed to probe any addresses, bail out
-            if probed_addresses.is_empty() {
-                return Err(n0_nat_traversal::Error::Multipath(err));
-            }
-        }
-
-        self.n0_nat_traversal
-            .client_side_mut()
-            .expect("connection side validated")
-            .set_round_path_ids(path_ids);
-
-        Ok(probed_addresses)
-    }
-
-    /// Attempts to continue a nat traversal round by trying to open paths for pending client probes.
-    ///
-    /// If there was nothing to do, it returns `None`. Otherwise it returns whether the path was
-    /// successfully open.
-    fn continue_nat_traversal_round(&mut self, now: Instant) -> Option<bool> {
-        let ipv6 = self.is_ipv6();
-        let client_state = self.n0_nat_traversal.client_side_mut().ok()?;
-        let (id, address) = client_state.continue_nat_traversal_round(ipv6)?;
-        let open_result = self.open_nat_traversal_path(now, address);
-        let client_state = self.n0_nat_traversal.client_side_mut().expect("validated");
-        match open_result {
-            Ok(None) => Some(true),
-            Ok(Some((path_id, _remote))) => {
-                client_state.add_round_path_id(path_id);
-                Some(true)
-            }
-            Err(e) => {
-                client_state.report_in_continuation(id, e);
-                Some(false)
-            }
-        }
+        Ok(probed_addrs)
     }
 
     /// Whether the handshake is considered **confirmed**.
@@ -7655,25 +7560,7 @@ impl SentFrames {
             Close(_) => { /* non retransmittable, but after this we don't really care */ }
             PathResponse(_) => self.non_retransmits = true,
             HandshakeDone(_) => self.retransmits_mut().handshake_done = true,
-            ReachOut(frame::ReachOut { round, ip, port }) => {
-                let (recorded_round, reach_outs) = self
-                    .retransmits_mut()
-                    .reach_out
-                    .get_or_insert_with(|| (round, FxHashSet::default()));
-                // Only record reach outs for the current round or a newer than the recorded one.
-                if *recorded_round == round {
-                    // Same round, simply append.
-                    reach_outs.insert((ip, port));
-                } else if *recorded_round < round {
-                    // New round.
-                    *recorded_round = round;
-                    reach_outs.drain();
-                    reach_outs.insert((ip, port));
-                } else {
-                    // ignore old reach out that was sent
-                }
-            }
-
+            ReachOut(frame) => self.retransmits_mut().reach_out.push(frame),
             ObservedAddr(_) => self.retransmits_mut().observed_addr = true,
             Ping(_) => self.non_retransmits = true,
             ImmediateAck(_) => self.non_retransmits = true,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2412,7 +2412,7 @@ impl Connection {
                         }
                     }
                     ConnTimer::NatTraversalProbeRetry => {
-                        if self.n0_nat_traversal.queue_retries() {
+                        if self.n0_nat_traversal.queue_retries(self.is_ipv6()) {
                             let delay =
                                 RttEstimator::new(self.config.initial_rtt).pto_base() * 2 / 3;
                             self.timers.set(

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4914,50 +4914,11 @@ impl Connection {
                 }
                 Frame::PathResponse(response) => {
                     // First try to see if this is a NAT probe response.
-                    if let Some(network_path) = self
+                    if self
                         .n0_nat_traversal
                         .handle_path_response(network_path, response.0)
                     {
-                        trace!(
-                            ?network_path,
-                            challenge = response.0,
-                            "Received valid NAT traversal probe response"
-                        );
-                        if self.side.is_client() {
-                            match self.open_path_ensure(network_path, PathStatus::Backup, now) {
-                                Ok((path_id, already_existed)) => {
-                                    debug!(
-                                        %path_id,
-                                        ?network_path,
-                                        new_path=!already_existed,
-                                        "Opened NAT traversal path",
-                                    );
-                                }
-                                Err(err) => match err {
-                                    PathError::MultipathNotNegotiated
-                                    | PathError::ServerSideNotAllowed
-                                    | PathError::ValidationFailed
-                                    | PathError::InvalidRemoteAddress(_) => {
-                                        error!(
-                                            ?err,
-                                            ?network_path,
-                                            "Failed to open path after NAT traversal"
-                                        );
-                                    }
-                                    PathError::MaxPathIdReached
-                                    | PathError::RemoteCidsExhausted => {
-                                        // This is a temporary failure, enqueue this.
-                                        debug!(
-                                            ?err,
-                                            ?network_path,
-                                            "Blocked opening NAT traversal path"
-                                        );
-                                        // TODO(flub): do this.
-                                    }
-                                },
-                            }
-                        }
-                        // Server-side: nothing else to do.
+                        self.open_nat_traversed_paths(now);
                     } else {
                         // Try to see if this is a response to an on-path PATH_CHALLENGE.
 
@@ -5154,7 +5115,9 @@ impl Connection {
 
                     use crate::cid_queue::InsertError;
                     match remote_cids.insert(frame) {
-                        Ok(None) => {}
+                        Ok(None) => {
+                            self.open_nat_traversed_paths(now);
+                        }
                         Ok(Some((retired, reset_token))) => {
                             let pending_retired =
                                 &mut self.spaces[SpaceId::Data].pending.retire_cids;
@@ -5173,6 +5136,7 @@ impl Connection {
                             }
                             pending_retired.extend(retired.map(|seq| (path_id, seq)));
                             self.set_reset_token(path_id, network_path.remote, reset_token);
+                            self.open_nat_traversed_paths(now);
                         }
                         Err(InsertError::ExceedsLimit) => {
                             return Err(TransportError::CONNECTION_ID_LIMIT_ERROR(""));
@@ -5391,6 +5355,7 @@ impl Connection {
                         self.remote_max_path_id = path_id;
                         self.issue_first_path_cids(now);
                     }
+                    self.open_nat_traversed_paths(now);
                 }
                 Frame::PathsBlocked(frame::PathsBlocked(max_path_id)) => {
                     // Receipt of a value of Maximum Path Identifier or Path Identifier that is higher than the local maximum value MUST
@@ -5596,6 +5561,53 @@ impl Connection {
         }
 
         Ok(())
+    }
+
+    /// Opens any paths that have been successfully NAT traversed.
+    fn open_nat_traversed_paths(&mut self, now: Instant) {
+        while let Some(network_path) = self
+            .n0_nat_traversal
+            .client_side_mut()
+            .map(|s| s.pop_pending_path_open())
+            .ok()
+            .flatten()
+        {
+            match self.open_path_ensure(network_path, PathStatus::Backup, now) {
+                Ok((path_id, already_existed)) => {
+                    debug!(
+                        %path_id,
+                        ?network_path,
+                        new_path = !already_existed,
+                        "Opened NAT traversal path",
+                    );
+                }
+                Err(err) => match err {
+                    PathError::MultipathNotNegotiated
+                    | PathError::ServerSideNotAllowed
+                    | PathError::ValidationFailed
+                    | PathError::InvalidRemoteAddress(_) => {
+                        error!(
+                            ?err,
+                            ?network_path,
+                            "Failed to open path for successful NAT traversal"
+                        );
+                    }
+                    PathError::MaxPathIdReached | PathError::RemoteCidsExhausted => {
+                        // Temporary error, put back.
+                        self.n0_nat_traversal
+                            .client_side_mut()
+                            .map(|s| s.push_pending_path_open(network_path))
+                            .ok();
+                        debug!(
+                            ?err,
+                            ?network_path,
+                            "Blocked opening NAT traversal path, enqueued"
+                        );
+                        return;
+                    }
+                },
+            }
+        }
     }
 
     /// Migrates the 4-tuple of the path.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5569,8 +5569,7 @@ impl Connection {
             .n0_nat_traversal
             .client_side_mut()
             .map(|s| s.pop_pending_path_open())
-            .ok()
-            .flatten()
+            .unwrap_or_default()
         {
             match self.open_path_ensure(network_path, PathStatus::Backup, now) {
                 Ok((path_id, already_existed)) => {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2412,9 +2412,7 @@ impl Connection {
                         }
                     }
                     ConnTimer::NatTraversalProbeRetry => {
-                        if let Ok(server_state) = self.n0_nat_traversal.server_side_mut()
-                            && server_state.queue_retries()
-                        {
+                        if self.n0_nat_traversal.queue_retries() {
                             let delay =
                                 RttEstimator::new(self.config.initial_rtt).pto_base() * 2 / 3;
                             self.timers.set(
@@ -2422,7 +2420,9 @@ impl Connection {
                                 now + delay,
                                 self.qlog.with_time(now),
                             );
-                            trace!("off-path probe retry timer fired, re-queued probes");
+                            trace!("re-queued NAT probes");
+                        } else {
+                            trace!("no more NAT probes remaining");
                         }
                     }
                 },

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -535,10 +535,7 @@ impl PathData {
 
                 let prev_status = std::mem::replace(&mut self.open_status, OpenStatus::Informed);
                 OnPathResponseReceived::OnPath {
-                    was_open: matches!(
-                        prev_status,
-                        OpenStatus::Informed | OpenStatus::Revalidating
-                    ),
+                    was_open: matches!(prev_status, OpenStatus::Informed),
                 }
             }
             // Response to an on-path PathChallenge that does not validate this path.
@@ -684,12 +681,6 @@ pub(super) enum OpenStatus {
     Sent,
     /// The application has been informed of this path.
     Informed,
-    /// The path was [`Self::Informed`] before, but we want to trigger path validation again.
-    ///
-    /// This is used to ensure we properly stop trying to re-send path challenges eventually, without
-    /// having to switch to [`Self::Pending`] when re-validating, as that would trigger another
-    /// application-level event about the path opening once validation succeeds.
-    Revalidating,
 }
 
 /// Congestion metrics as described in [`recovery_metrics_updated`].

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -763,6 +763,7 @@ impl PendingReachOutFrames {
         if frame.round < self.round {
             return;
         } else if frame.round > self.round {
+            self.round = frame.round;
             self.frames.clear();
         }
         self.frames.push(frame);
@@ -773,6 +774,7 @@ impl PendingReachOutFrames {
             other.frames.clear();
             return;
         } else if other.round > self.round {
+            self.round = other.round;
             self.frames.clear();
         }
         self.frames.append(&mut other.frames);

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -768,7 +768,7 @@ impl PendingReachOutFrames {
         self.frames.push(frame);
     }
 
-    pub(crate) fn append(&mut self, other: &mut PendingReachOutFrames) {
+    pub(crate) fn append(&mut self, other: &mut Self) {
         if other.round < self.round {
             other.frames.clear();
             return;

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -2,7 +2,6 @@ use std::{
     cmp,
     collections::{BTreeMap, BTreeSet, VecDeque},
     mem,
-    net::IpAddr,
     ops::{Bound, Index, IndexMut},
 };
 
@@ -558,7 +557,7 @@ pub struct Retransmits {
     /// Address IDs to remove in `REMOVE_ADDRESS` frames
     pub(super) remove_address: BTreeSet<RemoveAddress>,
     /// Round and local addresses to advertise in `REACH_OUT` frames
-    pub(super) reach_out: Option<(VarInt, FxHashSet<(IpAddr, u16)>)>,
+    pub(super) reach_out: PendingReachOutFrames,
 }
 
 impl Retransmits {
@@ -608,7 +607,7 @@ impl Retransmits {
             && path_cids_blocked.is_empty()
             && add_address.is_empty()
             && remove_address.is_empty()
-            && reach_out.is_none()
+            && reach_out.is_empty()
     }
 }
 
@@ -635,7 +634,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
             mut path_cids_blocked,
             add_address,
             remove_address,
-            reach_out,
+            mut reach_out,
         } = rhs;
 
         // We reduce in-stream head-of-line blocking by queueing retransmits before other data for
@@ -664,22 +663,7 @@ impl ::std::ops::BitOrAssign for Retransmits {
         self.path_cids_blocked.append(&mut path_cids_blocked);
         self.add_address.extend(add_address.iter().copied());
         self.remove_address.extend(remove_address.iter().copied());
-        if let Some((rhs_round, rhs_addrs)) = reach_out {
-            match self.reach_out.as_mut() {
-                // Use RHS if there is no recorded round.
-                None => self.reach_out = Some((rhs_round, rhs_addrs)),
-                // Use RHS if newer.
-                Some((lhs_round, _lhs_addrs)) if rhs_round > *lhs_round => {
-                    self.reach_out = Some((rhs_round, rhs_addrs));
-                }
-                // If both rounds are the same, merge them.
-                Some((lhs_round, lhs_addrs)) if rhs_round == *lhs_round => {
-                    lhs_addrs.extend(rhs_addrs);
-                }
-                // LHS round is newer, ignore RHS
-                Some(_) => {}
-            }
-        }
+        self.reach_out.append(&mut reach_out);
     }
 }
 
@@ -749,6 +733,71 @@ impl PendingNewCids {
         F: FnMut(&IssuedCid) -> bool,
     {
         self.cids.retain(f);
+    }
+}
+
+/// Logically a Vec of REACH_OUT frames queued for transmit.
+///
+/// This keeps track of the highest round ID and automatically drops frames with a lower
+/// round ID.
+///
+/// The API is directly modelled on [`Vec`].
+#[derive(Debug, Default, Clone)]
+pub(crate) struct PendingReachOutFrames {
+    /// The round ID of the REACH_OUT frames currently pending.
+    round: VarInt,
+    /// The REACH_OUT frames, always all having the same round ID.
+    frames: Vec<frame::ReachOut>,
+}
+
+impl PendingReachOutFrames {
+    pub(crate) fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    pub(crate) fn push(&mut self, frame: frame::ReachOut) {
+        if frame.round < self.round {
+            return;
+        } else if frame.round > self.round {
+            self.frames.clear();
+        }
+        self.frames.push(frame);
+    }
+
+    pub(crate) fn append(&mut self, other: &mut PendingReachOutFrames) {
+        if other.round < self.round {
+            other.frames.clear();
+            return;
+        } else if other.round > self.round {
+            self.frames.clear();
+        }
+        self.frames.append(&mut other.frames);
+    }
+
+    pub(crate) fn pop_if(
+        &mut self,
+        predicate: impl FnOnce(&mut frame::ReachOut) -> bool,
+    ) -> Option<frame::ReachOut> {
+        self.frames.pop_if(predicate)
+    }
+}
+
+impl FromIterator<frame::ReachOut> for PendingReachOutFrames {
+    fn from_iter<T: IntoIterator<Item = frame::ReachOut>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let size_hint = iter.size_hint();
+        let mut this = Self {
+            round: Default::default(),
+            frames: Vec::with_capacity(size_hint.1.unwrap_or(size_hint.0)),
+        };
+        for frame in iter {
+            this.push(frame);
+        }
+        this
     }
 }
 

--- a/noq-proto/src/frame.rs
+++ b/noq-proto/src/frame.rs
@@ -2370,7 +2370,8 @@ impl Encodable for AddAddress {
     }
 }
 
-/// Conjunction of the information contained in the reach out frames
+/// Conjunction of the information contained in the reach out frames.
+///
 /// ([`FrameType::ReachOutAtIpv4`], [`FrameType::ReachOutAtIpv6`])
 #[derive(Debug, PartialEq, Eq, Clone, derive_more::Display)]
 #[display("REACH_OUT round: {round} local_addr: {}", self.socket_addr())]
@@ -2384,21 +2385,7 @@ pub(crate) struct ReachOut {
     pub(crate) port: u16,
 }
 
-// TODO(@divma): remove
-#[allow(dead_code)]
 impl ReachOut {
-    /// Smallest number of bytes this type of frame is guaranteed to fit within
-    pub(crate) const SIZE_BOUND: usize = Self {
-        round: VarInt::MAX,
-        ip: IpAddr::V6(std::net::Ipv6Addr::LOCALHOST),
-        port: u16::MAX,
-    }
-    .size();
-
-    pub(crate) const fn new(round: VarInt, (ip, port): (IpAddr, u16)) -> Self {
-        Self { round, ip, port }
-    }
-
     /// Get the [`FrameType`] for this frame
     pub(crate) const fn get_type(&self) -> FrameType {
         if self.ip.is_ipv6() {

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -182,6 +182,18 @@ impl State {
             Self::ServerSide(state) => state.mark_probe_sent(remote, challenge),
         }
     }
+
+    /// Re-queues probes that have not yet succeeded or reached 0 remaining retries.
+    ///
+    /// Returns whether any probes are now queued to send. In this case the
+    /// `NatTraversalProbeRetry` timer needs to be reset.
+    pub(crate) fn queue_retries(&mut self) -> bool {
+        match self {
+            State::NotNegotiated => false,
+            State::ClientSide(state) => state.queue_retries(),
+            State::ServerSide(state) => state.queue_retries(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -162,6 +162,26 @@ impl State {
                 .collect()),
         }
     }
+
+    /// Returns the next ready probe's address.
+    ///
+    /// If this is actually sent you must call [`Self::mark_probe_sent`].
+    pub(crate) fn next_probe_addr(&self) -> Option<SocketAddr> {
+        match self {
+            Self::NotNegotiated => None,
+            Self::ClientSide(state) => state.next_probe_addr(),
+            Self::ServerSide(state) => state.next_probe_addr(),
+        }
+    }
+
+    /// Marks a probe as sent to the address with the challenge.
+    pub(crate) fn mark_probe_sent(&mut self, remote: IpPort, challenge: u64) {
+        match self {
+            Self::NotNegotiated => (),
+            Self::ClientSide(state) => state.mark_probe_sent(remote, challenge),
+            Self::ServerSide(state) => state.mark_probe_sent(remote, challenge),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -196,7 +216,7 @@ pub(crate) struct ClientState {
     /// Queued probes to be sent in the next [`poll_transmit`] call.
     ///
     /// [`poll_transmit`]: crate::connection::Connection::poll_transmit
-    pending_probes: Vec<IpPort>,
+    pending_probes: FxHashSet<IpPort>,
 }
 
 impl ClientState {
@@ -264,7 +284,7 @@ impl ClientState {
             .values_mut()
             .for_each(|((ip, port), state)| {
                 if let Some(ip) = map_to_local_socket_family(*ip, ipv6) {
-                    self.pending_probes.push((ip, *port));
+                    self.pending_probes.insert((ip, *port));
                     *state = ProbeState::Active(MAX_NAT_PROBE_ATTEMPTS - 1);
                 } else {
                     trace!(?ip, "not using IPv6 NAT candidate for IPv4 socket");
@@ -308,11 +328,24 @@ impl ClientState {
             .for_each(|(addr, state)| match state {
                 ProbeState::Active(remaining) if *remaining > 0 => {
                     *remaining -= 1;
-                    self.pending_probes.push(*addr);
+                    self.pending_probes.insert(*addr);
                 }
                 ProbeState::Active(_) | ProbeState::Succeeded => {}
             });
         !self.pending_probes.is_empty()
+    }
+
+    /// Returns the next ready probe's address.
+    ///
+    /// If this is actually sent you must call [`Self::mark_probe_sent`].
+    fn next_probe_addr(&self) -> Option<SocketAddr> {
+        self.pending_probes.iter().next().map(|addr| (*addr).into())
+    }
+
+    /// Marks a probe as sent to the address with the challenge.
+    fn mark_probe_sent(&mut self, remote: IpPort, challenge: u64) {
+        self.pending_probes.remove(&remote);
+        self.sent_challenges.insert(challenge, remote);
     }
 
     /// Adds an address to the remote set
@@ -548,12 +581,12 @@ impl ServerState {
     /// Returns the next ready probe's address.
     ///
     /// If this is actually sent you must call [`Self::mark_probe_sent`].
-    pub(crate) fn next_probe_addr(&self) -> Option<SocketAddr> {
+    fn next_probe_addr(&self) -> Option<SocketAddr> {
         self.pending_probes.iter().next().map(|addr| (*addr).into())
     }
 
     /// Marks a probe as sent to the address with the challenge.
-    pub(crate) fn mark_probe_sent(&mut self, remote: IpPort, challenge: u64) {
+    fn mark_probe_sent(&mut self, remote: IpPort, challenge: u64) {
         self.pending_probes.remove(&remote);
         self.sent_challenges.insert(challenge, remote);
     }

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -289,7 +289,7 @@ impl ClientState {
     /// round is initiated, the previous one is cancelled.
     ///
     /// `ipv6` indicates if the connection runs on a socket that supports IPv6. If so, then
-    /// all addresses returned in [`NatTraversalRound`] will be IPv6 addresses (and
+    /// all addresses returned [`PendingReachOutFrames`] will be IPv6 addresses (and
     /// IPv4-mapped IPv6 addresses if necessary). Otherwise they're all IPv4 addresses.  See
     /// also [`map_to_local_socket_family`].
     ///

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -113,14 +113,13 @@ impl State {
         &mut self,
         address: SocketAddr,
     ) -> Result<Option<AddAddress>, Error> {
-        let ip_port = IpPort::from((address.ip(), address.port()));
         match self {
             Self::NotNegotiated => Err(Error::ExtensionNotNegotiated),
             Self::ClientSide(client_state) => {
-                client_state.add_local_address(ip_port)?;
+                client_state.add_local_address(address)?;
                 Ok(None)
             }
-            Self::ServerSide(server_state) => server_state.add_local_address(ip_port),
+            Self::ServerSide(server_state) => server_state.add_local_address(address),
         }
     }
 
@@ -224,12 +223,17 @@ pub(crate) struct ClientState {
     /// These are addresses on which the server is potentially reachable, to use for NAT
     /// traversal attempts.
     ///
-    /// They are indexed by their ADD_ADDRESS sequence id.
+    /// They are indexed by their ADD_ADDRESS sequence id and stored in **canonical
+    /// form**. Not in the socket-native form as usual. This because we need to store them
+    /// so we have the correct sequence IDs.
     remote_addresses: FxHashMap<VarInt, (IpPort, ProbeState)>,
     /// Candidate addresses for the local endpoint.
     ///
     /// These are addresses on which we are potentially reachable, to use for NAT traversal
     /// attempts.
+    ///
+    /// They are stored in **canonical form**, not in socket-native form as usual. We may
+    /// nave a reflexive address that is IPv6 even if our local socket can only handle IPv4.
     local_addresses: FxHashSet<IpPort>,
     /// Current nat traversal round.
     round: VarInt,
@@ -265,7 +269,8 @@ impl ClientState {
         }
     }
 
-    fn add_local_address(&mut self, address: IpPort) -> Result<(), Error> {
+    fn add_local_address(&mut self, address: SocketAddr) -> Result<(), Error> {
+        let address = (address.ip().to_canonical(), address.port());
         if self.local_addresses.len() < self.max_local_addresses {
             self.local_addresses.insert(address);
             Ok(())
@@ -279,7 +284,8 @@ impl ClientState {
     }
 
     fn remove_local_address(&mut self, address: &IpPort) {
-        self.local_addresses.remove(address);
+        let address = (address.0.to_canonical(), address.1);
+        self.local_addresses.remove(&address);
     }
 
     /// Initiates a new nat traversal round.
@@ -398,7 +404,7 @@ impl ClientState {
         add_addr: AddAddress,
     ) -> Result<Option<SocketAddr>, Error> {
         let AddAddress { seq_no, ip, port } = add_addr;
-        let address = (ip, port);
+        let address = (ip.to_canonical(), port);
         let allow_new = self.remote_addresses.len() < self.max_remote_addresses;
         match self.remote_addresses.entry(seq_no) {
             Entry::Occupied(mut occupied_entry) => {
@@ -427,7 +433,7 @@ impl ClientState {
     ) -> Option<SocketAddr> {
         self.remote_addresses
             .remove(&remove_addr.seq_no)
-            .map(|(address, _report_in_continuation)| address.into())
+            .map(|(address, _)| address.into())
     }
 
     /// Checks that a received remote address is valid.
@@ -547,6 +553,9 @@ pub(crate) struct ServerState {
     max_local_addresses: usize,
     /// Candidate addresses the server reports as potentially reachable, to use for nat
     /// traversal attempts.
+    ///
+    /// They are stored in **canonical form**, not in socket-native form as usual. We may
+    /// nave a reflexive address that is IPv6 even if our local socket can only handle IPv4.
     local_addresses: FxHashMap<IpPort, VarInt>,
     /// The next id to use for local addresses sent to the client.
     next_local_addr_id: VarInt,
@@ -558,6 +567,8 @@ pub(crate) struct ServerState {
     /// The remote addresses participating in this round.
     ///
     /// The set is cleared when a new round starts.
+    ///
+    /// These are stored in the usual local-socket native form.
     remotes: FxHashMap<IpPort, ProbeState>,
     /// The data of PATH_CHALLENGE frames sent in probes.
     ///
@@ -587,7 +598,8 @@ impl ServerState {
         }
     }
 
-    fn add_local_address(&mut self, address: IpPort) -> Result<Option<AddAddress>, Error> {
+    fn add_local_address(&mut self, address: SocketAddr) -> Result<Option<AddAddress>, Error> {
+        let address = (address.ip().to_canonical(), address.port());
         let allow_new = self.local_addresses.len() < self.max_local_addresses;
         match self.local_addresses.entry(address) {
             Entry::Occupied(_) => Ok(None),

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -200,13 +200,9 @@ impl State {
     /// Returns the open network path if it was a response to one of the NAT traversal
     /// probes. Note that the NAT probes are not padded to 1200 bytes so only the address is
     /// validated, but not the entire path.
-    pub(crate) fn handle_path_response(
-        &mut self,
-        src: FourTuple,
-        challenge: u64,
-    ) -> Option<FourTuple> {
+    pub(crate) fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
         match self {
-            Self::NotNegotiated => None,
+            Self::NotNegotiated => false,
             Self::ClientSide(state) => state.handle_path_response(src, challenge),
             Self::ServerSide(state) => state.handle_path_response(src, challenge),
         }
@@ -246,6 +242,13 @@ pub(crate) struct ClientState {
     ///
     /// [`poll_transmit`]: crate::connection::Connection::poll_transmit
     pending_probes: FxHashSet<IpPort>,
+    /// Network paths that were successfully probed but not yet opened.
+    ///
+    /// When we do not have enough CIDs or free path IDs we might not have been able to open
+    /// a new path. This allows us to try re-open the path when we get new CIDs or a new
+    /// MAX_PATH_ID.
+    // TODO(flub): perhaps there should be a time-limit on these?
+    paths_to_be_opened: Vec<FourTuple>,
 }
 
 impl ClientState {
@@ -258,6 +261,7 @@ impl ClientState {
             round: Default::default(),
             sent_challenges: Default::default(),
             pending_probes: Default::default(),
+            paths_to_be_opened: Default::default(),
         }
     }
 
@@ -445,9 +449,9 @@ impl ClientState {
     /// Marks a remote as successful if the response matches a sent probe.
     ///
     /// Returns `true` if it was a response to one of the NAT traversal probes.
-    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> Option<FourTuple> {
+    fn handle_path_response(&mut self, network_path: FourTuple, challenge: u64) -> bool {
         if let Entry::Occupied(entry) = self.sent_challenges.entry(challenge) {
-            let remote = (src.remote().ip(), src.remote().port());
+            let remote = (network_path.remote().ip(), network_path.remote().port());
             if *entry.get() == remote {
                 entry.remove();
 
@@ -462,21 +466,36 @@ impl ClientState {
                     )
                     .next()
                 {
+                    trace!(
+                        ?network_path,
+                        challenge, "Received valid NAT traversal probe response"
+                    );
                     self.remote_addresses
                         .insert(seq, (remote, ProbeState::Succeeded));
-                    return Some(src);
+                    self.paths_to_be_opened.push(network_path);
+                    return true;
                 } else {
                     debug!("inconsistent remote addrs and seq");
                 }
             } else {
                 debug!(
                     ?challenge,
-                    ?src.remote,
+                    ?network_path.remote,
                     "PATH_RESPONSE matched a NAT traversal probe but mismatching addr",
                 )
             }
         }
-        None
+        false
+    }
+
+    /// Returns a path that was NAT traversed and needs to be opened.
+    pub(crate) fn pop_pending_path_open(&mut self) -> Option<FourTuple> {
+        self.paths_to_be_opened.pop()
+    }
+
+    /// Put back a path that needs to be opened, e.g. for a temporary failure.
+    pub(crate) fn push_pending_path_open(&mut self, network_path: FourTuple) {
+        self.paths_to_be_opened.push(network_path)
     }
 }
 
@@ -660,13 +679,13 @@ impl ServerState {
     /// Marks a remote as successful if the response matches a sent probe.
     ///
     /// Returns `true` if it was a response to one of the NAT traversal probes.
-    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> Option<FourTuple> {
+    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
         if let Entry::Occupied(entry) = self.sent_challenges.entry(challenge) {
             let remote = (src.remote().ip(), src.remote().port());
             if *entry.get() == remote {
                 entry.remove();
                 self.remotes.insert(remote, ProbeState::Succeeded);
-                return Some(src);
+                return true;
             } else {
                 debug!(
                     ?challenge,
@@ -675,7 +694,7 @@ impl ServerState {
                 )
             }
         }
-        None
+        false
     }
 }
 

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -9,7 +9,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::{debug, trace};
 
 use crate::{
-    FourTuple, PathId, Side, VarInt,
+    FourTuple, Side, VarInt,
+    connection::spaces::PendingReachOutFrames,
     frame::{AddAddress, ReachOut, RemoveAddress},
 };
 
@@ -36,22 +37,6 @@ pub enum Error {
     /// Attempted to initiate NAT traversal on a closed, or closing connection.
     #[error("The connection is already closed")]
     Closed,
-}
-
-pub(crate) struct NatTraversalRound {
-    /// Sequence number to use for the new reach out frames.
-    pub(crate) new_round: VarInt,
-    /// Addresses to use to send reach out frames.
-    pub(crate) reach_out_at: FxHashSet<IpPort>,
-    /// Remotes to probe by attempting to open new paths.
-    ///
-    /// The addresses include their Id, so that it can be used to signal these should be returned
-    /// in a nat traversal continuation by calling [`ClientState::report_in_continuation`].
-    ///
-    /// These are filtered and mapped to the IP family the local socket supports.
-    pub(crate) addresses_to_probe: Vec<(VarInt, IpPort)>,
-    /// [`PathId`]s of the cancelled round.
-    pub(crate) prev_round_path_ids: Vec<PathId>,
 }
 
 /// Event emitted when the client receives ADD_ADDRESS or REMOVE_ADDRESS frames.
@@ -189,19 +174,29 @@ pub(crate) struct ClientState {
     ///
     /// This is set by the remote endpoint.
     max_local_addresses: usize,
-    /// Candidate addresses the remote server reports as potentially reachable, to use for nat
+    /// Candidate addresses the remote endpoint advertises.
+    ///
+    /// These are addresses on which the server is potentially reachable, to use for NAT
     /// traversal attempts.
     ///
-    /// These are indexed by their advertised Id. For each address, whether the address should be
-    /// reported in nat traversal continuations is kept.
-    remote_addresses: FxHashMap<VarInt, (IpPort, bool)>,
-    /// Candidate addresses the local client reports as potentially reachable, to use for nat
-    /// traversal attempts.
+    /// They are indexed by their ADD_ADDRESS sequence id.
+    remote_addresses: FxHashMap<VarInt, (IpPort, ProbeState)>,
+    /// Candidate addresses for the local endpoint.
+    ///
+    /// These are addresses on which we are potentially reachable, to use for NAT traversal
+    /// attempts.
     local_addresses: FxHashSet<IpPort>,
     /// Current nat traversal round.
     round: VarInt,
-    /// [`PathId`]s used to probe remotes assigned to this round.
-    round_path_ids: Vec<PathId>,
+    /// The data of PATH_CHALLENGE frames sent in probes.
+    ///
+    /// These are cleared when a new round starts, so any late-arriving PATH_RESPONSEs will
+    /// have no effect.
+    sent_challenges: FxHashMap<u64, IpPort>,
+    /// Queued probes to be sent in the next [`poll_transmit`] call.
+    ///
+    /// [`poll_transmit`]: crate::connection::Connection::poll_transmit
+    pending_probes: Vec<IpPort>,
 }
 
 impl ClientState {
@@ -212,7 +207,8 @@ impl ClientState {
             remote_addresses: Default::default(),
             local_addresses: Default::default(),
             round: Default::default(),
-            round_path_ids: Default::default(),
+            sent_challenges: Default::default(),
+            pending_probes: Default::default(),
         }
     }
 
@@ -235,104 +231,101 @@ impl ClientState {
 
     /// Initiates a new nat traversal round.
     ///
-    /// A nat traversal round involves advertising the client's local addresses in `REACH_OUT`
-    /// frames, and initiating probing of the known remote addresses. When a new round is
-    /// initiated, the previous one is cancelled, and paths that have not been opened should be
-    /// closed.
+    /// A nat traversal round involves advertising the client's local addresses in
+    /// `REACH_OUT` frames, and initiating probing of the known remote addresses. When a new
+    /// round is initiated, the previous one is cancelled.
     ///
-    /// `ipv6` indicates if the connection runs on a socket that supports IPv6. If so, then all
-    /// addresses returned in [`NatTraversalRound`] will be IPv6 addresses (and IPv4-mapped IPv6
-    /// addresses if necessary). Otherwise they're all IPv4 addresses.
-    /// See also [`map_to_local_socket_family`].
+    /// `ipv6` indicates if the connection runs on a socket that supports IPv6. If so, then
+    /// all addresses returned in [`NatTraversalRound`] will be IPv6 addresses (and
+    /// IPv4-mapped IPv6 addresses if necessary). Otherwise they're all IPv4 addresses.  See
+    /// also [`map_to_local_socket_family`].
+    ///
+    /// # Returns
+    ///
+    /// The REACH_OUT frames that need to be sent to the peer and the probed addresses. The
+    /// probed addresses are only informational, the pending probes are stored in
+    /// [`Self::pending_probes`].
+    ///
+    /// If the probed addresses are non-empty the `NatTraversalProbeRetry` timer needs to be
+    /// set.
     pub(crate) fn initiate_nat_traversal_round(
         &mut self,
         ipv6: bool,
-    ) -> Result<NatTraversalRound, Error> {
+    ) -> Result<(PendingReachOutFrames, Vec<SocketAddr>), Error> {
         if self.local_addresses.is_empty() {
             return Err(Error::NotEnoughAddresses);
         }
 
-        let prev_round_path_ids = std::mem::take(&mut self.round_path_ids);
         self.round = self.round.saturating_add(1u8);
-        let mut addresses_to_probe = Vec::with_capacity(self.remote_addresses.len());
-        for (id, ((ip, port), report_in_continuation)) in self.remote_addresses.iter_mut() {
-            *report_in_continuation = false;
+        self.pending_probes.clear();
 
-            if let Some(ip) = map_to_local_socket_family(*ip, ipv6) {
-                addresses_to_probe.push((*id, (ip, *port)));
-            } else {
-                trace!(?ip, "not using IPv6 nat candidate for IPv4 socket");
-            }
-        }
-
-        Ok(NatTraversalRound {
-            new_round: self.round,
-            reach_out_at: self.local_addresses.iter().copied().collect(),
-            addresses_to_probe,
-            prev_round_path_ids,
-        })
-    }
-
-    /// Mark a remote address to be reported back in a nat traversal continuation if the error is
-    /// considered spurious from a nat traversal point of view.
-    ///
-    /// Ids not present are silently ignored.
-    pub(crate) fn report_in_continuation(&mut self, id: VarInt, e: crate::PathError) {
-        match e {
-            crate::PathError::MaxPathIdReached | crate::PathError::RemoteCidsExhausted => {
-                if let Some((_address, report_in_continuation)) = self.remote_addresses.get_mut(&id)
-                {
-                    *report_in_continuation = true;
+        // Enqueue the NAT probes to known remote addresses.
+        self.remote_addresses
+            .values_mut()
+            .for_each(|((ip, port), state)| {
+                if let Some(ip) = map_to_local_socket_family(*ip, ipv6) {
+                    self.pending_probes.push((ip, *port));
+                    *state = ProbeState::Active(MAX_NAT_PROBE_ATTEMPTS - 1);
+                } else {
+                    trace!(?ip, "not using IPv6 NAT candidate for IPv4 socket");
+                    *state = ProbeState::Active(0);
                 }
-            }
-            _ => {}
-        }
-    }
+            });
+        let probed_addrs: Vec<SocketAddr> = self
+            .pending_probes
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect();
 
-    /// Returns an address that needs to be probed, if any.
-    ///
-    /// The address will not be returned twice unless marked as such again with
-    /// [`Self::report_in_continuation`].
-    ///
-    /// `ipv6` indicates if the connection runs on a socket that supports IPv6. If so, then all
-    /// addresses returned in [`NatTraversalRound`] will be IPv6 addresses (and IPv4-mapped IPv6
-    /// addresses if necessary). Otherwise they're all IPv4 addresses.
-    /// See also [`map_to_local_socket_family`].
-    pub(crate) fn continue_nat_traversal_round(&mut self, ipv6: bool) -> Option<(VarInt, IpPort)> {
-        // this being random depends on iteration not returning always on the same order
-        let (id, (address, report_in_continuation)) = self
-            .remote_addresses
-            .iter_mut()
-            .filter(|(_id, (_addr, report))| *report)
-            .filter_map(|(id, ((ip, port), report))| {
-                // only continue with addresses we can send on our local socket
-                let Some(ip) = map_to_local_socket_family(*ip, ipv6) else {
-                    trace!(?ip, "not using IPv6 nat candidate for IPv4 socket");
-                    return None;
-                };
-                Some((*id, ((ip, *port), report)))
+        // Build the REACH_OUT frames.
+        let reach_out_frames: PendingReachOutFrames = self
+            .local_addresses
+            .iter()
+            .map(|&(ip, port)| ReachOut {
+                round: self.round,
+                ip,
+                port,
             })
-            .next()?;
-        *report_in_continuation = false;
-        Some((id, address))
+            .collect();
+
+        trace!(
+            round = %self.round,
+            reach_out = %reach_out_frames.len(),
+            to_probe = %self.pending_probes.len(),
+            "initiating NAT traversal round",
+        );
+        Ok((reach_out_frames, probed_addrs))
     }
 
-    /// Add a [`PathId`] as part of the current attempts to create paths based on the server's
-    /// advertised addresses.
-    pub(crate) fn set_round_path_ids(&mut self, path_ids: Vec<PathId>) {
-        self.round_path_ids = path_ids;
-    }
-
-    /// Add a [`PathId`] as part of the current attempts to create paths based on the server's
-    /// advertised addresses.
-    pub(crate) fn add_round_path_id(&mut self, path_id: PathId) {
-        self.round_path_ids.push(path_id);
+    /// Re-queues probes that have not yet succeeded or reached 0 remaining retries.
+    ///
+    /// Returns whether any probes are now queued to send. In this case the
+    /// `NatTraversalProbeRetry` timer needs to be reset.
+    pub(crate) fn queue_retries(&mut self) -> bool {
+        self.remote_addresses
+            .values_mut()
+            .for_each(|(addr, state)| match state {
+                ProbeState::Active(remaining) if *remaining > 0 => {
+                    *remaining -= 1;
+                    self.pending_probes.push(*addr);
+                }
+                ProbeState::Active(_) | ProbeState::Succeeded => {}
+            });
+        !self.pending_probes.is_empty()
     }
 
     /// Adds an address to the remote set
     ///
-    /// On success returns the address if it was new to the set. It will error when the set has no
-    /// capacity for the address.
+    /// On success returns the address if it was new to the set. It will error when the set
+    /// has no capacity for the address.
+    ///
+    /// If this is called while a round is in progress this will effectively add the address
+    /// to the current round. There is no guarantee however that the current round is still
+    /// in progress however, if the last [`Self::queue_retries`] call returned `false` the
+    /// round has stopped.
+    // TODO(flub): probably should add an event to signal that the round is finished, so
+    //    that the application knows to start a new round.
     pub(crate) fn add_remote_address(
         &mut self,
         add_addr: AddAddress,
@@ -344,21 +337,21 @@ impl ClientState {
             Entry::Occupied(mut occupied_entry) => {
                 let is_update = occupied_entry.get().0 != address;
                 if is_update {
-                    occupied_entry.insert((address, false));
+                    occupied_entry.insert((address, ProbeState::Active(MAX_NAT_PROBE_ATTEMPTS)));
                 }
                 // The value might be different. This should not happen, but we assume that the new
                 // address is more recent than the previous, and thus worth updating
                 Ok(is_update.then_some(address.into()))
             }
             Entry::Vacant(vacant_entry) if allow_new => {
-                vacant_entry.insert((address, false));
+                vacant_entry.insert((address, ProbeState::Active(MAX_NAT_PROBE_ATTEMPTS)));
                 Ok(Some(address.into()))
             }
             _ => Err(Error::TooManyAddresses),
         }
     }
 
-    /// Removes an address from the remote set
+    /// Removes an address from the remote set.
     ///
     /// Returns whether the address was present.
     pub(crate) fn remove_remote_address(
@@ -370,7 +363,7 @@ impl ClientState {
             .map(|(address, _report_in_continuation)| address.into())
     }
 
-    /// Checks that a received remote address is valid
+    /// Checks that a received remote address is valid.
     ///
     /// An address is valid as long as it does not change the value of a known address id.
     pub(crate) fn check_remote_address(&self, add_addr: &AddAddress) -> bool {
@@ -383,7 +376,7 @@ impl ClientState {
     pub(crate) fn get_remote_nat_traversal_addresses(&self) -> Vec<SocketAddr> {
         self.remote_addresses
             .values()
-            .map(|(address, _report_in_continuation)| (*address).into())
+            .map(|(address, _)| (*address).into())
             .collect()
     }
 }
@@ -537,7 +530,7 @@ impl ServerState {
 
     /// Re-queues probes that have not yet succeeded or reached [`MAX_NAT_PROBE_ATTEMPTS`].
     ///
-    /// Returns whether any probes are now queued to send.  In this case the
+    /// Returns whether any probes are now queued to send. In this case the
     /// `NatTraversalProbeRetry` timer needs to be reset.
     pub(crate) fn queue_retries(&mut self) -> bool {
         self.remotes

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -189,9 +189,20 @@ impl State {
     /// `NatTraversalProbeRetry` timer needs to be reset.
     pub(crate) fn queue_retries(&mut self) -> bool {
         match self {
-            State::NotNegotiated => false,
-            State::ClientSide(state) => state.queue_retries(),
-            State::ServerSide(state) => state.queue_retries(),
+            Self::NotNegotiated => false,
+            Self::ClientSide(state) => state.queue_retries(),
+            Self::ServerSide(state) => state.queue_retries(),
+        }
+    }
+
+    /// Marks a remote as successful if the response matches a sent probe.
+    ///
+    /// Returns `true` if it was a response to one of the NAT traversal probes.
+    pub(crate) fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
+        match self {
+            Self::NotNegotiated => false,
+            Self::ClientSide(state) => state.handle_path_response(src, challenge),
+            Self::ServerSide(state) => state.handle_path_response(src, challenge),
         }
     }
 }
@@ -424,6 +435,43 @@ impl ClientState {
             .map(|(address, _)| (*address).into())
             .collect()
     }
+
+    /// Marks a remote as successful if the response matches a sent probe.
+    ///
+    /// Returns `true` if it was a response to one of the NAT traversal probes.
+    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
+        if let Entry::Occupied(entry) = self.sent_challenges.entry(challenge) {
+            let remote = (src.remote().ip(), src.remote().port());
+            if *entry.get() == remote {
+                entry.remove();
+
+                // TODO: linear search is sad.
+                if let Some(seq) = self
+                    .remote_addresses
+                    .iter()
+                    .filter_map(
+                        |(seq, (addr, _))| {
+                            if *addr == remote { Some(*seq) } else { None }
+                        },
+                    )
+                    .next()
+                {
+                    self.remote_addresses
+                        .insert(seq, (remote, ProbeState::Succeeded));
+                    return true;
+                } else {
+                    debug!("inconsistent remote addrs and seq");
+                }
+            } else {
+                debug!(
+                    ?challenge,
+                    ?src.remote,
+                    "PATH_RESPONSE matched a NAT traversal probe but mismatching addr",
+                )
+            }
+        }
+        false
+    }
 }
 
 /// Maximum number of times we send a NAT probe to the same remote address in a round.
@@ -606,7 +654,7 @@ impl ServerState {
     /// Marks a remote as successful if the response matches a sent probe.
     ///
     /// Returns `true` if it was a response to one of the NAT traversal probes.
-    pub(crate) fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
+    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
         if let Entry::Occupied(entry) = self.sent_challenges.entry(challenge) {
             let remote = (src.remote().ip(), src.remote().port());
             if *entry.get() == remote {

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -448,7 +448,8 @@ impl ClientState {
 
     /// Marks a remote as successful if the response matches a sent probe.
     ///
-    /// Returns `true` if it was a response to one of the NAT traversal probes.
+    /// Returns `true` if it was a response to one of the NAT traversal probes. In that case
+    /// [`Self::pop_pending_path_open`] should be called to open the next path.
     fn handle_path_response(&mut self, network_path: FourTuple, challenge: u64) -> bool {
         if let Entry::Occupied(entry) = self.sent_challenges.entry(challenge) {
             let remote = (network_path.remote().ip(), network_path.remote().port());

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -186,10 +186,10 @@ impl State {
     ///
     /// Returns whether any probes are now queued to send. In this case the
     /// `NatTraversalProbeRetry` timer needs to be reset.
-    pub(crate) fn queue_retries(&mut self) -> bool {
+    pub(crate) fn queue_retries(&mut self, ipv6: bool) -> bool {
         match self {
             Self::NotNegotiated => false,
-            Self::ClientSide(state) => state.queue_retries(),
+            Self::ClientSide(state) => state.queue_retries(ipv6),
             Self::ServerSide(state) => state.queue_retries(),
         }
     }
@@ -241,10 +241,15 @@ pub(crate) struct ClientState {
     ///
     /// These are cleared when a new round starts, so any late-arriving PATH_RESPONSEs will
     /// have no effect.
+    ///
+    /// They are stored in the usual socket-native form.
     sent_challenges: FxHashMap<u64, IpPort>,
     /// Queued probes to be sent in the next [`poll_transmit`] call.
     ///
     /// [`poll_transmit`]: crate::connection::Connection::poll_transmit
+    ///
+    /// They are stored in the usual socket-native form. Probes to address families not
+    /// addressable by the family are never inserted.
     pending_probes: FxHashSet<IpPort>,
     /// Network paths that were successfully probed but not yet opened.
     ///
@@ -362,13 +367,20 @@ impl ClientState {
     ///
     /// Returns whether any probes are now queued to send. In this case the
     /// `NatTraversalProbeRetry` timer needs to be reset.
-    pub(crate) fn queue_retries(&mut self) -> bool {
+    ///
+    /// `ipv6` as for [`Self::initiate_nat_traversal_round`].
+    pub(crate) fn queue_retries(&mut self, ipv6: bool) -> bool {
         self.remote_addresses
             .values_mut()
             .for_each(|(addr, state)| match state {
                 ProbeState::Active(remaining) if *remaining > 0 => {
                     *remaining -= 1;
-                    self.pending_probes.insert(*addr);
+                    if let Some(ip) = map_to_local_socket_family(addr.0, ipv6) {
+                        self.pending_probes.insert((ip, addr.1));
+                    } else {
+                        trace!(?addr, "skipping IPv6 NAT candidate for IPv4 socket");
+                        *remaining = 0;
+                    }
                 }
                 ProbeState::Active(_) | ProbeState::Succeeded => {}
             });
@@ -478,7 +490,8 @@ impl ClientState {
                 {
                     trace!(
                         ?network_path,
-                        challenge, "Received valid NAT traversal probe response"
+                        challenge = %display(format_args!("0x{challenge:x}")),
+                        "Received valid NAT traversal probe response",
                     );
                     self.remote_addresses
                         .insert(seq, (remote, ProbeState::Succeeded));
@@ -489,9 +502,10 @@ impl ClientState {
                 }
             } else {
                 debug!(
-                    ?challenge,
                     ?network_path.remote,
-                    "PATH_RESPONSE matched a NAT traversal probe but mismatching addr",
+                    expected_remote = ?entry.get(),
+                    challenge = %display(format_args!("0x{challenge:x}")),
+                    "PATH_RESPONSE matched a NAT traversal probe but mismatching addr XXXX",
                 )
             }
         }

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -197,10 +197,16 @@ impl State {
 
     /// Marks a remote as successful if the response matches a sent probe.
     ///
-    /// Returns `true` if it was a response to one of the NAT traversal probes.
-    pub(crate) fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
+    /// Returns the open network path if it was a response to one of the NAT traversal
+    /// probes. Note that the NAT probes are not padded to 1200 bytes so only the address is
+    /// validated, but not the entire path.
+    pub(crate) fn handle_path_response(
+        &mut self,
+        src: FourTuple,
+        challenge: u64,
+    ) -> Option<FourTuple> {
         match self {
-            Self::NotNegotiated => false,
+            Self::NotNegotiated => None,
             Self::ClientSide(state) => state.handle_path_response(src, challenge),
             Self::ServerSide(state) => state.handle_path_response(src, challenge),
         }
@@ -439,7 +445,7 @@ impl ClientState {
     /// Marks a remote as successful if the response matches a sent probe.
     ///
     /// Returns `true` if it was a response to one of the NAT traversal probes.
-    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
+    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> Option<FourTuple> {
         if let Entry::Occupied(entry) = self.sent_challenges.entry(challenge) {
             let remote = (src.remote().ip(), src.remote().port());
             if *entry.get() == remote {
@@ -458,7 +464,7 @@ impl ClientState {
                 {
                     self.remote_addresses
                         .insert(seq, (remote, ProbeState::Succeeded));
-                    return true;
+                    return Some(src);
                 } else {
                     debug!("inconsistent remote addrs and seq");
                 }
@@ -470,7 +476,7 @@ impl ClientState {
                 )
             }
         }
-        false
+        None
     }
 }
 
@@ -654,13 +660,13 @@ impl ServerState {
     /// Marks a remote as successful if the response matches a sent probe.
     ///
     /// Returns `true` if it was a response to one of the NAT traversal probes.
-    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> bool {
+    fn handle_path_response(&mut self, src: FourTuple, challenge: u64) -> Option<FourTuple> {
         if let Entry::Occupied(entry) = self.sent_challenges.entry(challenge) {
             let remote = (src.remote().ip(), src.remote().port());
             if *entry.get() == remote {
                 entry.remove();
                 self.remotes.insert(remote, ProbeState::Succeeded);
-                return true;
+                return Some(src);
             } else {
                 debug!(
                     ?challenge,
@@ -669,7 +675,7 @@ impl ServerState {
                 )
             }
         }
-        false
+        None
     }
 }
 

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -310,6 +310,7 @@ impl ClientState {
         }
 
         self.round = self.round.saturating_add(1u8);
+        self.sent_challenges.clear();
         self.pending_probes.clear();
 
         // Enqueue the NAT probes to known remote addresses.
@@ -456,6 +457,8 @@ impl ClientState {
             if *entry.get() == remote {
                 entry.remove();
 
+                // self.remote_addresses is stored in canonical form.
+                let remote = (remote.0.to_canonical(), remote.1);
                 // TODO: linear search is sad.
                 if let Some(seq) = self
                     .remote_addresses

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1672,10 +1672,10 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");
-    assert!(matches!(event, Event::Path(PathEvent::Opened { .. })));
+    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
 
     let event = pair.poll(Server).expect("should have event");
-    assert!(matches!(event, Event::Path(PathEvent::Opened { .. })));
+    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
 
     Ok(())
 }

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1657,17 +1657,17 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");
-    assert!(matches!(
+    assert_matches!(
         event,
         Event::NatTraversal(n0_nat_traversal::Event::AddressAdded(_))
-    ));
+    );
 
     info!("init NAT traversal");
     pair.initiate_nat_traversal_round(Client)?;
 
     // Ensure we have no more events queued
-    assert!(pair.poll(Client).is_none());
-    assert!(pair.poll(Server).is_none());
+    assert_matches!(pair.poll(Client), None);
+    assert_matches!(pair.poll(Server), None);
 
     pair.drive();
 


### PR DESCRIPTION
## Description

Implement client-side off-path nat traversal:

- REACH_OUT frames are scheduled on a normal may_send_data path.
- NAT probes are sent off-path without opening a new path.
- On a successful probe a new path is opened.
- Paths to-be-opened are retried if they fail due to temporary errors.

Closes #568.

## Breaking Changes

While not specifically tested, I think this will still interoperate with a 0.98 peer.

## Notes & open questions

- Paths that fail to be opened due to insufficient CIDs or MAX_PATH_ID are retried without when those become available again, without time-limit. This is unlikely to be a big deal right now.

- The NAT state for ClientSide and ServerSide are very similar now. But I'd like to defer merging them further for a later refactor. This is already enough logic change. It's a tad annoying since one side needs to keep track of the sequence ID.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.