### PR TITLE
feat(proto): Mark `PathEvent` as `#[non_exhaustive]`

### DIFF
--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1041,6 +1041,7 @@ pub enum PathStatus {
 
 /// Application events about paths
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PathEvent {
     /// A new path has established connection with the peer.
     Established {

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1044,6 +1044,7 @@ pub enum PathStatus {
 #[non_exhaustive]
 pub enum PathEvent {
     /// A new path has established connection with the peer.
+    #[non_exhaustive]
     Established {
         /// The path which can now be used for application data.
         id: PathId,
@@ -1051,6 +1052,7 @@ pub enum PathEvent {
     /// A path was abandoned and is no longer usable.
     ///
     /// This event will always be followed by [`Self::Discarded`] after some time.
+    #[non_exhaustive]
     Abandoned {
         /// With path was abandoned.
         id: PathId,
@@ -1060,6 +1062,7 @@ pub enum PathEvent {
     /// A path was discarded and all remaining state for it has been removed.
     ///
     /// This event is the last event for a path, and is always emitted after [`Self::Abandoned`].
+    #[non_exhaustive]
     Discarded {
         /// Which path had its state dropped
         id: PathId,
@@ -1073,6 +1076,7 @@ pub enum PathEvent {
     /// The local status is not changed because of this event. It is up to the application
     /// to update the local status, which is used for packet scheduling, when the remote
     /// changes the status.
+    #[non_exhaustive]
     RemoteStatus {
         /// Path which has changed status
         id: PathId,
@@ -1080,6 +1084,7 @@ pub enum PathEvent {
         status: PathStatus,
     },
     /// Received an observation of our external address from the peer.
+    #[non_exhaustive]
     ObservedAddr {
         /// Path over which the observed address was reported, [`PathId::ZERO`] when multipath is
         /// not negotiated

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1684,6 +1684,10 @@ impl State {
                     // PathEvent is #[non_exhaustive].
                     // It's possible that noq is built against a newer noq-proto version.
                     // In that case, we need to ignore path events we can't handle yet.
+                    // But for tests, we expect noq and noq-proto to be in sync, so we
+                    // should panic in case we don't actually handle new cases.
+                    #[cfg(test)]
+                    panic!("Unhandled PathEvent variant: {event:?}");
                 }
             }
         }

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1680,6 +1680,11 @@ impl State {
                 NatTraversal(update) => {
                     self.nat_traversal_updates.send(update).ok();
                 }
+                _ => {
+                    // PathEvent is #[non_exhaustive].
+                    // It's possible that noq is built against a newer noq-proto version.
+                    // In that case, we need to ignore path events we can't handle yet.
+                }
             }
         }
     }

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1647,13 +1647,17 @@ impl State {
                         old != *addr
                     });
                 }
-                Path(ref evt @ PathEvent::Established { id }) => {
+                Path(ref evt @ PathEvent::Established { id, .. }) => {
                     self.path_events.send(evt.clone()).ok();
                     if let Some(sender) = self.open_path.remove(&id) {
                         sender.send_modify(|value| *value = Ok(()));
                     }
                 }
-                Path(ref evt @ PathEvent::Discarded { id, ref path_stats }) => {
+                Path(
+                    ref evt @ PathEvent::Discarded {
+                        id, ref path_stats, ..
+                    },
+                ) => {
                     if self.path_refs.contains_key(&id) {
                         self.final_path_stats.insert(id, *path_stats.clone());
                     }

--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -431,7 +431,9 @@ impl AddressDiscovery {
         let filter = async move {
             loop {
                 match path_events.recv().await {
-                    Ok(PathEvent::ObservedAddr { id, addr: observed }) if id == path_id => {
+                    Ok(PathEvent::ObservedAddr {
+                        id, addr: observed, ..
+                    }) if id == path_id => {
                         tx.send_if_modified(|addr| {
                             let old = std::mem::replace(addr, observed);
                             old != *addr

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1462,7 +1462,7 @@ async fn close_path() -> TestResult {
         // The server learns the path ID from the Opened event
         let mut path_id = None;
         while let Some(Ok(evt)) = path_events.next().await {
-            if let proto::PathEvent::Established { id } = evt {
+            if let proto::PathEvent::Established { id, .. } = evt {
                 path_id = Some(id);
                 break;
             }


### PR DESCRIPTION
## Description

This is for future-proofing the API.

Closes #642 

## Breaking Changes

- `enum PathEvent` and all of its cases are now marked as `#[non_exhaustive]`

## Notes & open questions

I'm ignoring the `_ =>` case, as anything else would mean we would "do something" in case e.g. noq is bound against a newer noq-proto.
In `#[cfg(test)]` however, I panic, as in that case the version we depend on must be up to date.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
