### PR TITLE
refactor!: return previous path status from Path::set_status

### DIFF
--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -185,12 +185,13 @@ impl Path {
     }
 
     /// Sets the [`PathStatus`] of this path.
-    pub fn set_status(&self, status: PathStatus) -> Result<(), SetPathStatusError> {
+    ///
+    /// Returns the previous status of the path.
+    pub fn set_status(&self, status: PathStatus) -> Result<PathStatus, SetPathStatusError> {
         self.conn
             .lock_and_wake("set path status")
             .inner
-            .set_path_status(self.id, status)?;
-        Ok(())
+            .set_path_status(self.id, status)
     }
 
     /// Returns the [`PathStats`] for this path.


### PR DESCRIPTION
## Description

This makes `noq::Path::set_status` return the previous `PathStatus`, so that callers can check whether the status changed without having to call `status` again (which would aquire another lock needlessly).

## Breaking Changes

* changed: `noq::Path::set_status` now returns `Result<PathStatus, SetPathStatusError>`, where `PathStatus` is the previous path status


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
