### PR TITLE
feat(proto)!: Rename NAT traversal config and expose multipath default value

### DIFF
--- a/noq-proto/src/config/mod.rs
+++ b/noq-proto/src/config/mod.rs
@@ -31,10 +31,10 @@ mod transport;
 
 #[cfg(feature = "qlog")]
 pub use qlog::{QlogConfig, QlogFactory, QlogFileFactory};
-pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
-
-#[cfg(doc)]
-pub use transport::DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED;
+pub use transport::{
+    AckFrequencyConfig, DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS, IdleTimeout, MtuDiscoveryConfig,
+    TransportConfig,
+};
 
 /// Global configuration for the endpoint, affecting all connections
 ///

--- a/noq-proto/src/config/mod.rs
+++ b/noq-proto/src/config/mod.rs
@@ -31,10 +31,7 @@ mod transport;
 
 #[cfg(feature = "qlog")]
 pub use qlog::{QlogConfig, QlogFactory, QlogFileFactory};
-pub use transport::{
-    AckFrequencyConfig, DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS, IdleTimeout, MtuDiscoveryConfig,
-    TransportConfig,
-};
+pub use transport::{AckFrequencyConfig, IdleTimeout, MtuDiscoveryConfig, TransportConfig};
 
 /// Global configuration for the endpoint, affecting all connections
 ///

