### PR TITLE
refactor(noq-proto)!: get ring and aws_lc_rs out of public API

### DIFF
--- a/noq-proto/src/crypto/ring_like.rs
+++ b/noq-proto/src/crypto/ring_like.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "aws-lc-rs", not(feature = "ring")))]
-use aws_lc_rs::{aead, error, hkdf, hmac};
+use aws_lc_rs::{aead, hkdf, hmac};
 #[cfg(feature = "ring")]
-use ring::{aead, error, hkdf, hmac};
+use ring::{aead, hkdf, hmac};
 
 use crate::crypto::{self, CryptoError};
 
@@ -15,7 +15,7 @@ impl crypto::HmacKey for hmac::Key {
     }
 
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), CryptoError> {
-        Ok(hmac::verify(self, data, signature)?)
+        Ok(hmac::verify(self, data, signature).map_err(|_| CryptoError)?)
     }
 }
 
@@ -58,7 +58,9 @@ impl crypto::HandshakeTokenKey for RetryTokenKey {
         let aead_key = self.derive_aead(token_nonce);
         let nonce = aead::Nonce::assume_unique_for_key([0u8; 12]); // See docs for RetryTokenKey
         let aad = aead::Aad::empty();
-        aead_key.seal_in_place_append_tag(nonce, aad, data)?;
+        aead_key
+            .seal_in_place_append_tag(nonce, aad, data)
+            .map_err(|_| CryptoError)?;
         Ok(())
     }
 
@@ -66,12 +68,8 @@ impl crypto::HandshakeTokenKey for RetryTokenKey {
         let aead_key = self.derive_aead(token_nonce);
         let aad = aead::Aad::empty();
         let nonce = aead::Nonce::assume_unique_for_key([0u8; 12]); // See docs for RetryTokenKey
-        Ok(aead_key.open_in_place(nonce, aad, data)?)
-    }
-}
-
-impl From<error::Unspecified> for CryptoError {
-    fn from(_: error::Unspecified) -> Self {
-        Self
+        Ok(aead_key
+            .open_in_place(nonce, aad, data)
+            .map_err(|_| CryptoError)?)
     }
 }

--- a/noq-proto/src/crypto/ring_like.rs
+++ b/noq-proto/src/crypto/ring_like.rs
@@ -15,7 +15,7 @@ impl crypto::HmacKey for hmac::Key {
     }
 
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), CryptoError> {
-        Ok(hmac::verify(self, data, signature).map_err(|_| CryptoError)?)
+        hmac::verify(self, data, signature).map_err(|_| CryptoError)
     }
 }
 


### PR DESCRIPTION
## Description

I ran `cargo-check-external-types` on the noq crates. It all looks reasonable. `noq-proto` has `ring` and `aws-lc-rs` in its public API though through a `From<ring::error::Unspecified> for CryptoError` impl (same for aws-lcs-rs, depending on feature flags). This means that from a strict POV that ring couldn't be updated without a semver breaking change.

This PR removes the From impl, instead using `map_err` at the few call sites.

## Breaking Changes

* changed: `noq_proto::crypto::CryptoError` no longer implements `From<ring::error::Unspecified>` and `From<aws_lcs_rs::error::Unspecified>`

## Notes & open questions

Remaining foreign types in public API are: `bytes`, `futures_core`, `rustls`, `rustls_pki_types`, `tokio` - all reasonable. Then we also have `identity_hash` (marker trait, but don't think there would be any need to update that crate during 1.0 so fine) and `arbitrary` (gated behind non-default `arbitrary` feature). I think we're good!

## Change checklist

- [x] Self-review.
- [x] All breaking changes documented.

