### PR TITLE
fix(noq): do a best-effort transmit on connection close

### DIFF
--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1233,6 +1233,14 @@ impl Drop for ConnectionRef {
             // be constructed for the newly opened stream.
             conn.implicit_close(&self.shared);
         }
+
+        // We also flush any pending packets, e.g. the CONNECTION_CLOSE, if we're able to do so
+        // synchronously. This is best-effort; we won't wait for them to be acked, but we have a
+        // decent chance of notifying the peer in the case that we're currently shutting down
+        // ungracefully.
+        let waker = std::task::Waker::noop();
+        let mut cx = std::task::Context::from_waker(waker);
+        let _ = conn.drive_transmit(&mut cx);
     }
 }
 


### PR DESCRIPTION
## Description

If we're shutting down ungracefully, we can make a best-effort attempt to write the CONNECTION_CLOSE to the socket and notify the peer. If we're in the middle of graceful shutdown, it doesn't hurt, either.

This can be taken advantage of by callers to do a quicker shutdown if they know the drain period isn't necessary. Discussion here: https://github.com/n0-computer/iroh/issues/4201