### PR TITLE
chore: Fail cargo-make flows for warnings

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,6 +4,10 @@
 skip_core_tasks = true
 default_to_workspace = false
 
+[env]
+RUSTFLAGS = "-Dwarnings"
+RUSTDOCFLAGS = "-Dwarnings"
+
 [tasks.default]
 alias = "dev-flow"
 


### PR DESCRIPTION
## Description

This sets the -Dwarnings flags so that the commands fail when there
are warnings. The output of the full flow easily scrolls off screen so
you don't notice things will fail on CI.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.