### PR TITLE
fix(proto): Use approximate comparison for network paths

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4245,9 +4245,9 @@ impl Connection {
                 let _guard = span.enter();
 
                 // Now the packet is authenticated we do the migration during the handshake,
-                // see Hanshake::allow_server_migration for details.  Be careful here to not
-                // yet rely on the path existing however, new paths are accepted and created
-                // later.
+                // see Handshake::allow_server_migration for details.  Be careful here to
+                // not yet rely on the path existing however, new paths are accepted and
+                // created later.
                 // Note that we can't do any other migrations yet, for those we need to know
                 // whether this was a probing packet or not. See the end of
                 // Self::process_packet for that.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3709,7 +3709,10 @@ impl Connection {
         // be reset and will delay detecting the path as idle. However tail-loss probes
         // would still not get acknowledged if the path was broken so eventually the path
         // would still become idle.
-        let is_on_path = *remote == self.path_data(path_id).network_path;
+        let is_on_path = self
+            .path_data(path_id)
+            .network_path
+            .is_probably_same_path(remote);
 
         self.total_authed_packets += 1;
         self.reset_keep_alive(path_id, now);

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5309,7 +5309,7 @@ impl Connection {
                     }
 
                     let path = self.path_data_mut(path_id);
-                    if network_path == path.network_path {
+                    if path.network_path.is_probably_same_path(&network_path) {
                         if let Some(updated) = path.update_observed_addr_report(observed)
                             && path.open_status == paths::OpenStatus::Informed
                         {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4243,7 +4243,11 @@ impl Connection {
 
                 // Now the packet is authenticated we do the migration during the
                 // handshake. See Handshake::allow_server_migration for details.
-                if self.is_handshaking() && network_path != self.path_data_mut(path_id).network_path
+                if self.is_handshaking()
+                    && !self
+                        .path_data_mut(path_id)
+                        .network_path
+                        .is_probably_same_path(&network_path)
                 {
                     if let Some(hs) = self.state.as_handshake()
                         && hs.allow_server_migration

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4259,8 +4259,6 @@ impl Connection {
                         })
                         .unwrap_or(false)
                 {
-                    // Accept the server migration, see Handshake::allow_server_migration
-                    // for details.
                     if let Some(hs) = self.state.as_handshake()
                         && hs.allow_server_migration
                     {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4256,7 +4256,11 @@ impl Connection {
                         self.path_data_mut(path_id).network_path = network_path;
                         self.qlog.emit_tuple_assigned(path_id, network_path, now);
                     } else {
-                        debug!("discarding packet with unexpected remote during handshake");
+                        debug!(
+                            recv_path = %network_path,
+                            expected_path = %self.path_data_mut(path_id).network_path,
+                            "discarding packet with unexpected remote during handshake",
+                        );
                         return;
                     }
                 }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4241,14 +4241,31 @@ impl Connection {
                 };
                 let _guard = span.enter();
 
-                // Now the packet is authenticated we do the migration during the
-                // handshake. See Handshake::allow_server_migration for details.
-                if self.is_handshaking()
-                    && !self
-                        .path_data_mut(path_id)
-                        .network_path
-                        .is_probably_same_path(&network_path)
+                // Now the packet is authenticated we can update the network path if needed.
+                // Be careful here to not yet rely on the path existing however, new paths
+                // are accepted and created later.
+                if let Some(known_network_path) = self
+                    .paths
+                    .get_mut(&path_id)
+                    .map(|path| &mut path.data.network_path)
+                    && known_network_path.remote == network_path.remote
+                    && known_network_path.local_ip.is_none()
+                    && network_path.local_ip.is_some()
                 {
+                    // Set the local IP if we did not yet have one. We do this for both the
+                    // server and the client since not all transports will report a local IP
+                    // at the very first incoming packet.
+                    trace!(?network_path.local_ip, "setting local IP from incoming packet");
+                    known_network_path.local_ip = network_path.local_ip;
+                }
+                if self.is_handshaking()
+                    && self
+                        .path(path_id)
+                        .map(|path_data| path_data.network_path != network_path)
+                        .unwrap_or(false)
+                {
+                    // Accept the server migration, see Handshake::allow_server_migration
+                    // for details.
                     if let Some(hs) = self.state.as_handshake()
                         && hs.allow_server_migration
                     {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4235,36 +4235,28 @@ impl Connection {
                     return;
                 }
             }
-            Ok((packet, number)) => {
+            Ok((packet, pn)) => {
                 // We received an authenticated packet and decrypted it.
-                qlog.header(&packet.header, number, path_id);
-                let span = match number {
+                qlog.header(&packet.header, pn, path_id);
+                let span = match pn {
                     Some(pn) => trace_span!("recv", space = ?packet.header.space(), pn),
                     None => trace_span!("recv", space = ?packet.header.space()),
                 };
                 let _guard = span.enter();
 
-                // Now the packet is authenticated we can update the network path if needed.
-                // Be careful here to not yet rely on the path existing however, new paths
-                // are accepted and created later.
-                if let Some(known_network_path) = self
-                    .paths
-                    .get_mut(&path_id)
-                    .map(|path| &mut path.data.network_path)
-                    && known_network_path.remote == network_path.remote
-                    && known_network_path.local_ip.is_none()
-                    && network_path.local_ip.is_some()
-                {
-                    // Set the local IP if we did not yet have one. We do this for both the
-                    // server and the client since not all transports will report a local IP
-                    // at the very first incoming packet.
-                    trace!(?network_path.local_ip, "setting local IP from incoming packet");
-                    known_network_path.local_ip = network_path.local_ip;
-                }
+                // Now the packet is authenticated we do the migration during the handshake,
+                // see Hanshake::allow_server_migration for details.  Be careful here to not
+                // yet rely on the path existing however, new paths are accepted and created
+                // later.
+                // Note that we can't do any other migrations yet, for those we need to know
+                // whether this was a probing packet or not. See the end of
+                // Self::process_packet for that.
                 if self.is_handshaking()
                     && self
                         .path(path_id)
-                        .map(|path_data| path_data.network_path != network_path)
+                        .map(|path_data| {
+                            !path_data.network_path.is_probably_same_path(&network_path)
+                        })
                         .unwrap_or(false)
                 {
                     // Accept the server migration, see Handshake::allow_server_migration
@@ -4292,7 +4284,7 @@ impl Connection {
                 let dedup = self.spaces[packet.header.space()]
                     .path_space_mut(path_id)
                     .map(|pns| &mut pns.dedup);
-                if number.zip(dedup).is_some_and(|(n, d)| d.insert(n)) {
+                if pn.zip(dedup).is_some_and(|(n, d)| d.insert(n)) {
                     debug!("discarding possible duplicate packet");
                     self.qlog.emit_packet_received(qlog, now);
                     return;
@@ -4323,7 +4315,7 @@ impl Connection {
 
                         if self.side().is_server() && !self.abandoned_paths.contains(&path_id) {
                             // Only the client is allowed to open paths
-                            self.ensure_path(path_id, network_path, now, number);
+                            self.ensure_path(path_id, network_path, now, pn);
                         }
                         if self.paths.contains_key(&path_id) {
                             self.on_packet_authenticated(
@@ -4331,7 +4323,7 @@ impl Connection {
                                 packet.header.space(),
                                 path_id,
                                 ecn,
-                                number,
+                                pn,
                                 spin,
                                 packet.header.is_1rtt(),
                                 &network_path,
@@ -4343,7 +4335,7 @@ impl Connection {
                         now,
                         network_path,
                         path_id,
-                        number,
+                        pn,
                         packet,
                         &mut qlog,
                     );

--- a/noq-proto/src/endpoint.rs
+++ b/noq-proto/src/endpoint.rs
@@ -660,7 +660,12 @@ impl Endpoint {
             incoming.rest,
         ) {
             Ok(()) => {
-                trace!(id = ch.0, icid = %dst_cid, "new connection");
+                trace!(
+                    id = ch.0,
+                    icid = %dst_cid,
+                    network_path = %incoming.network_path,
+                    "new connection",
+                );
 
                 for event in incoming_buffer.datagrams {
                     conn.handle_event(ConnectionEvent(ConnectionEventInner::Datagram(event)))


### PR DESCRIPTION
## Description

When the local IP is not yet set on a network path we need to do our network path comparisons with `is_probably_same_path` so that we accept this difference. We can not accept the local_ip earlier because for probing packets it should not be set. This requires a few fixed in various places where network paths are compared.

Additionally when doing these network path changes we are not allowed to depend on the PathData existing, it only gets created later for new paths.

## Breaking Changes

n/a

## Notes & open questions

Testing this is difficult, it relies on the strange way that transports are setup in iroh. Which is not even a notion that noq has at this time. I'll think about it but not sure I can come up with a test. I've created https://github.com/n0-computer/noq/issues/637 to follow up on this.

## Change checklist

- [x] Self-review.