### PR TITLE
fix(noq-proto): do not recreate path state for already abandonend paths

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2224,15 +2224,16 @@ impl Connection {
                 // Path may have been abandoned while this reply was in flight,
                 // retire the CIDs instead of queuing them.
                 if self.abandoned_paths.contains(&path_id) {
-                    debug_assert!(!self.state.is_drained());
-                    for issued in &ids {
-                        self.endpoint_events
-                            .push_back(EndpointEventInner::RetireConnectionId(
-                                now,
-                                path_id,
-                                issued.sequence,
-                                false,
-                            ));
+                    if !self.state.is_drained() {
+                        for issued in &ids {
+                            self.endpoint_events
+                                .push_back(EndpointEventInner::RetireConnectionId(
+                                    now,
+                                    path_id,
+                                    issued.sequence,
+                                    false,
+                                ));
+                        }
                     }
                     return;
                 }
@@ -6377,12 +6378,7 @@ impl Connection {
             };
             // Path was discarded after this CID was queued, drop.
             let Some(cid_state) = self.local_cid_state.get(&issued.path_id) else {
-                debug_assert!(
-                    self.abandoned_paths.contains(&issued.path_id),
-                    "missing local CID state for non-abandoned path={}",
-                    issued.path_id,
-                );
-                warn!(
+                debug!(
                     path = %issued.path_id, seq = issued.sequence,
                     "dropping queued NEW_CONNECTION_ID for discarded path",
                 );

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2220,6 +2220,23 @@ impl Connection {
             NewIdentifiers(ids, now, cid_len, cid_lifetime) => {
                 let path_id = ids.first().map(|issued| issued.path_id).unwrap_or_default();
                 debug_assert!(ids.iter().all(|issued| issued.path_id == path_id));
+
+                // Path may have been abandoned while this reply was in flight,
+                // retire the CIDs instead of queuing them.
+                if self.abandoned_paths.contains(&path_id) {
+                    debug_assert!(!self.state.is_drained());
+                    for issued in &ids {
+                        self.endpoint_events
+                            .push_back(EndpointEventInner::RetireConnectionId(
+                                now,
+                                path_id,
+                                issued.sequence,
+                                false,
+                            ));
+                    }
+                    return;
+                }
+
                 let cid_state = self
                     .local_cid_state
                     .entry(path_id)
@@ -6358,11 +6375,20 @@ impl Connection {
             let Some(issued) = space.pending.new_cids.pop() else {
                 break;
             };
-            let retire_prior_to = self
-                .local_cid_state
-                .get(&issued.path_id)
-                .map(|cid_state| cid_state.retire_prior_to())
-                .unwrap_or_else(|| panic!("missing local CID state for path={}", issued.path_id));
+            // Path was discarded after this CID was queued, drop.
+            let Some(cid_state) = self.local_cid_state.get(&issued.path_id) else {
+                debug_assert!(
+                    self.abandoned_paths.contains(&issued.path_id),
+                    "missing local CID state for non-abandoned path={}",
+                    issued.path_id,
+                );
+                warn!(
+                    path = %issued.path_id, seq = issued.sequence,
+                    "dropping queued NEW_CONNECTION_ID for discarded path",
+                );
+                continue;
+            };
+            let retire_prior_to = cid_state.retire_prior_to();
 
             let cid_path_id = match is_multipath_negotiated {
                 true => Some(issued.path_id),

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1419,6 +1419,63 @@ fn abandon_path_data_continues() -> TestResult {
     Ok(())
 }
 
+/// Regression test: a `NewIdentifiers` reply arriving after `close_path` must not
+/// leave `pending.new_cids` referencing a path whose `local_cid_state` will be
+/// removed when `PathTimer::PathDrained` fires.
+#[test]
+fn new_identifiers_after_abandon_does_not_panic() -> TestResult {
+    use crate::shared::{ConnectionEvent, ConnectionEventInner, IssuedCid};
+    use crate::token::ResetToken;
+
+    let _guard = subscribe();
+    let mut pair = multipath_pair();
+
+    // A second path is needed so close_path(0) is not the last open path.
+    let server_addr = pair.addrs_to_server();
+    let _path1 = pair.open_path(Client, server_addr, PathStatus::Available)?;
+    pair.drive();
+    while pair.poll(Client).is_some() {}
+    while pair.poll(Server).is_some() {}
+
+    let (_, max_seq) = pair.conn(Client).active_local_path_cid_seq(0);
+
+    // Drive the PATH_ABANDON exchange manually so PathDrained timers get set on
+    // both sides without advance_time() firing them.
+    pair.close_path(Client, PathId::ZERO, 0u8.into())?;
+    let abandon_time = pair.time;
+    pair.drive_client();
+    pair.drive_server();
+    pair.drive_client();
+    debug_assert_eq!(pair.time, abandon_time);
+
+    // Inject the late NewIdentifiers reply that the bug fails to ignore.
+    let issued = vec![IssuedCid {
+        path_id: PathId::ZERO,
+        sequence: max_seq + 1,
+        id: ConnectionId::new(&[0xAAu8; 8]),
+        reset_token: ResetToken::from([0u8; crate::RESET_TOKEN_SIZE]),
+    }];
+    let late_event = ConnectionEvent(ConnectionEventInner::NewIdentifiers(
+        issued, pair.time, 8, None,
+    ));
+    pair.handle_event(Client, late_event);
+
+    // Past PathDrained (~100ms) but below max_idle_timeout (30s).
+    pair.handle_timeout(Client, pair.time + Duration::from_millis(500));
+
+    let mut buf = Vec::new();
+    let _ = pair.poll_transmit(
+        Client,
+        std::num::NonZeroUsize::new(10).expect("non-zero"),
+        &mut buf,
+    );
+
+    assert!(!pair.is_closed(Client));
+    assert!(!pair.is_closed(Server));
+
+    Ok(())
+}
+
 /// Ported from picoquic `multipath_test_ab1`. Abandon + reopen cycle, 3 rounds.
 #[test]
 fn abandon_cycle() -> TestResult {

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1419,9 +1419,9 @@ fn abandon_path_data_continues() -> TestResult {
     Ok(())
 }
 
-/// Regression test: a `NewIdentifiers` reply arriving after `close_path` must not
-/// leave `pending.new_cids` referencing a path whose `local_cid_state` will be
-/// removed when `PathTimer::PathDrained` fires.
+/// Regression test: a NewIdentifiers reply arriving after a path is abandoned
+/// must not result in the frames being queued for transmission in
+/// `pending.new_cids`.
 #[test]
 fn new_identifiers_after_abandon_does_not_panic() -> TestResult {
     use crate::shared::{ConnectionEvent, ConnectionEventInner, IssuedCid};
@@ -1434,24 +1434,19 @@ fn new_identifiers_after_abandon_does_not_panic() -> TestResult {
     let server_addr = pair.addrs_to_server();
     let _path1 = pair.open_path(Client, server_addr, PathStatus::Available)?;
     pair.drive();
-    while pair.poll(Client).is_some() {}
-    while pair.poll(Server).is_some() {}
 
-    let (_, max_seq) = pair.conn(Client).active_local_path_cid_seq(0);
+    let cid_seq_before = pair.conn(Client).active_local_path_cid_seq(0);
 
-    // Drive the PATH_ABANDON exchange manually so PathDrained timers get set on
-    // both sides without advance_time() firing them.
     pair.close_path(Client, PathId::ZERO, 0u8.into())?;
-    let abandon_time = pair.time;
     pair.drive_client();
     pair.drive_server();
     pair.drive_client();
-    debug_assert_eq!(pair.time, abandon_time);
 
-    // Inject the late NewIdentifiers reply that the bug fails to ignore.
+    // Inject a NewIdentifiers reply for the just-abandoned path.
+    let synthetic_seq = cid_seq_before.1 + 1;
     let issued = vec![IssuedCid {
         path_id: PathId::ZERO,
-        sequence: max_seq + 1,
+        sequence: synthetic_seq,
         id: ConnectionId::new(&[0xAAu8; 8]),
         reset_token: ResetToken::from([0u8; crate::RESET_TOKEN_SIZE]),
     }];
@@ -1460,18 +1455,11 @@ fn new_identifiers_after_abandon_does_not_panic() -> TestResult {
     ));
     pair.handle_event(Client, late_event);
 
-    // Past PathDrained (~100ms) but below max_idle_timeout (30s).
-    pair.handle_timeout(Client, pair.time + Duration::from_millis(500));
-
-    let mut buf = Vec::new();
-    let _ = pair.poll_transmit(
-        Client,
-        std::num::NonZeroUsize::new(10).expect("non-zero"),
-        &mut buf,
-    );
-
-    assert!(!pair.is_closed(Client));
-    assert!(!pair.is_closed(Server));
+    // The CID must not have been added to local_cid_state, otherwise it would be
+    // queued in `pending.new_cids` and later sent as a NEW_CONNECTION_ID frame
+    // for an abandoned path.
+    let cid_seq_after = pair.conn(Client).active_local_path_cid_seq(0);
+    assert_eq!(cid_seq_before, cid_seq_after);
 
     Ok(())
 }


### PR DESCRIPTION
Closes #630

