### PR TITLE
refactor: Add internal fn initial_network_path.

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -819,6 +819,24 @@ impl Connection {
             .ok_or(ClosedPath { _private: () })
     }
 
+    /// Returns the network path of the initial path (`PathId::ZERO`).
+    ///
+    /// This always succeeds while the handshake is in progress: `PathId::ZERO` is
+    /// created at connection setup, multipath is not negotiated until the handshake
+    /// completes, and nothing in the handshake teardown path removes it. The only
+    /// way for it to disappear is an explicit post-handshake call to
+    /// `discard_path(PathId::ZERO)` (see the `debug_assert` in `discard_path`).
+    ///
+    /// Use this from contexts that have a `Connection` but not a specific `PathId` —
+    /// notably `Connecting`-stage accessors that observe the handshake's 4-tuple.
+    /// After the handshake completes and especially in multipath connections, prefer
+    /// [`Self::network_path`] with an explicit path id.
+    pub fn initial_network_path(&self) -> FourTuple {
+        self.path(PathId::ZERO)
+            .expect("PathId::ZERO is present until explicitly discarded post-handshake")
+            .network_path
+    }
+
     /// Sets the [`PathStatus`] for a known [`PathId`]
     ///
     /// Returns the previous path status on success.
@@ -3301,6 +3319,12 @@ impl Connection {
 
     /// Drops the path state, declaring any remaining in-flight packets as lost
     fn discard_path(&mut self, path_id: PathId, now: Instant) {
+        // `Connection::initial_network_path` and similar callers rely on `PathId::ZERO`
+        // being present until at least the handshake has completed.
+        assert!(
+            path_id != PathId::ZERO || !self.state.is_handshake(),
+            "PathId::ZERO must not be discarded during handshake"
+        );
         trace!(%path_id, "dropping path state");
         let path = self.path_data(path_id);
         let in_flight_mtu_probe = path.mtud.in_flight_mtu_probe();

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -188,12 +188,7 @@ impl Connecting {
     pub fn local_ip(&self) -> Option<IpAddr> {
         let conn = self.conn.as_ref().expect("used after yielding Ready");
         let inner = conn.lock_without_waking("local_ip");
-
-        inner
-            .inner
-            .network_path(PathId::ZERO)
-            .expect("PathId::ZERO is the only path during the handshake")
-            .local_ip()
+        inner.inner.initial_network_path().local_ip()
     }
 
     /// The peer's UDP addresses
@@ -204,8 +199,7 @@ impl Connecting {
         conn_ref
             .lock_without_waking("remote_address")
             .inner
-            .network_path(PathId::ZERO)
-            .expect("PathId::ZERO is the only path during the handshake")
+            .initial_network_path()
             .remote()
     }
 }


### PR DESCRIPTION
## Description

Tiny refactor to unify the two places that assume that path zero exists. Also make it impossible to discard path zero during handshake so the invariant is safer against future changes.

## Breaking Changes

None

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the -->
<!-- PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
