### PR TITLE
feat: make negotiated_key_exchange_group always available

### DIFF
--- a/noq-proto/src/crypto/rustls.rs
+++ b/noq-proto/src/crypto/rustls.rs
@@ -61,12 +61,10 @@ impl crypto::Session for TlsSession {
                 Connection::Client(_) => None,
                 Connection::Server(ref session) => session.server_name().map(|x| x.into()),
             },
-            #[cfg(feature = "__rustls-post-quantum-test")]
             negotiated_key_exchange_group: self
                 .inner
                 .negotiated_key_exchange_group()
-                .expect("key exchange group is negotiated")
-                .name(),
+                .map(|kx| kx.name()),
         }))
     }
 
@@ -264,9 +262,11 @@ pub struct HandshakeData {
     ///
     /// Always `None` for outgoing connections
     pub server_name: Option<String>,
-    /// The key exchange group negotiated with the peer
-    #[cfg(feature = "__rustls-post-quantum-test")]
-    pub negotiated_key_exchange_group: rustls::NamedGroup,
+    /// The key exchange group negotiated with the peer.
+    ///
+    /// `None` until the handshake has completed, and also for resumed TLS 1.2
+    /// sessions where no key exchange occurs.
+    pub negotiated_key_exchange_group: Option<rustls::NamedGroup>,
 }
 
 /// A QUIC-compatible TLS client configuration

--- a/noq-proto/src/crypto/rustls.rs
+++ b/noq-proto/src/crypto/rustls.rs
@@ -265,8 +265,7 @@ pub struct HandshakeData {
     pub server_name: Option<String>,
     /// The key exchange group negotiated with the peer.
     ///
-    /// `None` until the handshake has completed, and also for resumed TLS 1.2
-    /// sessions where no key exchange occurs.
+    /// `None` until the handshake has completed.
     pub negotiated_key_exchange_group: Option<rustls::NamedGroup>,
 }
 

--- a/noq-proto/src/crypto/rustls.rs
+++ b/noq-proto/src/crypto/rustls.rs
@@ -253,6 +253,7 @@ impl crypto::HeaderKey for Box<dyn HeaderProtectionKey> {
 }
 
 /// Authentication data for (rustls) TLS session
+#[non_exhaustive]
 pub struct HandshakeData {
     /// The negotiated application protocol, if ALPN is in use
     ///

--- a/noq-proto/src/crypto/rustls.rs
+++ b/noq-proto/src/crypto/rustls.rs
@@ -263,7 +263,7 @@ pub struct HandshakeData {
     ///
     /// Always `None` for outgoing connections
     pub server_name: Option<String>,
-    /// The key exchange group negotiated with the peer.
+    /// The key exchange group negotiated with the peer. Useful for logging and metrics.
     ///
     /// `None` until the handshake has completed.
     pub negotiated_key_exchange_group: Option<rustls::NamedGroup>,

--- a/noq/tests/post_quantum.rs
+++ b/noq/tests/post_quantum.rs
@@ -54,7 +54,7 @@ async fn check_post_quantum_key_exchange(min_mtu: u16) {
                 .downcast::<HandshakeData>()
                 .unwrap()
                 .negotiated_key_exchange_group,
-            NamedGroup::X25519MLKEM768
+            Some(NamedGroup::X25519MLKEM768)
         )
     });
 


### PR DESCRIPTION
## Description

Make `negotiated_key_exchange_group` always available. This is useful if you configured post quantum key exchange and want to make sure that you actually got one, but also in general. It just costs 32 bit in size, and getting it is very cheap.

## Breaking Changes

`crypto::rustls::HandshakeData`: public struct gets a new field negotiated_key_exchange_group.

## Notes & open questions

Note: we could choose a shorter name?
Note: I made the struct non_exhaustive in case we want to add more.

Needed for https://github.com/n0-computer/iroh/issues/4195

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