--- a/noq-proto/src/config/transport.rs
+++ b/noq-proto/src/config/transport.rs
@@ -14,10 +14,6 @@ use crate::{
 #[cfg(feature = "qlog")]
 use crate::{QlogFactory, QlogFileFactory};
 
-/// When multipath is required and has not been explicitly enabled, this value will be used for
-/// [`TransportConfig::max_concurrent_multipath_paths`].
-pub const DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS: u32 = 8;
-
 /// Parameters governing the core QUIC state machine
 ///
 /// Default values should be suitable for most internet applications. Applications protocols which
@@ -452,12 +448,11 @@ impl TransportConfig {
     /// <https://www.ietf.org/archive/id/draft-seemann-quic-nat-traversal-02.html>
     ///
     /// This implementation expects the multipath extension to be enabled as well. if not yet
-    /// enabled via [`Self::max_concurrent_multipath_paths`], then that setting is set to
-    /// [`DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS`].
+    /// enabled via [`Self::max_concurrent_multipath_paths`], then that setting is set to 8.
     pub fn max_remote_nat_traversal_addresses(&mut self, max_addresses: u8) -> &mut Self {
         self.max_remote_nat_traversal_addresses = NonZeroU8::new(max_addresses);
         if max_addresses != 0 && self.max_concurrent_multipath_paths.is_none() {
-            self.max_concurrent_multipath_paths(DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS);
+            self.max_concurrent_multipath_paths(8);
         }
         self
     }

--- a/noq-proto/src/config/transport.rs
+++ b/noq-proto/src/config/transport.rs
@@ -16,19 +16,7 @@ use crate::{QlogFactory, QlogFileFactory};
 
 /// When multipath is required and has not been explicitly enabled, this value will be used for
 /// [`TransportConfig::max_concurrent_multipath_paths`].
-const DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED_: NonZeroU32 = {
-    match NonZeroU32::new(8) {
-        Some(v) => v,
-        None => panic!("to enable multipath this must be positive, which clearly it is"),
-    }
-};
-
-/// When multipath is required and has not been explicitly enabled, this value will be used for
-///
-/// [`TransportConfig::max_concurrent_multipath_paths`].
-#[cfg(doc)]
-pub const DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED: NonZeroU32 =
-    DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED_;
+pub const DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS: u32 = 8;
 
 /// Parameters governing the core QUIC state machine
 ///
@@ -464,14 +452,12 @@ impl TransportConfig {
     /// <https://www.ietf.org/archive/id/draft-seemann-quic-nat-traversal-02.html>
     ///
     /// This implementation expects the multipath extension to be enabled as well. if not yet
-    /// enabled via [`Self::max_concurrent_multipath_paths`], a default value of
-    /// [`DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED`] will be used.
-    pub fn set_max_remote_nat_traversal_addresses(&mut self, max_addresses: u8) -> &mut Self {
+    /// enabled via [`Self::max_concurrent_multipath_paths`], then that setting is set to
+    /// [`DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS`].
+    pub fn max_remote_nat_traversal_addresses(&mut self, max_addresses: u8) -> &mut Self {
         self.max_remote_nat_traversal_addresses = NonZeroU8::new(max_addresses);
         if max_addresses != 0 && self.max_concurrent_multipath_paths.is_none() {
-            self.max_concurrent_multipath_paths(
-                DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED_.get(),
-            );
+            self.max_concurrent_multipath_paths(DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS);
         }
         self
     }

--- a/noq-proto/src/lib.rs
+++ b/noq-proto/src/lib.rs
@@ -56,11 +56,10 @@ use test_strategy::Arbitrary;
 pub use rustls;
 
 mod config;
-#[cfg(doc)]
-pub use config::DEFAULT_CONCURRENT_MULTIPATH_PATHS_WHEN_ENABLED;
 pub use config::{
-    AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
-    ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
+    AckFrequencyConfig, ClientConfig, ConfigError, DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS,
+    EndpointConfig, IdleTimeout, MtuDiscoveryConfig, ServerConfig, StdSystemTime, TimeSource,
+    TransportConfig, ValidationTokenConfig,
 };
 #[cfg(feature = "qlog")]
 pub use config::{QlogConfig, QlogFactory, QlogFileFactory};

--- a/noq-proto/src/lib.rs
+++ b/noq-proto/src/lib.rs
@@ -57,9 +57,8 @@ pub use rustls;
 
 mod config;
 pub use config::{
-    AckFrequencyConfig, ClientConfig, ConfigError, DEFAULT_MAX_CONCURRENT_MULTIPATH_PATHS,
-    EndpointConfig, IdleTimeout, MtuDiscoveryConfig, ServerConfig, StdSystemTime, TimeSource,
-    TransportConfig, ValidationTokenConfig,
+    AckFrequencyConfig, ClientConfig, ConfigError, EndpointConfig, IdleTimeout, MtuDiscoveryConfig,
+    ServerConfig, StdSystemTime, TimeSource, TransportConfig, ValidationTokenConfig,
 };
 #[cfg(feature = "qlog")]
 pub use config::{QlogConfig, QlogFactory, QlogFileFactory};

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -41,7 +41,7 @@ fn multipath_pair_with_nat_traversal(nat_traversal: bool) -> ConnPair {
     // Assume a low-latency connection so pacing doesn't interfere with the test
     cfg.initial_rtt(Duration::from_millis(10));
     if nat_traversal {
-        cfg.set_max_remote_nat_traversal_addresses(8);
+        cfg.max_remote_nat_traversal_addresses(8);
     }
     #[cfg(feature = "qlog")]
     cfg.qlog_from_env("multipath_test");

--- a/noq-proto/src/tests/proptests.rs
+++ b/noq-proto/src/tests/proptests.rs
@@ -140,7 +140,7 @@ impl PairSetup {
 
         if self.extensions.is_qnt_enabled() {
             // enable QNT:
-            transport.set_max_remote_nat_traversal_addresses(MAX_QNT_ADDRS);
+            transport.max_remote_nat_traversal_addresses(MAX_QNT_ADDRS);
         }
 
         // Initialize the server config

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1468,7 +1468,7 @@ async fn nat_traversal_wakes_connection_driver() -> TestResult {
 
     let mut transport_config = TransportConfig::default();
     transport_config.max_concurrent_multipath_paths(3);
-    transport_config.set_max_remote_nat_traversal_addresses(10);
+    transport_config.max_remote_nat_traversal_addresses(10);
     let server = factory.endpoint_with_config("server", transport_config.clone());
     let server_addr = server.local_addr().unwrap();
 


### PR DESCRIPTION
## Description

There was some inconsistency in naming in the transport config between the multipath enabling config and NAT traversal enabling config:
- `max_concurrent_multipath_paths` vs.
- `set_max_remote_nat_traversal_addresses`

This renames `set_max_remote_nat_traversal_addresses` to `max_remote_nat_traversal_addresses`, dropping the `set_` prefix.

I'm also removing the whole `#[cfg(doc)] pub const DEFAULT_MAX_CONCURRENT_MULTIPATHS_PATHS` dance with two `const` values and `NonZeroUSize`. There is no previous pattern for exposing config defaults, so I'm keep it consistent.

## Breaking Changes

- Renamed `set_max_remote_nat_traversal_addresses` to `max_remote_nat_traversal_addresses`.

## Notes & open questions

This is based on https://github.com/n0-computer/noq/pull/620 to avoid conflicts.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
