### PR TITLE
refactor(multipath)!: Rename PathEvent::Opened to Established

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -553,8 +553,8 @@ impl Connection {
     /// Opens a new path.
     ///
     /// Further errors might occur and they will be emitted in [`PathEvent::Abandoned`]
-    /// events with this path id.  When the path is opened it will be reported as an
-    /// [`PathEvent::Established`].
+    /// events with this path id.  Once the path is opened and can carry application data it
+    /// will be reported using a [`PathEvent::Established`] event.
     pub fn open_path(
         &mut self,
         network_path: FourTuple,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -550,10 +550,11 @@ impl Connection {
         }
     }
 
-    /// Opens a new path
+    /// Opens a new path.
     ///
-    /// Further errors might occur and they will be emitted in [`PathEvent::Abandoned`] events with this path id.
-    /// When the path is opened it will be reported as an [`PathEvent::Opened`].
+    /// Further errors might occur and they will be emitted in [`PathEvent::Abandoned`]
+    /// events with this path id.  When the path is opened it will be reported as an
+    /// [`PathEvent::Established`].
     pub fn open_path(
         &mut self,
         network_path: FourTuple,
@@ -5022,9 +5023,9 @@ impl Connection {
 
                                 if !was_open {
                                     if is_multipath_negotiated {
-                                        self.events.push_back(Event::Path(PathEvent::Opened {
-                                            id: path_id,
-                                        }));
+                                        self.events.push_back(Event::Path(
+                                            PathEvent::Established { id: path_id },
+                                        ));
                                     }
                                     if let Some(observed) =
                                         path.data.last_observed_addr_report.as_ref()

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1042,9 +1042,9 @@ pub enum PathStatus {
 /// Application events about paths
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PathEvent {
-    /// A new path has been opened
-    Opened {
-        /// Which path is now open
+    /// A new path has established connection with the peer.
+    Established {
+        /// The path which can now be used for application data.
         id: PathId,
     },
     /// A path was abandoned and is no longer usable.

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -438,12 +438,12 @@ fn open_path() -> TestResult {
     pair.drive();
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
 
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
     Ok(())
 }
@@ -462,12 +462,12 @@ fn open_path_key_update() -> TestResult {
     pair.drive();
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
 
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
     Ok(())
 }
@@ -566,12 +566,12 @@ fn open_path_ensure_after_abandon() -> TestResult {
 
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
 
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
 
     info!("closing path {path_id}");
@@ -613,12 +613,12 @@ fn open_path_ensure_after_abandon() -> TestResult {
     // The path should have been opened:
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
 
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
     Ok(())
 }
@@ -715,7 +715,7 @@ fn per_path_observed_address() -> TestResult {
     );
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(PathEvent::Opened { id: PathId(1) }))
+        Some(Event::Path(PathEvent::Established { id: PathId(1) }))
     );
     assert_matches!(
         pair.poll(Client),
@@ -763,11 +763,11 @@ fn mtud_on_two_paths() -> TestResult {
     // Ensure the path opened correctly.
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(crate::PathEvent::Opened { id  })) if id == path_id
+        Some(Event::Path(crate::PathEvent::Established { id  })) if id == path_id
     );
 
     // MTU should be 1200 for both paths.
@@ -851,7 +851,7 @@ fn network_change_multipath_no_hint_replaces_path() -> TestResult {
     );
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(PathEvent::Opened { id: PathId(1) }))
+        Some(Event::Path(PathEvent::Established { id: PathId(1) }))
     );
 
     // The server sees the old path closed with PATH_UNSTABLE_OR_POOR
@@ -866,7 +866,7 @@ fn network_change_multipath_no_hint_replaces_path() -> TestResult {
     // And then sees the new path
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(PathEvent::Opened { id: PathId(1) }))
+        Some(Event::Path(PathEvent::Established { id: PathId(1) }))
     );
     // Both client and server see the old path as discarded
     assert_matches!(
@@ -921,11 +921,11 @@ fn network_change_selective_hint() -> TestResult {
 
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(PathEvent::Opened { id })) if id == second_path
+        Some(Event::Path(PathEvent::Established { id })) if id == second_path
     );
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(PathEvent::Opened { id })) if id == second_path
+        Some(Event::Path(PathEvent::Established { id })) if id == second_path
     );
 
     // A hint that says PathId::ZERO is recoverable but the second path is not
@@ -954,7 +954,7 @@ fn network_change_selective_hint() -> TestResult {
     assert!(
         client_events
             .iter()
-            .any(|e| matches!(e, Event::Path(PathEvent::Opened { .. }))),
+            .any(|e| matches!(e, Event::Path(PathEvent::Established { .. }))),
         "expected an Opened event for the replacement path, got: {client_events:?}"
     );
     // PathId::ZERO should NOT have been closed
@@ -987,11 +987,11 @@ fn network_change_server_two_paths_selective_hint() -> TestResult {
 
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(PathEvent::Opened { id })) if id == second_path
+        Some(Event::Path(PathEvent::Established { id })) if id == second_path
     );
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(PathEvent::Opened { id })) if id == second_path
+        Some(Event::Path(PathEvent::Established { id })) if id == second_path
     );
 
     // Hint: The provided PathId is recoverable, others are not.
