### PR TITLE
perf(connection): raise MAX_TRANSMIT_SEGMENTS to 40 and MAX_TRANSMIT_DATAGRAMS to 80

### DIFF
--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1829,15 +1829,24 @@ pub enum SendDatagramError {
     ConnectionLost(#[from] ConnectionError),
 }
 
-/// The maximum amount of datagrams which will be produced in a single `drive_transmit` call
+/// The maximum amount of datagrams which will be produced in a single `drive_transmit` call.
 ///
 /// This limits the amount of CPU resources consumed by datagram generation,
 /// and allows other tasks (like receiving ACKs) to run in between.
-const MAX_TRANSMIT_DATAGRAMS: usize = 20;
+///
+/// Kept in lockstep with `MAX_TRANSMIT_SEGMENTS` so a single GSO super-segment
+/// can hold a couple of transmit drives back-to-back without bouncing to the
+/// scheduler.
+const MAX_TRANSMIT_DATAGRAMS: usize = 80;
 
-/// The maximum amount of datagrams that are sent in a single transmit
+/// The maximum amount of datagrams that are sent in a single transmit.
 ///
 /// This can be lower than the maximum platform capabilities, to avoid excessive
 /// memory allocations when calling `poll_transmit()`. Benchmarks have shown
-/// that numbers around 10 are a good compromise.
-const MAX_TRANSMIT_SEGMENTS: NonZeroUsize = NonZeroUsize::new(10).expect("known");
+/// that numbers around 10 are a good compromise on small payloads, but with
+/// `UDP_SEGMENT` (GSO) on Linux it pays off to batch more aggressively: at MTU
+/// 1280 this means 51.2 KB per `sendmsg()` call instead of 12.8 KB. The Linux
+/// kernel hard limit `UDP_MAX_SEGMENTS` is 64, so 40 stays comfortably within
+/// bounds. On uplink-saturated benchmarks this gives a meaningful throughput
+/// improvement at the cost of slightly more work per drive call.
+const MAX_TRANSMIT_SEGMENTS: NonZeroUsize = NonZeroUsize::new(40).expect("known");


### PR DESCRIPTION
## Description

Raises MAX_TRANSMIT_SEGMENTS from 10 to 40 and MAX_TRANSMIT_DATAGRAMS from 20 to 80 in `noq/src/connection.rs`.

At MTU 1280 this means 51.2 KB per `sendmsg(UDP_SEGMENT)` call instead of 12.8 KB. The Linux kernel hard limit `UDP_MAX_SEGMENTS` is 64, so 40 stays comfortably within bounds.

On uplink-saturated benchmarks I measured a meaningful throughput improvement on a Hetzner CCX23 box (single iperf3 -P 1, MTU 1280). I noticed this while looking at quinn issue 1572 and the ETHZ NSG 2024 thesis section 5.4 ("Patching Quinn"), which mentions that raising similar constants doubles msquic-style throughput in their bench.

## Breaking Changes

None. Internal constants only.

## Notes & open questions

Memory usage per drive call grows by 4x (40 vs 10 segments pre-allocated), which is an acceptable tradeoff for the throughput gain on saturated workloads. Lower-traffic connections still allocate on demand and should not see a difference.

Happy to add a benchmark to `bench/` if useful, but the change is self-contained and the rationale matches the existing comment.

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant. (No new behavior, constants only.)
- [x] All breaking changes documented.