### PR TITLE
feat(proto): Send NAT probes with off-path PATH_RESPONSE

### DIFF
--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -50,13 +50,24 @@ jobs:
       - name: Patch noq crates in iroh workspace
         working-directory: iroh
         run: |
-          cat >> Cargo.toml <<'EOF'
+          if [ grep -q '\[patch\.crates-io\]' ]; then
+            awk -i '
+              BEGIN { in_patch = 0 }
+              /\[patch\.crates-io\]/ { in_patch = 1 }
+              in_patch && /^noq =/ { print "noq = { path = "../noq/noq" }"; next }
+              in_patch && /^noq-proto =/ { print "noq-proto = { path = "../noq/noq-proto" }"; next }
+              in_patch && /^noq-udp =/ { print "noq-udp = { path = "../noq/noq-udp" }"; next }
+              { print }
+              ' Cargo.toml
+          else
+            cat >> Cargo.toml <<'EOF'
 
-          [patch.crates-io]
-          noq = { path = "../noq/noq" }
-          noq-proto = { path = "../noq/noq-proto" }
-          noq-udp = { path = "../noq/noq-udp" }
-          EOF
+            [patch.crates-io]
+            noq = { path = "../noq/noq" }
+            noq-proto = { path = "../noq/noq-proto" }
+            noq-udp = { path = "../noq/noq-udp" }
+            EOF
+          fi
 
       - name: Build patchbay tests
         working-directory: iroh

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -54,11 +54,7 @@ jobs:
           # assumes the patch section is trailing and the only reason
           # there would be any patch is because of noq. Could be
           # smarter.
-          awk -i '
-            BEGIN { in_patch = 0 }
-            /\[patch\.crates-io\]/ { in_patch = 1 }
-            !in_patch { print }
-            ' Cargo.toml
+          awk -i 'BEGIN { in_patch = 0 }; /\[patch\.crates-io\]/ { in_patch = 1 }; !in_patch { print }' Cargo.toml
 
           # Add our own patch section.
           cat >> Cargo.toml <<'EOF'

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -50,24 +50,24 @@ jobs:
       - name: Patch noq crates in iroh workspace
         working-directory: iroh
         run: |
-          if [ grep -q '\[patch\.crates-io\]' ]; then
-            awk -i '
-              BEGIN { in_patch = 0 }
-              /\[patch\.crates-io\]/ { in_patch = 1 }
-              in_patch && /^noq =/ { print "noq = { path = "../noq/noq" }"; next }
-              in_patch && /^noq-proto =/ { print "noq-proto = { path = "../noq/noq-proto" }"; next }
-              in_patch && /^noq-udp =/ { print "noq-udp = { path = "../noq/noq-udp" }"; next }
-              { print }
-              ' Cargo.toml
-          else
-            cat >> Cargo.toml <<'EOF'
+          # Delete any pre-existing trailing patch section. This
+          # assumes the patch section is trailing and the only reason
+          # there would be any patch is because of noq. Could be
+          # smarter.
+          awk -i '
+            BEGIN { in_patch = 0 }
+            /\[patch\.crates-io\]/ { in_patch = 1 }
+            !in_patch { print }
+            ' Cargo.toml
 
-            [patch.crates-io]
-            noq = { path = "../noq/noq" }
-            noq-proto = { path = "../noq/noq-proto" }
-            noq-udp = { path = "../noq/noq-udp" }
-            EOF
-          fi
+          # Add our own patch section.
+          cat >> Cargo.toml <<'EOF'
+
+          [patch.crates-io]
+          noq = { path = "../noq/noq" }
+          noq-proto = { path = "../noq/noq-proto" }
+          noq-udp = { path = "../noq/noq-udp" }
+          EOF
 
       - name: Build patchbay tests
         working-directory: iroh

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -54,7 +54,8 @@ jobs:
           # assumes the patch section is trailing and the only reason
           # there would be any patch is because of noq. Could be
           # smarter.
-          awk -i 'BEGIN { in_patch = 0 }; /\[patch\.crates-io\]/ { in_patch = 1 }; !in_patch { print }' Cargo.toml
+          mv Cargo.toml Cargo.toml.in
+          awk 'BEGIN { in_patch = 0 }; /\[patch\.crates-io\]/ { in_patch = 1 }; !in_patch { print }' Cargo.toml.in > Cargo.toml
 
           # Add our own patch section.
           cat >> Cargo.toml <<'EOF'