@@ -1090,11 +1090,11 @@ fn network_change_server_no_hint_recovers() -> TestResult {
 
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(PathEvent::Opened { id })) if id == second_path
+        Some(Event::Path(PathEvent::Established { id })) if id == second_path
     );
     assert_matches!(
         pair.poll(Server),
-        Some(Event::Path(PathEvent::Opened { id })) if id == second_path
+        Some(Event::Path(PathEvent::Established { id })) if id == second_path
     );
 
     // Signal network change without actually changing the server's local address. This
@@ -1140,7 +1140,7 @@ fn path_open_deadline_is_set_on_send() -> TestResult {
 
     assert_matches!(
         pair.poll(Client),
-        Some(Event::Path(PathEvent::Opened { id })) if id == path_id,
+        Some(Event::Path(PathEvent::Established { id })) if id == path_id,
         "path should open successfully after the challenge is sent"
     );
 
@@ -1216,7 +1216,10 @@ fn server_abandon_last_verified_path() -> TestResult {
         Some(Event::Path(PathEvent::Abandoned { .. }))
     ));
     let evt = pair.poll(Server);
-    assert!(matches!(evt, Some(Event::Path(PathEvent::Opened { .. }))));
+    assert!(matches!(
+        evt,
+        Some(Event::Path(PathEvent::Established { .. }))
+    ));
 
     let evt = pair.poll(Server);
     let Some(Event::Path(PathEvent::Discarded { path_stats, .. })) = evt else {
@@ -1348,7 +1351,7 @@ fn remote_path_abandon_last_path_client_opens_new() -> TestResult {
                 reason: PathAbandonReason::RemoteAbandoned { .. },
                 ..
             }) => saw_abandon = true,
-            Event::Path(PathEvent::Opened { id }) if id == new_path_id => saw_opened = true,
+            Event::Path(PathEvent::Established { id }) if id == new_path_id => saw_opened = true,
             _ => {}
         }
     }
@@ -1717,10 +1720,10 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");
-    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
 
     let event = pair.poll(Server).expect("should have event");
-    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
 
     Ok(())
 }
@@ -1772,10 +1775,10 @@ fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");
-    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
 
     let event = pair.poll(Server).expect("should have event");
-    assert_matches!(event, Event::Path(PathEvent::Opened { .. }));
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
 
     Ok(())
 }

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -442,8 +442,8 @@ impl Connection {
     /// carry application data, or if there was an error.
     ///
     /// Dropping the returned future does not cancel the opening of the path, the
-    /// [`PathEvent::Opened`] event will still be emitted from [`Self::path_events`] if the
-    /// path opens.  The [`PathId`] for the events can be extracted from
+    /// [`PathEvent::Established`] event will still be emitted from [`Self::path_events`] if
+    /// the path opens.  The [`PathId`] for the events can be extracted from
     /// [`OpenPath::path_id`].
     ///
     /// Failure to open a path can either occur immediately, before polling the returned
@@ -1639,7 +1639,7 @@ impl State {
                         old != *addr
                     });
                 }
-                Path(ref evt @ PathEvent::Opened { id }) => {
+                Path(ref evt @ PathEvent::Established { id }) => {
                     self.path_events.send(evt.clone()).ok();
                     if let Some(sender) = self.open_path.remove(&id) {
                         sender.send_modify(|value| *value = Ok(()));

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1459,7 +1459,7 @@ async fn close_path() -> TestResult {
         // The server learns the path ID from the Opened event
         let mut path_id = None;
         while let Some(Ok(evt)) = path_events.next().await {
-            if let proto::PathEvent::Opened { id } = evt {
+            if let proto::PathEvent::Established { id } = evt {
                 path_id = Some(id);
                 break;
             }


### PR DESCRIPTION
## Description

The event only is emitted when the path is usable for application
data, having it called Opened is confusing as that does not match
multipath terminology. Maybe in the future there is a need for an
event when the path is really opened, according to multipath, and then
we'd have to come up with a different event name.

Established also matches how we consider the state of the connection:
once the handshake is *completed*, it is considered established. So I
think this is a good match.

## Breaking Changes

- `PathEvent::Opened` -> `PathEvent::Established`

## Notes & open questions

Yes, this is an API breaking change in an RC release.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] All breaking changes documented.