### PR TITLE
refactor!: cleanup single path based expectations

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1367,7 +1367,11 @@ impl Connection {
         if last_packet_number.is_some() || congestion_blocked {
             self.qlog.emit_recovery_metrics(
                 path_id,
-                &mut self.paths.get_mut(&path_id).unwrap().data,
+                &mut self
+                    .paths
+                    .get_mut(&path_id)
+                    .expect("path_id was iterated from self.paths above")
+                    .data,
                 now,
             );
         }
@@ -2436,7 +2440,11 @@ impl Connection {
                             self.on_loss_detection_timeout(now, path_id);
                             self.qlog.emit_recovery_metrics(
                                 path_id,
-                                &mut self.paths.get_mut(&path_id).unwrap().data,
+                                &mut self
+                                    .paths
+                                    .get_mut(&path_id)
+                                    .expect("loss-detection timer fires only on live paths")
+                                    .data,
                                 now,
                             );
                         }
@@ -3879,7 +3887,11 @@ impl Connection {
 
         self.qlog.emit_recovery_metrics(
             path_id,
-            &mut self.paths.get_mut(&path_id).unwrap().data,
+            &mut self
+                .paths
+                .get_mut(&path_id)
+                .expect("path_id was supplied by the caller for an active path")
+                .data,
             now,
         );
 
@@ -4059,7 +4071,10 @@ impl Connection {
         pns.loss_time = None;
         pns.loss_probes = 0;
         let sent_packets = mem::take(&mut pns.sent_packets);
-        let path = self.paths.get_mut(&PathId::ZERO).unwrap();
+        let path = self
+            .paths
+            .get_mut(&PathId::ZERO)
+            .expect("PathId::ZERO is alive while Initial/Handshake spaces exist");
         for (_, packet) in sent_packets.into_iter() {
             path.data.remove_in_flight(&packet);
         }

--- a/noq/examples/connection.rs
+++ b/noq/examples/connection.rs
@@ -21,7 +21,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         let conn = incoming_conn.await.unwrap();
         println!(
             "[server] connection accepted: addr={}",
-            conn.remote_address()
+            conn.path(noq::PathId::ZERO)
+                .expect("path open after connect")
+                .remote_address()
+                .expect("path is alive")
         );
         // Dropping all handles associated with a connection implicitly closes it
     });
@@ -33,7 +36,14 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
         .unwrap()
         .await
         .unwrap();
-    println!("[client] connected: addr={}", connection.remote_address());
+    println!(
+        "[client] connected: addr={}",
+        connection
+            .path(noq::PathId::ZERO)
+            .expect("path open after connect")
+            .remote_address()
+            .expect("path is alive")
+    );
 
     // Waiting for a stream will complete with an error when the server closes the connection
     let _ = connection.accept_uni().await;

--- a/noq/examples/insecure_connection.rs
+++ b/noq/examples/insecure_connection.rs
@@ -32,7 +32,10 @@ async fn run_server(addr: SocketAddr) {
     let conn = incoming_conn.await.unwrap();
     println!(
         "[server] connection accepted: addr={}",
-        conn.remote_address()
+        conn.path(noq::PathId::ZERO)
+            .expect("path open after connect")
+            .remote_address()
+            .expect("path is alive")
     );
 }
 
@@ -52,7 +55,14 @@ async fn run_client(server_addr: SocketAddr) -> Result<(), Box<dyn Error + Send 
         .unwrap()
         .await
         .unwrap();
-    println!("[client] connected: addr={}", connection.remote_address());
+    println!(
+        "[client] connected: addr={}",
+        connection
+            .path(noq::PathId::ZERO)
+            .expect("path open after connect")
+            .remote_address()
+            .expect("path is alive")
+    );
     // Dropping handles allows the corresponding objects to automatically shut down
     drop(connection);
     // Make sure the server has a chance to clean up

--- a/noq/examples/server.rs
+++ b/noq/examples/server.rs
@@ -175,7 +175,7 @@ async fn handle_connection(root: Arc<Path>, conn: noq::Incoming) -> Result<()> {
     let connection = conn.await?;
     let span = info_span!(
         "connection",
-        remote = %connection.remote_address(),
+        remote = ?connection.path(noq::PathId::ZERO).and_then(|p| p.remote_address().ok()),
         protocol = %connection
             .handshake_data()
             .unwrap()

--- a/noq/examples/single_socket.rs
+++ b/noq/examples/single_socket.rs
@@ -50,7 +50,11 @@ fn run_server(
         let connection = endpoint.accept().await.unwrap().await.unwrap();
         println!(
             "[server] incoming connection: addr={}",
-            connection.remote_address()
+            connection
+                .path(noq::PathId::ZERO)
+                .expect("path open after connect")
+                .remote_address()
+                .expect("path is alive")
         );
     });
 
@@ -61,5 +65,12 @@ fn run_server(
 async fn run_client(endpoint: &Endpoint, server_addr: SocketAddr) {
     let connect = endpoint.connect(server_addr, "localhost").unwrap();
     let connection = connect.await.unwrap();
-    println!("[client] connected: addr={}", connection.remote_address());
+    println!(
+        "[client] connected: addr={}",
+        connection
+            .path(noq::PathId::ZERO)
+            .expect("path open after connect")
+            .remote_address()
+            .expect("path is alive")
+    );
 }

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -186,13 +186,13 @@ impl Connecting {
     ///
     /// Will panic if called after `poll` has returned `Ready`.
     pub fn local_ip(&self) -> Option<IpAddr> {
-        let conn = self.conn.as_ref().unwrap();
+        let conn = self.conn.as_ref().expect("used after yielding Ready");
         let inner = conn.lock_without_waking("local_ip");
 
         inner
             .inner
             .network_path(PathId::ZERO)
-            .expect("path exists when connecting")
+            .expect("PathId::ZERO is the only path during the handshake")
             .local_ip()
     }
 
@@ -201,12 +201,11 @@ impl Connecting {
     /// Will panic if called after `poll` has returned `Ready`.
     pub fn remote_address(&self) -> SocketAddr {
         let conn_ref: &ConnectionRef = self.conn.as_ref().expect("used after yielding Ready");
-        // TODO: another unwrap
         conn_ref
             .lock_without_waking("remote_address")
             .inner
             .network_path(PathId::ZERO)
-            .expect("path exists when connecting")
+            .expect("PathId::ZERO is the only path during the handshake")
             .remote()
     }
 }
@@ -742,51 +741,6 @@ impl Connection {
     /// The side of the connection (client or server)
     pub fn side(&self) -> Side {
         self.0.lock_without_waking("side").inner.side()
-    }
-
-    /// The peer's UDP address
-    ///
-    /// If [`ServerConfig::migration`] is `true`, clients may change addresses at will,
-    /// e.g. when switching to a cellular internet connection.
-    ///
-    /// If [`multipath`] is enabled this will return the address of *any*
-    /// path, and may not be consistent. Prefer [`Path::remote_address`] instead.
-    ///
-    /// [`ServerConfig::migration`]: crate::ServerConfig::migration
-    /// [`multipath`]: crate::TransportConfig::max_concurrent_multipath_paths
-    pub fn remote_address(&self) -> SocketAddr {
-        // TODO: an unwrap again
-        let state = self.0.lock_without_waking("remote_address");
-        state
-            .inner
-            .paths()
-            .iter()
-            .filter_map(|id| state.inner.network_path(*id).ok())
-            .next()
-            .unwrap()
-            .remote()
-    }
-
-    /// The local IP address which was used when the peer established
-    /// the connection
-    ///
-    /// This can be different from the address the endpoint is bound to, in case
-    /// the endpoint is bound to a wildcard address like `0.0.0.0` or `::`.
-    ///
-    /// This will return `None` for clients, or when the platform does not expose this
-    /// information. See [`noq_udp::RecvMeta::dst_ip`](udp::RecvMeta::dst_ip) for a list of
-    /// supported platforms when using [`noq_udp`](udp) for I/O, which is the default.
-    pub fn local_ip(&self) -> Option<IpAddr> {
-        // TODO: an unwrap again
-        let state = self.0.lock_without_waking("remote_address");
-        state
-            .inner
-            .paths()
-            .iter()
-            .filter_map(|id| state.inner.network_path(*id).ok())
-            .next()
-            .unwrap()
-            .local_ip()
     }
 
     /// Current best estimate of this connection's latency (round-trip-time)

--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, ready};
@@ -273,6 +273,15 @@ impl Path {
     pub fn remote_address(&self) -> Result<SocketAddr, ClosedPath> {
         let state = self.conn.lock_without_waking("per_path_remote_address");
         Ok(state.inner.network_path(self.id)?.remote())
+    }
+
+    /// The local IP used for this path, if known.
+    ///
+    /// Returns `Ok(None)` for clients or when the platform does not expose this information; see
+    /// [`noq_udp::RecvMeta::dst_ip`](udp::RecvMeta::dst_ip) for supported platforms.
+    pub fn local_ip(&self) -> Result<Option<IpAddr>, ClosedPath> {
+        let state = self.conn.lock_without_waking("per_path_local_ip");
+        Ok(state.inner.network_path(self.id)?.local_ip())
     }
 
     /// Ping the remote endpoint over this path.

--- a/noq/tests/post_quantum.rs
+++ b/noq/tests/post_quantum.rs
@@ -43,7 +43,10 @@ async fn check_post_quantum_key_exchange(min_mtu: u16) {
         let conn = incoming_conn.await.unwrap();
         info!(
             "[server] connection accepted: addr={}",
-            conn.remote_address()
+            conn.path(noq::PathId::ZERO)
+                .expect("path open after connect")
+                .remote_address()
+                .expect("path is alive")
         );
         assert_eq!(
             conn.handshake_data()
@@ -63,7 +66,14 @@ async fn check_post_quantum_key_exchange(min_mtu: u16) {
         .unwrap()
         .await
         .unwrap();
-    info!("[client] connected: addr={}", connection.remote_address());
+    info!(
+        "[client] connected: addr={}",
+        connection
+            .path(noq::PathId::ZERO)
+            .expect("path open after connect")
+            .remote_address()
+            .expect("path is alive")
+    );
 
     // Waiting for a stream will complete with an error when the server closes the connection
     let _ = connection.accept_uni().await;

--- a/perf/src/server.rs
+++ b/perf/src/server.rs
@@ -101,7 +101,14 @@ pub async fn run(opt: Opt) -> Result<()> {
 async fn handle(handshake: noq::Incoming, opt: Arc<Opt>) -> Result<()> {
     let connection = handshake.await.context("handshake failed")?;
 
-    debug!("{} connected", connection.remote_address());
+    debug!(
+        "{} connected",
+        connection
+            .path(noq::PathId::ZERO)
+            .expect("path open after connect")
+            .remote_address()
+            .expect("path is alive")
+    );
     tokio::try_join!(
         drive_uni(connection.clone()),
         drive_bi(connection.clone()),


### PR DESCRIPTION
## Description

- Removes the two API calls on `Connection` that haven't been migrated yet
- Adds some more explicit `expect`s for unnamed `unwrap`s

Closes #514

## Breaking Changes

- remove
  - `noq::Connection::local_ip`
  - `noq::Connection::remote_address`

