### PR TITLE
feat(proto)!: Set default max concurrent multipath paths to 8 (instead of 12)

### DIFF
--- a/noq-proto/src/config/transport.rs
+++ b/noq-proto/src/config/transport.rs
@@ -17,7 +17,7 @@ use crate::{QlogFactory, QlogFileFactory};
 /// When multipath is required and has not been explicitly enabled, this value will be used for
 /// [`TransportConfig::max_concurrent_multipath_paths`].
 const DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED_: NonZeroU32 = {
-    match NonZeroU32::new(12) {
+    match NonZeroU32::new(8) {
         Some(v) => v,
         None => panic!("to enable multipath this must be positive, which clearly it is"),
     }

--- a/noq-proto/src/tests/proptests.rs
+++ b/noq-proto/src/tests/proptests.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 // These TransportConfig constants are designed to match iroh for now.
-const MAX_MULTIPATH_PATHS: u32 = 13;
+const MAX_MULTIPATH_PATHS: u32 = 8;
 const MAX_QNT_ADDRS: u8 = 12;
 const PATH_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);


### PR DESCRIPTION
## Description

Since we're using off-path PATH_CHALLENGEs for punching firewall holes (#567), we don't need as many concurrent multipath paths.

## Breaking Changes

None, only behavioral: The default maximum multipath paths is reduced from 12 to 8.

## Notes & open questions

Partially addresses #613 

But really, we need to change the default in iroh more than the one in noq.

I also changed the default used in the proptests. Those shouldn't break older regression tests, none of them hit the concurrent path limit.

We might want to consider changing the whole `DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED_` constant dance, but I'll do that in another PR.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
