### PR TITLE
feat(proto): Discover NAT candidates from off-path PATH_CHALLENGEs

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4962,7 +4962,8 @@ impl Connection {
                     // If we were passively migrated (e.g. NAT rebinding), our local_ip will
                     // not match. Once we processed a non-probing packet the local_ip will
                     // finally be updated.
-                    if network_path.remote == path.network_path.remote {
+                    let on_path = network_path.remote == path.network_path.remote;
+                    if on_path {
                         // PATH_CHALLENGE on active path, possible off-path packet
                         // forwarding attack. Send a non-probing packet to recover the
                         // active path. See
@@ -4974,6 +4975,37 @@ impl Connection {
                             true => self.immediate_ack(path_id),
                             false => {
                                 self.ping_path(path_id).ok();
+                            }
+                        }
+                    } else {
+                        // Off-path PATH_CHALLENGE. If we are the client of this
+                        // connection and NAT traversal was negotiated, this is the
+                        // server's own probe arriving at us. Its source address is the
+                        // server's NAT-mapped 4-tuple for this flow, which may differ
+                        // from what the server advertised via ADD_ADDRESS (for example
+                        // when the server is behind a symmetric NAT). Treat that source
+                        // as a fresh probe target. A path is only opened once the
+                        // client's own probe to that target gets back a matching
+                        // PATH_RESPONSE; we never open a path off the bare PATH_CHALLENGE.
+                        // discover_remote_from_probe is a no-op on the server side.
+                        let ipv6 = self.is_ipv6();
+                        if self
+                            .n0_nat_traversal
+                            .discover_remote_from_probe(network_path.remote, ipv6)
+                        {
+                            let timer_armed = self
+                                .timers
+                                .get(Timer::Conn(ConnTimer::NatTraversalProbeRetry))
+                                .is_some();
+                            if !timer_armed
+                                && let Some(delay) =
+                                    self.n0_nat_traversal.retry_delay(self.config.initial_rtt)
+                            {
+                                self.timers.set(
+                                    Timer::Conn(ConnTimer::NatTraversalProbeRetry),
+                                    now + delay,
+                                    self.qlog.with_time(now),
+                                );
                             }
                         }
                     }

--- a/noq-proto/src/n0_nat_traversal.rs
+++ b/noq-proto/src/n0_nat_traversal.rs
@@ -297,6 +297,21 @@ impl State {
         }
     }
 
+    /// Records a remote address discovered from an incoming off-path PATH_CHALLENGE and
+    /// queues a probe to it.
+    ///
+    /// Returns `true` if a new probe was queued and the `NatTraversalProbeRetry` timer
+    /// should be reset. Returns `false` for any reason discovery did not produce a new
+    /// probe (already known, at capacity, address family mismatch, server side, or
+    /// nat traversal not negotiated). See
+    /// [`ClientState::discover_remote_from_probe`] for the full client-side behavior.
+    pub(crate) fn discover_remote_from_probe(&mut self, addr: SocketAddr, ipv6: bool) -> bool {
+        match self {
+            Self::ClientSide(state) => state.discover_remote_from_probe(addr, ipv6),
+            Self::NotNegotiated | Self::ServerSide(_) => false,
+        }
+    }
+
     /// Returns the delay to arm the `NatTraversalProbeRetry` timer.
     ///
     /// `initial_rtt` must be [`TransportConfig::initial_rtt`] so retries are scaled to this
@@ -353,14 +368,17 @@ pub(crate) struct ClientState {
     ///
     /// This is set by the remote endpoint.
     max_local_addresses: usize,
-    /// Candidate addresses the remote endpoint advertises.
+    /// Candidate addresses the remote endpoint advertises, plus any addresses we discovered
+    /// from incoming off-path PATH_CHALLENGE frames.
     ///
     /// These are addresses on which the server is potentially reachable, to use for NAT
     /// traversal attempts.
     ///
     /// They are indexed by their ADD_ADDRESS sequence id and stored in **canonical
     /// form**. Not in the socket-native form as usual. This because we need to store them
-    /// so we have the correct sequence IDs.
+    /// so we have the correct sequence IDs. Addresses discovered locally
+    /// (see [`Self::discover_remote_from_probe`]) use sequence ids allocated by the client
+    /// from the top of the `VarInt` range so they cannot collide with peer-advertised ids.
     remote_addresses: FxHashMap<VarInt, (CanonicalIpPort, ProbeState)>,
     /// Candidate addresses for the local endpoint.
     ///
@@ -398,6 +416,12 @@ pub(crate) struct ClientState {
     /// MAX_PATH_ID.
     // TODO(flub): perhaps there should be a time-limit on these?
     paths_to_be_opened: Vec<FourTuple>,
+    /// Next sequence id to allocate for an address discovered from an incoming off-path
+    /// PATH_CHALLENGE.
+    ///
+    /// Walks down from [`VarInt::MAX`] so it never collides with peer-advertised
+    /// ADD_ADDRESS sequence ids, which start at 0.
+    next_discovered_seq: VarInt,
 }
 
 impl ClientState {
@@ -412,6 +436,7 @@ impl ClientState {
             sent_challenges: Default::default(),
             pending_probes: Default::default(),
             paths_to_be_opened: Default::default(),
+            next_discovered_seq: VarInt::MAX,
         }
     }
 
@@ -588,6 +613,50 @@ impl ClientState {
         self.remote_addresses
             .remove(&remove_addr.seq_no)
             .map(|(address, _)| address.as_canonical_addr())
+    }
+
+    /// Records a remote address discovered from an incoming off-path PATH_CHALLENGE and
+    /// queues a probe to it.
+    ///
+    /// This bridges the asymmetry between client-initiated path opening and bidirectional
+    /// probing: when the server is behind a symmetric NAT, its ADD_ADDRESS-advertised
+    /// reflexive address (mapped against the relay) is unreachable from the client. The
+    /// server's own probes do reach the client when the client's NAT is permissive, but they
+    /// come from a different, NAT-rebound source address. By treating that source as a probe
+    /// target, the client can reach the server on the hot 4-tuple, validate the response,
+    /// and open a path.
+    ///
+    /// Sequence ids for discovered remotes are allocated from the top of the `VarInt`
+    /// range and cannot collide with peer-advertised ids (which start at 0). `addr` is
+    /// canonicalized before storage.
+    ///
+    /// Returns `true` if a new address was added and queued for probing. Returns `false`
+    /// when the address is already known, when there is no capacity left, or when the
+    /// address family is not addressable from the local socket.
+    pub(crate) fn discover_remote_from_probe(&mut self, addr: SocketAddr, ipv6: bool) -> bool {
+        let canonical = CanonicalIpPort::from(addr);
+        if self.remote_addresses.values().any(|(a, _)| *a == canonical) {
+            return false;
+        }
+        if self.remote_addresses.len() >= self.max_remote_addresses {
+            return false;
+        }
+        let Some(ip_port) = canonical.as_local_socket_family(ipv6) else {
+            return false;
+        };
+        let seq = self.next_discovered_seq;
+        self.next_discovered_seq =
+            VarInt::from_u64(seq.into_inner().saturating_sub(1)).unwrap_or(VarInt::MAX);
+        self.remote_addresses.insert(
+            seq,
+            (canonical, ProbeState::Active(MAX_NAT_PROBE_ATTEMPTS - 1)),
+        );
+        self.pending_probes.insert(ip_port);
+        trace!(
+            %addr,
+            "discovered NAT traversal candidate from off-path PATH_CHALLENGE"
+        );
+        true
     }
 
     /// Checks that a received remote address is valid.


### PR DESCRIPTION
## Description

This is claude's attempt at fixing holepunching when the server is behind a hard NAT - not yet reviewed.
See https://github.com/n0-computer/iroh/pull/4254 for the iroh PR using this to unignore two so-far failing patchbay NAT tests.

When the server is behind a symmetric NAT, its NAT sets a different mapping per destination 4-tuple. Say the server discovers its reflexive address by pinging a relay, let's call it S_relay, and advertises  via ADD_ADDRESS. This address  is unreachable from the client. When the server sends a PATH_CHALLENGE to the client directly, its NAT sets a fresh binding S_client against the client's address. The client sees an off-path PATH_CHALLENGE arriving from
S_client, a source no ADD_ADDRESS announced.

Old behavior: the client sends a PATH_RESPONSE back to S_client and forgets the source. No path is ever opened, because the server never opens paths.

New behavior: the client treats S_client as a fresh probe target and sends its own PATH_CHALLENGE there. The server's NAT recognizes return traffic on the binding it just defined and forwards it through. The PATH_RESPONSE matches one of the client's outstanding challenges, and the existing client-only path-opening flow opens the path.

Sequence ids for discovered addresses walk down from VarInt::MAX so they cannot collide with peer-advertised ADD_ADDRESS ids (which start at 0).

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the -->
<!-- PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