--- a/noq-proto/src/cid_queue.rs
+++ b/noq-proto/src/cid_queue.rs
@@ -128,6 +128,7 @@ impl CidQueue {
     ///
     /// If there's no more CIDs in the ready set, this will return None.
     /// CIDs marked as reserved will be skipped when the active one advances.
+    #[allow(dead_code)]
     pub(crate) fn next_reserved(&mut self) -> Option<ConnectionId> {
         let (i, cid_data) = self.iter_from_reserved().nth(1)?;
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2026,7 +2026,7 @@ impl Connection {
 
         // If we are a client doing NAT traversal, always include a PATH_CHALLENGE with any
         // off-path PATH_RESPONSE. No need to schedule any retries for this, if NAT
-        // traversal is taking place then this remote is already is being probed with
+        // traversal is taking place then this remote already is being probed with
         // retries, this only speeds up a successful traversal.
         if self
             .find_validated_path_on_network_path(network_path)

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2012,11 +2012,8 @@ impl Connection {
         let cid_queue = self.remote_cids.get_mut(&path_id)?;
         let (token, network_path) = path.path_responses.pop_off_path(path.network_path)?;
 
-        let cid = cid_queue
-            .next_reserved()
-            .unwrap_or_else(|| cid_queue.active());
-        // TODO(@divma): we should take a different approach when there is no fresh CID to use.
-        // https://github.com/quinn-rs/quinn/issues/2184
+        // TODO: make off-path probes unlinkable.
+        let cid = cid_queue.active();
 
         let frame = frame::PathResponse(token);
 
@@ -2026,6 +2023,23 @@ impl Connection {
         let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, cid, buf, self)?;
         let stats = &mut self.path_stats.for_path(path_id).frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(off-path)"));
+
+        // If we are a client doing NAT traversal, always include a PATH_CHALLENGE with any
+        // off-path PATH_RESPONSE. No need to schedule any retries for this, if NAT
+        // traversal is taking place then this remote is already is being probed with
+        // retries, this only speeds up a successful traversal.
+        if self
+            .find_validated_path_on_network_path(network_path)
+            .is_none()
+            && self.n0_nat_traversal.client_side().is_ok()
+        {
+            let token = self.rng.random();
+            let stats = &mut self.path_stats.for_path(path_id).frame_tx;
+            builder.write_frame(frame::PathChallenge(token), stats);
+            let ip_port = (network_path.remote.ip(), network_path.remote.port());
+            self.n0_nat_traversal.mark_probe_sent(ip_port, token);
+        }
+
         // Off-path: not tracked in congestion control. The packet is sent to a
         // different destination than path_id's network path.
         builder.pad_to(MIN_INITIAL_SIZE);

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1708,7 +1708,7 @@ fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
     // Client sends probe (blocked) + REACH_OUT, server send probe. Both firewalls open.
     pair.step();
 
-    // Client receives probe, includes it's own challenge with the response.
+    // Client receives probe, includes its own challenge with the response.
     let stats0 = pair.stats(Client);
     pair.step();
     let stats1 = pair.stats(Client);

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1679,3 +1679,58 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
 
     Ok(())
 }
+
+/// Test that a PATH_CHALLENGE is added to a PATH_RESPONSE for NAT traversal.
+#[test]
+fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
+    let _guard = subscribe();
+    let mut pair = multipath_pair_with_nat_traversal(true);
+
+    info!("setting routes, adding addrs");
+    pair.routes = Some(Box::new(SimpleFirewallRoutingTable::new()));
+    pair.add_nat_traversal_address(Server, SimpleFirewallRoutingTable::SERVER_FW_ADDR)?;
+    pair.add_nat_traversal_address(Client, SimpleFirewallRoutingTable::CLIENT_FW_ADDR)?;
+    pair.drive();
+
+    let event = pair.poll(Client).expect("should have event");
+    assert_matches!(
+        event,
+        Event::NatTraversal(n0_nat_traversal::Event::AddressAdded(_))
+    );
+
+    info!("init NAT traversal");
+    pair.initiate_nat_traversal_round(Client)?;
+
+    // Ensure we have no more events queued
+    assert_matches!(pair.poll(Client), None);
+    assert_matches!(pair.poll(Server), None);
+
+    // Client sends probe (blocked) + REACH_OUT, server send probe. Both firewalls open.
+    pair.step();
+
+    // Client receives probe, includes it's own challenge with the response.
+    let stats0 = pair.stats(Client);
+    pair.step();
+    let stats1 = pair.stats(Client);
+
+    // Without the challenge-with-response only a PATH_RESPONSE would have been sent.
+    assert_eq!(
+        stats1.frame_tx.path_response - stats0.frame_tx.path_response,
+        1
+    );
+    assert_eq!(
+        stats1.frame_tx.path_challenge - stats0.frame_tx.path_challenge,
+        1
+    );
+
+    // Continue till the end.
+    pair.drive();
+
+    let event = pair.poll(Client).expect("should have event");
+    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
+
+    let event = pair.poll(Server).expect("should have event");
+    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

When we are NAT probing and we are sending a PATH_RESPONSE as a
client, we include a PATH_CHALLENGE. This ensures that if the peer got
through the firewall first that the client immediately gets through as
well and can open the path. Speeding up NAT traversal.

## Breaking Changes

n/a

## Notes & open questions

Closes #570.

Also fixes an oversight from before: we were still consuming CIDs for
off-path responses. For now we want to not do that.

## Change checklist

- [x] Self-review.