### PR TITLE
fix(qlog): emit RTT values in milliseconds

### DIFF
--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -748,7 +748,7 @@ impl RecoveryMetrics {
                 .map(|rtt| rtt.as_micros() as f32 / 1000.0),
             rtt_variance: updated
                 .rtt_variance
-                .map(|rtt| rtt.as_micros() as f32 / 1000),
+                .map(|rtt| rtt.as_micros() as f32 / 1000.0),
             pto_count: updated
                 .pto_count
                 .map(|count| count.try_into().unwrap_or(u16::MAX)),

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -739,10 +739,16 @@ impl RecoveryMetrics {
         }
 
         Some(RecoveryMetricsUpdated {
-            min_rtt: updated.min_rtt.map(|rtt| rtt.as_secs_f32()),
-            smoothed_rtt: updated.smoothed_rtt.map(|rtt| rtt.as_secs_f32()),
-            latest_rtt: updated.latest_rtt.map(|rtt| rtt.as_secs_f32()),
-            rtt_variance: updated.rtt_variance.map(|rtt| rtt.as_secs_f32()),
+            min_rtt: updated.min_rtt.map(|rtt| rtt.as_micros() as f32 / 1000.0),
+            smoothed_rtt: updated
+                .smoothed_rtt
+                .map(|rtt| rtt.as_micros() as f32 / 1000.0),
+            latest_rtt: updated
+                .latest_rtt
+                .map(|rtt| rtt.as_micros() as f32 / 1000.0),
+            rtt_variance: updated
+                .rtt_variance
+                .map(|rtt| rtt.as_micros() as f32 / 1000),
             pto_count: updated
                 .pto_count
                 .map(|count| count.try_into().unwrap_or(u16::MAX)),


### PR DESCRIPTION
## Description

draft-ietf-quic-qlog-main-schema-13.txt: All timestamps and
time-related values (e.g. offsets) in qlog are logged as float64 in
the millisecond resolution.

## Breaking Changes

n/a

## Notes & open questions

Port of https://github.com/quinn-rs/quinn/pull/2631

## Change checklist

- [x] Self-review.