### PR TITLE
feat(noq)!: Return Closed struct from Connection::on_closed with path stats

### DIFF
--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -568,9 +568,9 @@ impl Connection {
     pub fn on_closed(&self) -> OnClosed {
         let (tx, rx) = oneshot::channel();
         let mut state = self.0.lock_without_waking("on_closed");
-        if state.error.is_some() {
+        if let Some(reason) = state.error.clone() {
             // Connection already closed, send immediately
-            let _ = tx.send(Closed::new(&mut state));
+            let _ = tx.send(Closed::new(&mut state, reason));
         } else {
             state.on_closed.push(tx);
         }
@@ -1180,12 +1180,7 @@ impl Closed {
     /// Snapshot the current connection state into a [`Closed`] value.
     ///
     /// Must only be called once `state.error` has been set.
-    pub(crate) fn new(state: &mut State) -> Self {
-        let reason = state
-            .error
-            .clone()
-            .expect("Closed::new called before error was set");
-
+    pub(crate) fn new(state: &mut State, reason: ConnectionError) -> Self {
         let stats = state.inner.stats();
 
         let non_discarded_paths = state.inner.paths();
@@ -1737,7 +1732,7 @@ impl State {
 
     /// Used to wake up all blocked futures when the connection becomes closed for any reason
     fn terminate(&mut self, reason: ConnectionError, shared: &Shared) {
-        self.error = Some(reason);
+        self.error = Some(reason.clone());
         if let Some(x) = self.on_handshake_data.take() {
             let _ = x.send(());
         }
@@ -1758,7 +1753,7 @@ impl State {
 
         // Send to the registered on_closed futures.
         if !self.on_closed.is_empty() {
-            let closed = Closed::new(self);
+            let closed = Closed::new(self, reason);
             for tx in self.on_closed.drain(..) {
                 tx.send(closed.clone()).ok();
             }
@@ -1829,9 +1824,11 @@ impl Drop for State {
                 .send((self.handle, proto::EndpointEvent::drained()));
         }
 
-        if !self.on_closed.is_empty() {
+        if !self.on_closed.is_empty()
+            && let Some(reason) = self.error.clone()
+        {
             // Ensure that all on_closed oneshot senders are triggered before dropping.
-            let closed = Closed::new(self);
+            let closed = Closed::new(self, reason);
             for tx in self.on_closed.drain(..) {
                 tx.send(closed.clone()).ok();
             }

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1,6 +1,5 @@
 use std::{
     any::Any,
-    collections::BTreeMap,
     fmt,
     future::Future,
     io,
@@ -1174,7 +1173,7 @@ pub struct Closed {
     /// or [`WeakPathHandle`] handle was kept alive.
     ///
     /// [`WeakPathHandle`]: crate::WeakPathHandle
-    pub path_stats: BTreeMap<PathId, PathStats>,
+    pub path_stats: Vec<(PathId, PathStats)>,
 }
 
 impl Closed {
@@ -1186,18 +1185,26 @@ impl Closed {
             .error
             .clone()
             .expect("Closed::new called before error was set");
+
         let stats = state.inner.stats();
-        let mut path_stats = BTreeMap::new();
+
+        let non_discarded_paths = state.inner.paths();
+        let mut path_stats =
+            Vec::with_capacity(non_discarded_paths.len() + state.final_path_stats.len());
+
         // Non-discarded paths are tracked by proto::Connection.
-        for path_id in state.inner.paths() {
-            if let Some(stats) = state.inner.path_stats(path_id) {
-                path_stats.insert(path_id, stats);
-            }
-        }
+        path_stats.extend(
+            non_discarded_paths
+                .into_iter()
+                .filter_map(|id| state.inner.path_stats(id).map(|stats| (id, stats))),
+        );
         // Already-discarded paths whose final stats we kept around.
-        for (path_id, ps) in &state.final_path_stats {
-            path_stats.entry(*path_id).or_insert(*ps);
-        }
+        path_stats.extend(
+            state
+                .final_path_stats
+                .iter()
+                .map(|(id, stats)| (*id, *stats)),
+        );
         Self {
             reason,
             stats,

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -560,7 +560,7 @@ impl Connection {
 
     /// Wait for the connection to be closed without keeping a strong reference to the connection
     ///
-    /// Returns a future that resolves, once the connection is closed, to [`Closed`]
+    /// Returns a future that resolves, once the connection is closed, to a [`Closed`] struct
     /// describing the close reason and final connection and per-path statistics.
     ///
     /// Calling [`Self::closed`] keeps the connection alive until it is either closed locally via [`Connection::close`]

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1,5 +1,6 @@
 use std::{
     any::Any,
+    collections::BTreeMap,
     fmt,
     future::Future,
     io,
@@ -559,8 +560,8 @@ impl Connection {
 
     /// Wait for the connection to be closed without keeping a strong reference to the connection
     ///
-    /// Returns a future that resolves, once the connection is closed, to a tuple of
-    /// ([`ConnectionError`], [`ConnectionStats`]).
+    /// Returns a future that resolves, once the connection is closed, to [`Closed`]
+    /// describing the close reason and final connection and per-path statistics.
     ///
     /// Calling [`Self::closed`] keeps the connection alive until it is either closed locally via [`Connection::close`]
     /// or closed by the remote peer. This function instead does not keep the connection itself alive,
@@ -569,9 +570,9 @@ impl Connection {
     pub fn on_closed(&self) -> OnClosed {
         let (tx, rx) = oneshot::channel();
         let mut state = self.0.lock_without_waking("on_closed");
-        if let Some(error) = &state.error {
+        if state.error.is_some() {
             // Connection already closed, send immediately
-            let _ = tx.send((error.clone(), state.inner.stats()));
+            let _ = tx.send(Closed::new(&mut state));
         } else {
             state.on_closed.push(tx);
         }
@@ -1202,11 +1203,60 @@ impl Future for SendDatagram<'_> {
     }
 }
 
+/// State of a [`Connection`] at the moment it was closed.
+///
+/// Returned by the [`OnClosed`] future from [`Connection::on_closed`].
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct Closed {
+    /// The reason the connection was closed.
+    pub reason: ConnectionError,
+    /// Aggregate connection statistics at the moment of close.
+    pub stats: ConnectionStats,
+    /// Per-path statistics for every path the connection knew about at close time.
+    ///
+    /// This includes paths that haven't been discarded at close time, plus any
+    /// already-discarded paths whose final stats had been retained because a [`Path`]
+    /// or [`WeakPathHandle`] handle was kept alive.
+    ///
+    /// [`WeakPathHandle`]: crate::WeakPathHandle
+    pub path_stats: BTreeMap<PathId, PathStats>,
+}
+
+impl Closed {
+    /// Snapshot the current connection state into a [`Closed`] value.
+    ///
+    /// Must only be called once `state.error` has been set.
+    pub(crate) fn new(state: &mut State) -> Self {
+        let reason = state
+            .error
+            .clone()
+            .expect("Closed::new called before error was set");
+        let stats = state.inner.stats();
+        let mut path_stats = BTreeMap::new();
+        // Non-discarded paths are tracked by proto::Connection.
+        for path_id in state.inner.paths() {
+            if let Some(stats) = state.inner.path_stats(path_id) {
+                path_stats.insert(path_id, stats);
+            }
+        }
+        // Already-discarded paths whose final stats we kept around.
+        for (path_id, ps) in &state.final_path_stats {
+            path_stats.entry(*path_id).or_insert(*ps);
+        }
+        Self {
+            reason,
+            stats,
+            path_stats,
+        }
+    }
+}
+
 /// Future returned by [`Connection::on_closed`]
 ///
-/// Resolves to a tuple of ([`ConnectionError`], [`ConnectionStats`]).
+/// Resolves to [`Closed`].
 pub struct OnClosed {
-    rx: oneshot::Receiver<(ConnectionError, ConnectionStats)>,
+    rx: oneshot::Receiver<Closed>,
     conn: WeakConnectionHandle,
 }
 
@@ -1226,7 +1276,7 @@ impl Drop for OnClosed {
 }
 
 impl Future for OnClosed {
-    type Output = (ConnectionError, ConnectionStats);
+    type Output = Closed;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -1426,7 +1476,7 @@ pub(crate) struct State {
     /// last report across all paths.
     pub(crate) observed_external_addr: watch::Sender<Option<SocketAddr>>,
     pub(crate) nat_traversal_updates: tokio::sync::broadcast::Sender<n0_nat_traversal::Event>,
-    on_closed: Vec<oneshot::Sender<(ConnectionError, ConnectionStats)>>,
+    on_closed: Vec<oneshot::Sender<Closed>>,
 }
 
 impl State {
@@ -1726,7 +1776,7 @@ impl State {
 
     /// Used to wake up all blocked futures when the connection becomes closed for any reason
     fn terminate(&mut self, reason: ConnectionError, shared: &Shared) {
-        self.error = Some(reason.clone());
+        self.error = Some(reason);
         if let Some(x) = self.on_handshake_data.take() {
             let _ = x.send(());
         }
@@ -1746,9 +1796,11 @@ impl State {
         shared.closed.notify_waiters();
 
         // Send to the registered on_closed futures.
-        let stats = self.inner.stats();
-        for tx in self.on_closed.drain(..) {
-            tx.send((reason.clone(), stats.clone())).ok();
+        if !self.on_closed.is_empty() {
+            let closed = Closed::new(self);
+            for tx in self.on_closed.drain(..) {
+                tx.send(closed.clone()).ok();
+            }
         }
     }
 
@@ -1818,10 +1870,9 @@ impl Drop for State {
 
         if !self.on_closed.is_empty() {
             // Ensure that all on_closed oneshot senders are triggered before dropping.
-            let reason = self.error.as_ref().expect("closed without error reason");
-            let stats = self.inner.stats();
+            let closed = Closed::new(self);
             for tx in self.on_closed.drain(..) {
-                tx.send((reason.clone(), stats.clone())).ok();
+                tx.send(closed.clone()).ok();
             }
         }
     }

--- a/noq/src/lib.rs
+++ b/noq/src/lib.rs
@@ -77,7 +77,7 @@ pub use rustls;
 pub use udp;
 
 pub use crate::connection::{
-    AcceptBi, AcceptUni, Connecting, Connection, OnClosed, OpenBi, OpenUni, ReadDatagram,
+    AcceptBi, AcceptUni, Closed, Connecting, Connection, OnClosed, OpenBi, OpenUni, ReadDatagram,
     SendDatagram, SendDatagramError, WeakConnectionHandle, ZeroRttAccepted,
 };
 pub use crate::endpoint::{Accept, Endpoint, EndpointStats};

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -23,9 +23,7 @@ use std::{
 use crate::runtime::TokioRuntime;
 use crate::{Duration, Instant};
 use bytes::Bytes;
-use proto::{
-    ConnectionError, PathId, RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig,
-};
+use proto::{ConnectionError, PathId, RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rustls::{
     RootCertStore,

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -23,7 +23,9 @@ use std::{
 use crate::runtime::TokioRuntime;
 use crate::{Duration, Instant};
 use bytes::Bytes;
-use proto::{ConnectionError, PathId, RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig};
+use proto::{
+    ConnectionError, PathId, RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig,
+};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rustls::{
     RootCertStore,
@@ -1407,14 +1409,17 @@ async fn closed_includes_path_stats_for_all_known_paths() -> TestResult {
         let closed = on_closed_fut.await;
 
         let initial_path = PathId::ZERO;
-        let keys: Vec<_> = closed.path_stats.keys().copied().collect();
+        let ids: Vec<_> = closed.path_stats.iter().map(|(id, _stats)| *id).collect();
         assert!(
-            closed.path_stats.contains_key(&path2_id),
-            "Closed.path_stats missing the discarded path {path2_id:?}; keys={keys:?}",
+            closed.path_stats.iter().any(|(id, _stats)| *id == path2_id),
+            "Closed.path_stats missing the discarded path {path2_id:?}; ids={ids:?}",
         );
         assert!(
-            closed.path_stats.contains_key(&initial_path),
-            "Closed.path_stats missing the initial path {initial_path:?}; keys={keys:?}",
+            closed
+                .path_stats
+                .iter()
+                .any(|(id, _stats)| *id == initial_path),
+            "Closed.path_stats missing the initial path {initial_path:?}; ids={ids:?}",
         );
 
         TestResult::Ok(())

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -23,7 +23,7 @@ use std::{
 use crate::runtime::TokioRuntime;
 use crate::{Duration, Instant};
 use bytes::Bytes;
-use proto::{ConnectionError, RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig};
+use proto::{ConnectionError, PathId, RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rustls::{
     RootCertStore,
@@ -1103,9 +1103,12 @@ async fn on_closed() {
             .expect("connection");
         let on_closed = conn.on_closed();
         let cause = conn.closed().await;
-        let (cause1, _stats) = on_closed.await;
+        let closed = on_closed.await;
         assert!(matches!(cause, ConnectionError::ApplicationClosed(_)));
-        assert!(matches!(cause1, ConnectionError::ApplicationClosed(_)));
+        assert!(matches!(
+            closed.reason,
+            ConnectionError::ApplicationClosed(_)
+        ));
     });
     let client_task = tokio::spawn(async move {
         let conn = endpoint
@@ -1117,10 +1120,8 @@ async fn on_closed() {
         let on_closed2 = conn.on_closed();
         drop(conn);
 
-        let (cause, _stats) = on_closed1.await;
-        assert_eq!(cause, ConnectionError::LocallyClosed);
-        let (cause, _stats) = on_closed2.await;
-        assert_eq!(cause, ConnectionError::LocallyClosed);
+        assert_eq!(on_closed1.await.reason, ConnectionError::LocallyClosed);
+        assert_eq!(on_closed2.await.reason, ConnectionError::LocallyClosed);
     });
     let (server_res, client_res) = tokio::join!(server_task, client_task);
     server_res.expect("server task panicked");
@@ -1147,10 +1148,10 @@ async fn on_closed_endpoint_drop() {
             let on_closed = conn.on_closed();
             drop(conn);
             drop(server);
-            let (cause, _stats) = on_closed.await;
+            let closed = on_closed.await;
             // Depending on timing we might have received a close frame or not.
             assert!(matches!(
-                cause,
+                closed.reason,
                 ConnectionError::ApplicationClosed(_) | ConnectionError::LocallyClosed
             ));
         }),
@@ -1167,10 +1168,10 @@ async fn on_closed_endpoint_drop() {
             let on_closed = conn.on_closed();
             drop(conn);
             drop(client);
-            let (cause, _stats) = on_closed.await;
+            let closed = on_closed.await;
             // Depending on timing we might have received a close frame or not.
             assert!(matches!(
-                cause,
+                closed.reason,
                 ConnectionError::ApplicationClosed(_) | ConnectionError::LocallyClosed
             ));
         }),
@@ -1344,6 +1345,86 @@ async fn path_clone_stats_after_abandon() {
     .instrument(info_span!("client"));
 
     tokio::join!(server_task, client_task);
+}
+
+/// `Closed::path_stats` should expose stats for every path the connection
+/// knew about — paths still in the proto layer at close time and paths
+/// already discarded but cached in the noq layer's final stats.
+#[tokio::test]
+async fn closed_includes_path_stats_for_all_known_paths() -> TestResult {
+    let _logging = subscribe();
+    let factory = EndpointFactory::new();
+
+    let mut transport_config = TransportConfig::default();
+    transport_config.max_concurrent_multipath_paths(3);
+    let server = factory.endpoint_with_config("server", transport_config.clone());
+    let server_addr = server.local_addr()?;
+
+    let server_task = async move {
+        let conn = server.accept().await.ok_or("closed conn?")?.await?;
+        let _ = conn.closed().await;
+        TestResult::Ok(())
+    }
+    .instrument(info_span!("server"));
+
+    let client = factory.endpoint_with_config("client", transport_config);
+
+    let client_task = async move {
+        let conn = client.connect(server_addr, "localhost")?.await?;
+        let mut path_events = conn.path_events();
+
+        // Open a second path.
+        let path2 = loop {
+            match conn
+                .open_path(server_addr, proto::PathStatus::Available)
+                .await
+            {
+                Ok(p) => break p,
+                Err(proto::PathError::RemoteCidsExhausted) => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(err) => Err(err)?,
+            }
+        };
+        let path2_id = path2.id();
+
+        // Close path 2 and wait for the Discarded event. We hold `path2`
+        // alive past the discard so the final stats land in noq's
+        // `final_path_stats` cache and become visible in `Closed`.
+        path2.close()?;
+        while let Some(Ok(evt)) = path_events.next().await {
+            if let proto::PathEvent::Discarded { id, .. } = evt
+                && id == path2_id
+            {
+                break;
+            }
+        }
+
+        // Now close the connection. The initial path should still be in
+        // proto.paths() at close time.
+        let on_closed_fut = conn.on_closed();
+        conn.close(0u32.into(), b"done");
+        let closed = on_closed_fut.await;
+
+        let initial_path = PathId::ZERO;
+        let keys: Vec<_> = closed.path_stats.keys().copied().collect();
+        assert!(
+            closed.path_stats.contains_key(&path2_id),
+            "Closed.path_stats missing the discarded path {path2_id:?}; keys={keys:?}",
+        );
+        assert!(
+            closed.path_stats.contains_key(&initial_path),
+            "Closed.path_stats missing the initial path {initial_path:?}; keys={keys:?}",
+        );
+
+        TestResult::Ok(())
+    }
+    .instrument(info_span!("client"));
+
+    let (server_res, client_res) = tokio::join!(server_task, client_task);
+    server_res?;
+    client_res?;
+    Ok(())
 }
 
 /// Tests the [`Path::close`] api.


### PR DESCRIPTION
## Description

Replace the (ConnectionError, ConnectionStats) tuple with a named Closed struct that exposes the close reason, the aggregate connection stats and per-path stats for every path the connection knew about at close time. Path stats are sourced from the proto layer for paths still tracked at close time and from the cached final stats for already-discarded paths.

## Breaking Changes

* changed: the `OnClosed` future returned `noq::Connection::on_closed` now resolves to a struct `Closed` instead of a tuple `(ConnectionError, ConnectionStats)`. `Closed` has public fields `reason`, `stats`, and `path_stats`.

## Notes & open questions

I gave the `Closed` struct public fields plus `#[non_exhaustive]`. Could also be accessor methods and private fields, but then the path stats and the connection error would have to be cloned out to get hold of owned variants, or we'd have to have both getters and `into_` methods. I think the public fields are fine here, but can also change it.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.

