### PR TITLE
tests(proto): Always set a RoutingTable

### DIFF
--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1409,7 +1409,7 @@ fn close_from_migrated_address() {
     pair.drive();
 
     // Change client address - server will see this as migration
-    let client_addr = pair.routes.mut_basic().passive_migration(Client);
+    let client_addr = pair.routes.as_basic_mut().passive_migration(Client);
 
     // Client closes connection from the NEW address.  The server will see the migration and
     // close the connection on the new address.
@@ -1461,7 +1461,7 @@ fn migration() {
 
     let client_stats_after_connect = pair.client_conn_mut(client_ch).stats();
 
-    let client_addr = pair.routes.mut_basic().passive_migration(Client);
+    let client_addr = pair.routes.as_basic_mut().passive_migration(Client);
     pair.client_conn_mut(client_ch).ping();
 
     // Assert that just receiving the ping message is accounted into the servers
@@ -1579,7 +1579,7 @@ fn regression_path_validation_stale_local_after_passive_migration() {
     // only *after* passive migration has changed the client's observed local IP.
     pair.client.inbound.clear();
 
-    pair.routes.mut_basic().passive_migration(Client);
+    pair.routes.as_basic_mut().passive_migration(Client);
 
     // Send a ping so the server detects the migration and starts routing to the new ip.
     pair.conn_mut(Client).ping();
@@ -2689,7 +2689,7 @@ fn migrate_detects_new_mtu_and_respects_original_peer_max_udp_payload_size() {
 
     // Migrate client to a different port (and simulate a higher path MTU)
     pair.mtu = 1500;
-    let client_addr = pair.routes.mut_basic().passive_migration(Client);
+    let client_addr = pair.routes.as_basic_mut().passive_migration(Client);
     pair.client_conn_mut(client_ch).ping();
     pair.drive();
 
@@ -3973,7 +3973,7 @@ fn address_discovery_rebind_retransmission() {
     let time = pair.time;
     pair.client_conn_mut(client_ch)
         .handle_network_change(None, time);
-    let client_addr = pair.routes.mut_basic().passive_migration(Client);
+    let client_addr = pair.routes.as_basic_mut().passive_migration(Client);
 
     pair.drive();
     let conn = pair.client_conn_mut(client_ch);
@@ -3998,7 +3998,7 @@ fn network_change_single_path_recovery() {
     let cid_seq_before = pair.conn(Client).active_remote_cid_seq();
 
     // Simulate a passive migration (port change) + network change notification
-    pair.routes.mut_basic().passive_migration(Client);
+    pair.routes.as_basic_mut().passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     // The path should NOT be closed and there should be no path events

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1409,9 +1409,9 @@ fn close_from_migrated_address() {
     pair.drive();
 
     // Change client address - server will see this as migration
-    pair.client.addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1);
-    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
-    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
+    let client_addr = pair
+        .downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
 
     // Client closes connection from the NEW address.  The server will see the migration and
     // close the connection on the new address.
@@ -1431,7 +1431,7 @@ fn close_from_migrated_address() {
     );
 
     let path = pair.conn(Server).network_path(PathId::ZERO).unwrap();
-    assert_eq!(path.remote(), pair.client.addr);
+    assert_eq!(path.remote(), client_addr);
 }
 
 #[test]
@@ -1463,9 +1463,9 @@ fn migration() {
 
     let client_stats_after_connect = pair.client_conn_mut(client_ch).stats();
 
-    pair.client.addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1);
-    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
-    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
+    let client_addr = pair
+        .downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     pair.client_conn_mut(client_ch).ping();
 
     // Assert that just receiving the ping message is accounted into the servers
@@ -1480,7 +1480,7 @@ fn migration() {
         pair.server_conn_mut(server_ch)
             .network_path(PathId::ZERO)
             .map(|addrs| addrs.remote),
-        Ok(pair.client.addr)
+        Ok(client_addr)
     );
 
     // Assert that the client's response to the PATH_CHALLENGE was an IMMEDIATE_ACK, instead of a
@@ -1583,7 +1583,8 @@ fn regression_path_validation_stale_local_after_passive_migration() {
     // only *after* passive migration has changed the client's observed local IP.
     pair.client.inbound.clear();
 
-    pair.passive_migration(Client);
+    pair.downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
 
     // Send a ping so the server detects the migration and starts routing to the new ip.
     pair.conn_mut(Client).ping();
@@ -2693,9 +2694,9 @@ fn migrate_detects_new_mtu_and_respects_original_peer_max_udp_payload_size() {
 
     // Migrate client to a different port (and simulate a higher path MTU)
     pair.mtu = 1500;
-    pair.client.addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1);
-    assert_ne!(pair.client.addr, Pair::CLIENT_ADDR);
-    assert_ne!(pair.client.addr, Pair::SERVER_ADDR);
+    let client_addr = pair
+        .downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     pair.client_conn_mut(client_ch).ping();
     pair.drive();
 
@@ -2704,7 +2705,7 @@ fn migrate_detects_new_mtu_and_respects_original_peer_max_udp_payload_size() {
         pair.server_conn_mut(server_ch)
             .network_path(PathId::ZERO)
             .map(|addrs| addrs.remote),
-        Ok(pair.client.addr)
+        Ok(client_addr)
     );
 
     // MTU detection has successfully run after migrating
@@ -3979,14 +3980,18 @@ fn address_discovery_rebind_retransmission() {
     let time = pair.time;
     pair.client_conn_mut(client_ch)
         .handle_network_change(None, time);
-    pair.client
-        .addr
-        .set_port(pair.client.addr.port().overflowing_add(1).0);
+    let client_addr = pair
+        .downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
 
     pair.drive();
     let conn = pair.client_conn_mut(client_ch);
     assert_matches!(conn.poll(), Some(Event::HandshakeConfirmed));
-    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == pair.client.addr);
+    assert_matches!(
+        conn.poll(),
+        Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
+            if addr == client_addr
+    );
 }
 
 /// Non-multipath: handle_network_change pings for liveness and rotates the CID
@@ -4002,7 +4007,8 @@ fn network_change_single_path_recovery() {
     let cid_seq_before = pair.conn(Client).active_remote_cid_seq();
 
     // Simulate a passive migration (port change) + network change notification
-    pair.passive_migration(Client);
+    pair.downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     // The path should NOT be closed and there should be no path events

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1409,9 +1409,7 @@ fn close_from_migrated_address() {
     pair.drive();
 
     // Change client address - server will see this as migration
-    let client_addr = pair
-        .downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    let client_addr = pair.routes.mut_basic().passive_migration(Client);
 
     // Client closes connection from the NEW address.  The server will see the migration and
     // close the connection on the new address.
@@ -1463,9 +1461,7 @@ fn migration() {
 
     let client_stats_after_connect = pair.client_conn_mut(client_ch).stats();
 
-    let client_addr = pair
-        .downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    let client_addr = pair.routes.mut_basic().passive_migration(Client);
     pair.client_conn_mut(client_ch).ping();
 
     // Assert that just receiving the ping message is accounted into the servers
@@ -1583,8 +1579,7 @@ fn regression_path_validation_stale_local_after_passive_migration() {
     // only *after* passive migration has changed the client's observed local IP.
     pair.client.inbound.clear();
 
-    pair.downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    pair.routes.mut_basic().passive_migration(Client);
 
     // Send a ping so the server detects the migration and starts routing to the new ip.
     pair.conn_mut(Client).ping();
@@ -2694,9 +2689,7 @@ fn migrate_detects_new_mtu_and_respects_original_peer_max_udp_payload_size() {
 
     // Migrate client to a different port (and simulate a higher path MTU)
     pair.mtu = 1500;
-    let client_addr = pair
-        .downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    let client_addr = pair.routes.mut_basic().passive_migration(Client);
     pair.client_conn_mut(client_ch).ping();
     pair.drive();
 
@@ -3980,9 +3973,7 @@ fn address_discovery_rebind_retransmission() {
     let time = pair.time;
     pair.client_conn_mut(client_ch)
         .handle_network_change(None, time);
-    let client_addr = pair
-        .downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    let client_addr = pair.routes.mut_basic().passive_migration(Client);
 
     pair.drive();
     let conn = pair.client_conn_mut(client_ch);
@@ -4007,8 +3998,7 @@ fn network_change_single_path_recovery() {
     let cid_seq_before = pair.conn(Client).active_remote_cid_seq();
 
     // Simulate a passive migration (port change) + network change notification
-    pair.downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    pair.routes.mut_basic().passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     // The path should NOT be closed and there should be no path events

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -21,7 +21,7 @@ use crate::{
     n0_nat_traversal,
 };
 
-use super::util::{min_opt, subscribe};
+use super::util::{BasicRouting, min_opt, subscribe};
 use super::{Pair, SimpleFirewallRoutingTable, client_config, server_config};
 
 const MAX_PATHS: u32 = 3;
@@ -550,10 +550,10 @@ fn open_path_ensure_after_abandon() -> TestResult {
     let mut second_server_addr = pair.server.addr;
     second_client_addr.set_port(second_client_addr.port() + 1);
     second_server_addr.set_port(second_server_addr.port() + 1);
-    pair.routes = Some(Box::new(RoutingTable::simple_symmetric(
+    pair.routes = Box::new(RoutingTable::simple_symmetric(
         [pair.client.addr, second_client_addr],
         [pair.server.addr, second_server_addr],
-    )));
+    ));
 
     let second_path = FourTuple {
         local_ip: Some(second_client_addr.ip()),
@@ -692,16 +692,26 @@ fn per_path_observed_address() -> TestResult {
 
     // check that the client received the correct address
     let expected_addr = pair.client.addr;
-    assert_matches!(pair.poll(Client), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
+    assert_matches!(
+        pair.poll(Client),
+        Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
+            if addr == expected_addr
+    );
     assert_matches!(pair.poll(Client), None);
 
     // check that the server received the correct address
     let expected_addr = pair.server.addr;
-    assert_matches!(pair.poll(Server), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
+    assert_matches!(
+        pair.poll(Server),
+        Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
+            if addr == expected_addr
+    );
     assert_matches!(pair.poll(Server), None);
 
     // simulate a rebind on the client, this will close the current path and open a new one
-    let our_addr = pair.passive_migration(Client);
+    let our_addr = pair
+        .downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     pair.drive();
@@ -804,7 +814,8 @@ fn remote_can_close_last_validated_path() -> TestResult {
     let _guard = subscribe();
     let mut pair = multipath_pair();
 
-    pair.passive_migration(Client);
+    pair.downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     let route = FourTuple {
         remote: pair.server.addr,
         local_ip: None,
@@ -836,7 +847,8 @@ fn network_change_multipath_no_hint_replaces_path() -> TestResult {
     let mut pair = multipath_pair();
 
     // Simulate a passive migration + network change with no hint
-    pair.passive_migration(Client);
+    pair.downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     pair.drive();
@@ -938,7 +950,8 @@ fn network_change_selective_hint() -> TestResult {
     }
     let hint = SelectiveHint(PathId::ZERO);
 
-    pair.passive_migration(Client);
+    pair.downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     pair.handle_network_change(Client, Some(&hint));
 
     pair.drive();
@@ -1199,7 +1212,8 @@ fn server_abandon_last_verified_path() -> TestResult {
     // will assume the 2nd path is validated but to the server it will be
     // un-validated. Otherwise the client would not allow closing path 0 since there would
     // be no validated path left over.
-    pair.passive_migration(Client);
+    pair.downcast_routes_mut::<BasicRouting>()
+        .passive_migration(Client);
     let route = FourTuple {
         remote: pair.server.addr,
         local_ip: None,
@@ -1490,10 +1504,10 @@ fn abandon_cycle() -> TestResult {
         sa.set_port(sa.port() + i);
         addrs_server.push(sa);
     }
-    pair.routes = Some(Box::new(RoutingTable::simple_symmetric(
+    pair.routes = Box::new(RoutingTable::simple_symmetric(
         addrs_client.clone(),
         addrs_server.clone(),
-    )));
+    ));
 
     // Cycle: open a second path, abandon path 0, verify cleanup, repeat with new paths.
     // Each cycle uses a fresh pair of addresses.
@@ -1699,7 +1713,7 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     let mut pair = multipath_pair_with_nat_traversal(true);
 
     info!("setting routes, adding addrs");
-    pair.routes = Some(Box::new(SimpleFirewallRoutingTable::new()));
+    pair.routes = Box::new(SimpleFirewallRoutingTable::new());
     pair.add_nat_traversal_address(Server, SimpleFirewallRoutingTable::SERVER_FW_ADDR)?;
     pair.add_nat_traversal_address(Client, SimpleFirewallRoutingTable::CLIENT_FW_ADDR)?;
     pair.drive();
@@ -1735,7 +1749,7 @@ fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
     let mut pair = multipath_pair_with_nat_traversal(true);
 
     info!("setting routes, adding addrs");
-    pair.routes = Some(Box::new(SimpleFirewallRoutingTable::new()));
+    pair.routes = Box::new(SimpleFirewallRoutingTable::new());
     pair.add_nat_traversal_address(Server, SimpleFirewallRoutingTable::SERVER_FW_ADDR)?;
     pair.add_nat_traversal_address(Client, SimpleFirewallRoutingTable::CLIENT_FW_ADDR)?;
     pair.drive();

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -710,7 +710,7 @@ fn per_path_observed_address() -> TestResult {
     assert_matches!(pair.poll(Server), None);
 
     // simulate a rebind on the client, this will close the current path and open a new one
-    let our_addr = pair.routes.mut_basic().passive_migration(Client);
+    let our_addr = pair.routes.as_basic_mut().passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     pair.drive();
@@ -813,7 +813,7 @@ fn remote_can_close_last_validated_path() -> TestResult {
     let _guard = subscribe();
     let mut pair = multipath_pair();
 
-    pair.routes.mut_basic().passive_migration(Client);
+    pair.routes.as_basic_mut().passive_migration(Client);
     let route = FourTuple {
         remote: pair.server.addr,
         local_ip: None,
@@ -845,7 +845,7 @@ fn network_change_multipath_no_hint_replaces_path() -> TestResult {
     let mut pair = multipath_pair();
 
     // Simulate a passive migration + network change with no hint
-    pair.routes.mut_basic().passive_migration(Client);
+    pair.routes.as_basic_mut().passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     pair.drive();
@@ -947,7 +947,7 @@ fn network_change_selective_hint() -> TestResult {
     }
     let hint = SelectiveHint(PathId::ZERO);
 
-    pair.routes.mut_basic().passive_migration(Client);
+    pair.routes.as_basic_mut().passive_migration(Client);
     pair.handle_network_change(Client, Some(&hint));
 
     pair.drive();
@@ -1208,7 +1208,7 @@ fn server_abandon_last_verified_path() -> TestResult {
     // will assume the 2nd path is validated but to the server it will be
     // un-validated. Otherwise the client would not allow closing path 0 since there would
     // be no validated path left over.
-    pair.routes.mut_basic().passive_migration(Client);
+    pair.routes.as_basic_mut().passive_migration(Client);
     let route = FourTuple {
         remote: pair.server.addr,
         local_ip: None,

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -9,7 +9,7 @@ use assert_matches::assert_matches;
 use testresult::TestResult;
 use tracing::info;
 
-use crate::tests::RoutingTable;
+use crate::tests::ManyToManyRouting;
 use crate::tests::util::ConnPair;
 use crate::{
     ClientConfig, ConnectionId, ConnectionIdGenerator, Endpoint, EndpointConfig, FourTuple,
@@ -21,8 +21,8 @@ use crate::{
     n0_nat_traversal,
 };
 
-use super::util::{BasicRouting, min_opt, subscribe};
-use super::{Pair, SimpleFirewallRoutingTable, client_config, server_config};
+use super::util::{min_opt, subscribe};
+use super::{Pair, SimpleFirewallRouting, client_config, server_config};
 
 const MAX_PATHS: u32 = 3;
 
@@ -550,10 +550,11 @@ fn open_path_ensure_after_abandon() -> TestResult {
     let mut second_server_addr = pair.server.addr;
     second_client_addr.set_port(second_client_addr.port() + 1);
     second_server_addr.set_port(second_server_addr.port() + 1);
-    pair.routes = Box::new(RoutingTable::simple_symmetric(
+    pair.routes = ManyToManyRouting::simple_symmetric(
         [pair.client.addr, second_client_addr],
         [pair.server.addr, second_server_addr],
-    ));
+    )
+    .into();
 
     let second_path = FourTuple {
         local_ip: Some(second_client_addr.ip()),
@@ -709,9 +710,7 @@ fn per_path_observed_address() -> TestResult {
     assert_matches!(pair.poll(Server), None);
 
     // simulate a rebind on the client, this will close the current path and open a new one
-    let our_addr = pair
-        .downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    let our_addr = pair.routes.mut_basic().passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     pair.drive();
@@ -814,8 +813,7 @@ fn remote_can_close_last_validated_path() -> TestResult {
     let _guard = subscribe();
     let mut pair = multipath_pair();
 
-    pair.downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    pair.routes.mut_basic().passive_migration(Client);
     let route = FourTuple {
         remote: pair.server.addr,
         local_ip: None,
@@ -847,8 +845,7 @@ fn network_change_multipath_no_hint_replaces_path() -> TestResult {
     let mut pair = multipath_pair();
 
     // Simulate a passive migration + network change with no hint
-    pair.downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    pair.routes.mut_basic().passive_migration(Client);
     pair.handle_network_change(Client, None);
 
     pair.drive();
@@ -950,8 +947,7 @@ fn network_change_selective_hint() -> TestResult {
     }
     let hint = SelectiveHint(PathId::ZERO);
 
-    pair.downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    pair.routes.mut_basic().passive_migration(Client);
     pair.handle_network_change(Client, Some(&hint));
 
     pair.drive();
@@ -1212,8 +1208,7 @@ fn server_abandon_last_verified_path() -> TestResult {
     // will assume the 2nd path is validated but to the server it will be
     // un-validated. Otherwise the client would not allow closing path 0 since there would
     // be no validated path left over.
-    pair.downcast_routes_mut::<BasicRouting>()
-        .passive_migration(Client);
+    pair.routes.mut_basic().passive_migration(Client);
     let route = FourTuple {
         remote: pair.server.addr,
         local_ip: None,
@@ -1504,10 +1499,8 @@ fn abandon_cycle() -> TestResult {
         sa.set_port(sa.port() + i);
         addrs_server.push(sa);
     }
-    pair.routes = Box::new(RoutingTable::simple_symmetric(
-        addrs_client.clone(),
-        addrs_server.clone(),
-    ));
+    pair.routes =
+        ManyToManyRouting::simple_symmetric(addrs_client.clone(), addrs_server.clone()).into();
 
     // Cycle: open a second path, abandon path 0, verify cleanup, repeat with new paths.
     // Each cycle uses a fresh pair of addresses.
@@ -1713,9 +1706,9 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     let mut pair = multipath_pair_with_nat_traversal(true);
 
     info!("setting routes, adding addrs");
-    pair.routes = Box::new(SimpleFirewallRoutingTable::new());
-    pair.add_nat_traversal_address(Server, SimpleFirewallRoutingTable::SERVER_FW_ADDR)?;
-    pair.add_nat_traversal_address(Client, SimpleFirewallRoutingTable::CLIENT_FW_ADDR)?;
+    pair.routes = SimpleFirewallRouting::new().into();
+    pair.add_nat_traversal_address(Server, SimpleFirewallRouting::SERVER_FW_ADDR)?;
+    pair.add_nat_traversal_address(Client, SimpleFirewallRouting::CLIENT_FW_ADDR)?;
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");
@@ -1749,9 +1742,9 @@ fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
     let mut pair = multipath_pair_with_nat_traversal(true);
 
     info!("setting routes, adding addrs");
-    pair.routes = Box::new(SimpleFirewallRoutingTable::new());
-    pair.add_nat_traversal_address(Server, SimpleFirewallRoutingTable::SERVER_FW_ADDR)?;
-    pair.add_nat_traversal_address(Client, SimpleFirewallRoutingTable::CLIENT_FW_ADDR)?;
+    pair.routes = SimpleFirewallRouting::new().into();
+    pair.add_nat_traversal_address(Server, SimpleFirewallRouting::SERVER_FW_ADDR)?;
+    pair.add_nat_traversal_address(Client, SimpleFirewallRouting::CLIENT_FW_ADDR)?;
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");

--- a/noq-proto/src/tests/proptests.rs
+++ b/noq-proto/src/tests/proptests.rs
@@ -16,7 +16,7 @@ use crate::{
     ClientConfig, Connection, ConnectionClose, ConnectionError, Event, PathStatus, Side,
     TransportConfig, TransportErrorCode,
     tests::{
-        Pair, RoutingTable, client_config,
+        ManyToManyRouting, Pair, client_config,
         random_interaction::{TestOp, run_random_interaction},
         server_config, subscribe,
     },
@@ -96,27 +96,7 @@ pub(super) enum RoutingSetup {
     /// Use [`RoutingTable::simple_symmetric`] with the default [`CLIENT_ADDRS`] and [`SERVER_ADDRS`].
     SimpleSymmetric,
     /// Use given generated routing table.
-    Complex(#[strategy(routing_table())] RoutingTable),
-}
-
-impl RoutingSetup {
-    fn routing(&self) -> RoutingTableKind {
-        match self {
-            RoutingSetup::Basic => RoutingTableKind::Basic,
-            RoutingSetup::SimpleSymmetric | RoutingSetup::Complex(_) => RoutingTableKind::OG,
-        }
-    }
-}
-
-/// Which [`PairRoutingTable`] is in use.
-///
-/// We need this to know how to downcast it.
-#[derive(Debug, Copy, Clone)]
-pub(super) enum RoutingTableKind {
-    /// [`BasicRouting`]
-    Basic,
-    /// [`RoutingTable`]
-    OG,
+    Complex(#[strategy(routing_table())] ManyToManyRouting),
 }
 
 /// Which seed to use in the test setup.
@@ -182,21 +162,22 @@ impl PairSetup {
 
         match self.routing_setup {
             RoutingSetup::Basic => {
-                pair.routes = Box::new(BasicRouting {
+                pair.routes = BasicRouting {
                     client_addr: pair.client.addr,
                     server_addr: pair.server.addr,
-                });
+                }
+                .into();
             }
             RoutingSetup::SimpleSymmetric => {
-                let routes = RoutingTable::simple_symmetric(CLIENT_ADDRS, SERVER_ADDRS);
+                let routes = ManyToManyRouting::simple_symmetric(CLIENT_ADDRS, SERVER_ADDRS);
                 pair.client.addr = routes.client_addr(0).unwrap();
                 pair.server.addr = routes.server_addr(0).unwrap();
-                pair.routes = Box::new(routes);
+                pair.routes = routes.into();
             }
             RoutingSetup::Complex(routes) => {
                 pair.client.addr = routes.client_addr(0).unwrap();
                 pair.server.addr = routes.server_addr(0).unwrap();
-                pair.routes = Box::new(routes);
+                pair.routes = routes.into();
             }
         }
 
@@ -228,10 +209,8 @@ fn random_interaction(
     setup: PairSetup,
     #[strategy(vec(any::<TestOp>(), 0..100))] interactions: Vec<TestOp>,
 ) {
-    let routing = setup.routing_setup.routing();
     let (mut pair, client_config) = setup.run("random_interaction");
-    let (client_ch, server_ch) =
-        run_random_interaction(routing, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     prop_assert!(!pair.drive_bounded(1000), "connection never became idle");
     prop_assert!(allowed_error(poll_to_close(
@@ -242,7 +221,7 @@ fn random_interaction(
     )));
 }
 
-fn routing_table() -> impl Strategy<Value = RoutingTable> {
+fn routing_table() -> impl Strategy<Value = ManyToManyRouting> {
     (vec(0..=5usize, 0..=4), vec(0..=5usize, 0..=4)).prop_map(|(client_offsets, server_offsets)| {
         let mut client_addr = SocketAddr::new(
             IpAddr::V6(Ipv4Addr::new(1, 1, 1, 0).to_ipv6_mapped()),
@@ -271,7 +250,7 @@ fn routing_table() -> impl Strategy<Value = RoutingTable> {
             server_routes.push((server_addr, client_idx));
         }
 
-        RoutingTable::from_routes(client_routes, server_routes)
+        ManyToManyRouting::from_routes(client_routes, server_routes)
     })
 }
 
@@ -279,8 +258,8 @@ fn routing_table() -> impl Strategy<Value = RoutingTable> {
 ///
 /// Client and server have multiple interfaces, but all outgoing links go to the first
 /// interface of defined for the peer.
-fn old_routing_table() -> RoutingTable {
-    let mut routes = RoutingTable::simple_symmetric([CLIENT_ADDRS[0]], [SERVER_ADDRS[0]]);
+fn old_routing_table() -> ManyToManyRouting {
+    let mut routes = ManyToManyRouting::simple_symmetric([CLIENT_ADDRS[0]], [SERVER_ADDRS[0]]);
     for addr in CLIENT_ADDRS.into_iter().skip(1) {
         routes.add_client_route(addr, 0);
     }
@@ -355,8 +334,7 @@ fn regression_unset_packet_acked() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -395,8 +373,7 @@ fn regression_invalid_key() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -447,8 +424,7 @@ fn regression_invalid_key2() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -482,8 +458,7 @@ fn regression_key_update_error() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -522,8 +497,7 @@ fn regression_never_idle() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -564,8 +538,7 @@ fn regression_never_idle2() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     // We needed to increase the bounds. It eventually times out.
     assert!(!pair.drive_bounded(1000), "connection never became idle");
@@ -607,8 +580,7 @@ fn regression_packet_number_space_missing() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -642,8 +614,7 @@ fn regression_peer_failed_to_respond_with_path_abandon() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -687,8 +658,7 @@ fn regression_peer_failed_to_respond_with_path_abandon2() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -736,7 +706,7 @@ fn regression_path_validation() {
     let setup = PairSetup {
         seed: Seed::Zeroes,
         extensions: Extensions::MultipathOnly,
-        routing_setup: RoutingSetup::Complex(RoutingTable::from_routes(
+        routing_setup: RoutingSetup::Complex(ManyToManyRouting::from_routes(
             vec![("[::ffff:1.1.1.0]:44433".parse().unwrap(), 0)],
             vec![
                 ("[::ffff:2.2.2.0]:4433".parse().unwrap(), 0),
@@ -767,8 +737,7 @@ fn regression_path_validation() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -825,8 +794,7 @@ fn regression_never_idle3() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -865,8 +833,7 @@ fn regression_frame_encoding_error() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -898,8 +865,7 @@ fn regression_there_should_be_at_least_one_path() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -951,8 +917,7 @@ fn regression_conn_never_idle5() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -1020,8 +985,7 @@ fn regression_peer_ignored_path_abandon() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -1061,7 +1025,7 @@ fn regression_never_idle4() {
     let setup = PairSetup {
         seed: Seed::Zeroes,
         extensions: Extensions::MultipathOnly,
-        routing_setup: RoutingSetup::Complex(RoutingTable::from_routes(
+        routing_setup: RoutingSetup::Complex(ManyToManyRouting::from_routes(
             vec![
                 ("[::ffff:1.1.1.0]:44433".parse().unwrap(), 0),
                 ("[::ffff:1.1.1.1]:44433".parse().unwrap(), 0),
@@ -1110,8 +1074,7 @@ fn regression_never_idle4() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -1173,8 +1136,7 @@ fn regression_infinite_loop() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     // This bug originally occurred at exactly 4540 iterations.
     // At 4539 it still finishes (but fails the assertion).
@@ -1235,8 +1197,7 @@ fn regression_qnt_revalidating_path_forever() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) =
-        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
+    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(

--- a/noq-proto/src/tests/proptests.rs
+++ b/noq-proto/src/tests/proptests.rs
@@ -22,6 +22,8 @@ use crate::{
     },
 };
 
+use super::BasicRouting;
+
 // These TransportConfig constants are designed to match iroh for now.
 const MAX_MULTIPATH_PATHS: u32 = 8;
 const MAX_QNT_ADDRS: u8 = 32;
@@ -88,13 +90,33 @@ enum Extensions {
 /// The advantage of using this is very efficient shrinking: The first attempt at shrinking the
 /// routing setup will be to reduce the routing setup to nothing or a simple symmetric one.
 #[derive(Debug, test_strategy::Arbitrary)]
-enum RoutingSetup {
-    /// Set [`Pair::routes`] to `None`
-    None,
+pub(super) enum RoutingSetup {
+    /// Set [`Pair::routes`] to [`BasicRouting`]
+    Basic,
     /// Use [`RoutingTable::simple_symmetric`] with the default [`CLIENT_ADDRS`] and [`SERVER_ADDRS`].
     SimpleSymmetric,
     /// Use given generated routing table.
     Complex(#[strategy(routing_table())] RoutingTable),
+}
+
+impl RoutingSetup {
+    fn routing(&self) -> RoutingTableKind {
+        match self {
+            RoutingSetup::Basic => RoutingTableKind::Basic,
+            RoutingSetup::SimpleSymmetric | RoutingSetup::Complex(_) => RoutingTableKind::OG,
+        }
+    }
+}
+
+/// Which [`PairRoutingTable`] is in use.
+///
+/// We need this to know how to downcast it.
+#[derive(Debug, Copy, Clone)]
+pub(super) enum RoutingTableKind {
+    /// [`BasicRouting`]
+    Basic,
+    /// [`RoutingTable`]
+    OG,
 }
 
 /// Which seed to use in the test setup.
@@ -159,19 +181,22 @@ impl PairSetup {
         // Add routing, if enabled
 
         match self.routing_setup {
-            RoutingSetup::None => {
-                pair.routes = None;
+            RoutingSetup::Basic => {
+                pair.routes = Box::new(BasicRouting {
+                    client_addr: pair.client.addr,
+                    server_addr: pair.server.addr,
+                });
             }
             RoutingSetup::SimpleSymmetric => {
                 let routes = RoutingTable::simple_symmetric(CLIENT_ADDRS, SERVER_ADDRS);
                 pair.client.addr = routes.client_addr(0).unwrap();
                 pair.server.addr = routes.server_addr(0).unwrap();
-                pair.routes = Some(Box::new(routes));
+                pair.routes = Box::new(routes);
             }
             RoutingSetup::Complex(routes) => {
                 pair.client.addr = routes.client_addr(0).unwrap();
                 pair.server.addr = routes.server_addr(0).unwrap();
-                pair.routes = Some(Box::new(routes));
+                pair.routes = Box::new(routes);
             }
         }
 
@@ -203,8 +228,10 @@ fn random_interaction(
     setup: PairSetup,
     #[strategy(vec(any::<TestOp>(), 0..100))] interactions: Vec<TestOp>,
 ) {
+    let routing = setup.routing_setup.routing();
     let (mut pair, client_config) = setup.run("random_interaction");
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(routing, &mut pair, interactions, client_config);
 
     prop_assert!(!pair.drive_bounded(1000), "connection never became idle");
     prop_assert!(allowed_error(poll_to_close(
@@ -328,7 +355,8 @@ fn regression_unset_packet_acked() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -367,7 +395,8 @@ fn regression_invalid_key() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -418,7 +447,8 @@ fn regression_invalid_key2() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -452,7 +482,8 @@ fn regression_key_update_error() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -491,7 +522,8 @@ fn regression_never_idle() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -532,7 +564,8 @@ fn regression_never_idle2() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     // We needed to increase the bounds. It eventually times out.
     assert!(!pair.drive_bounded(1000), "connection never became idle");
@@ -574,7 +607,8 @@ fn regression_packet_number_space_missing() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -608,7 +642,8 @@ fn regression_peer_failed_to_respond_with_path_abandon() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -652,7 +687,8 @@ fn regression_peer_failed_to_respond_with_path_abandon2() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -731,7 +767,8 @@ fn regression_path_validation() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -788,7 +825,8 @@ fn regression_never_idle3() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -827,7 +865,8 @@ fn regression_frame_encoding_error() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -859,7 +898,8 @@ fn regression_there_should_be_at_least_one_path() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -911,7 +951,8 @@ fn regression_conn_never_idle5() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -979,7 +1020,8 @@ fn regression_peer_ignored_path_abandon() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -1068,7 +1110,8 @@ fn regression_never_idle4() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(
@@ -1130,7 +1173,8 @@ fn regression_infinite_loop() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     // This bug originally occurred at exactly 4540 iterations.
     // At 4539 it still finishes (but fails the assertion).
@@ -1191,7 +1235,8 @@ fn regression_qnt_revalidating_path_forever() {
 
     let _guard = subscribe();
     let (mut pair, client_config) = setup.run(prefix);
-    let (client_ch, server_ch) = run_random_interaction(&mut pair, interactions, client_config);
+    let (client_ch, server_ch) =
+        run_random_interaction(RoutingTableKind::OG, &mut pair, interactions, client_config);
 
     assert!(!pair.drive_bounded(1000), "connection never became idle");
     assert!(allowed_error(poll_to_close(

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -9,7 +9,7 @@ use crate::{
     tests::{Pair, TestEndpoint},
 };
 
-use super::{BasicRouting, RoutingTable, proptests::RoutingTableKind};
+use super::RoutingTable;
 
 #[derive(Debug, Clone, Copy, Arbitrary)]
 pub(super) enum TestOp {
@@ -104,13 +104,7 @@ pub(super) struct State {
 }
 
 impl TestOp {
-    fn run(
-        self,
-        routing: RoutingTableKind,
-        pair: &mut Pair,
-        client: &mut State,
-        server: &mut State,
-    ) -> Option<()> {
+    fn run(self, pair: &mut Pair, client: &mut State, server: &mut State) -> Option<()> {
         let now = pair.time;
         match self {
             Self::Drive { side: Side::Client } => pair.drive_client(),
@@ -142,27 +136,25 @@ impl TestOp {
             Self::PassiveMigration {
                 side: Side::Client,
                 addr_idx,
-            } => match routing {
-                RoutingTableKind::Basic => {
-                    pair.downcast_routes_mut::<BasicRouting>()
-                        .passive_migration(Side::Client);
+            } => match pair.routes {
+                RoutingTable::Basic(ref mut routes) => {
+                    routes.passive_migration(Side::Client);
                 }
-                RoutingTableKind::OG => {
-                    pair.downcast_routes_mut::<RoutingTable>()
-                        .sim_client_migration(addr_idx, inc_last_addr_octet);
+                RoutingTable::SimpleFirewall(_) => unimplemented!(),
+                RoutingTable::ManyToMany(ref mut routes) => {
+                    routes.sim_client_migration(addr_idx, inc_last_addr_octet);
                 }
             },
             Self::PassiveMigration {
                 side: Side::Server,
                 addr_idx,
-            } => match routing {
-                RoutingTableKind::Basic => {
-                    pair.downcast_routes_mut::<BasicRouting>()
-                        .passive_migration(Side::Server);
+            } => match pair.routes {
+                RoutingTable::Basic(ref mut routes) => {
+                    routes.passive_migration(Side::Server);
                 }
-                RoutingTableKind::OG => {
-                    pair.downcast_routes_mut::<RoutingTable>()
-                        .sim_server_migration(addr_idx, inc_last_addr_octet);
+                RoutingTable::SimpleFirewall(_) => unimplemented!(),
+                RoutingTable::ManyToMany(ref mut routes) => {
+                    routes.sim_server_migration(addr_idx, inc_last_addr_octet);
                 }
             },
             Self::OpenPath {
@@ -170,21 +162,16 @@ impl TestOp {
                 status,
                 addr_idx,
             } => {
-                let remote = match routing {
-                    RoutingTableKind::Basic => {
-                        let routes = pair.downcast_routes_ref::<BasicRouting>();
-                        match side {
-                            Side::Client => routes.server_addr,
-                            Side::Server => routes.client_addr,
-                        }
-                    }
-                    RoutingTableKind::OG => {
-                        let routes = pair.downcast_routes_ref::<RoutingTable>();
-                        match side {
-                            Side::Client => routes.server_addr(addr_idx)?,
-                            Side::Server => routes.client_addr(addr_idx)?,
-                        }
-                    }
+                let remote = match pair.routes {
+                    RoutingTable::Basic(ref routes) => match side {
+                        Side::Client => routes.server_addr,
+                        Side::Server => routes.client_addr,
+                    },
+                    RoutingTable::SimpleFirewall(_) => unimplemented!(),
+                    RoutingTable::ManyToMany(ref routes) => match side {
+                        Side::Client => routes.server_addr(addr_idx)?,
+                        Side::Server => routes.client_addr(addr_idx)?,
+                    },
                 };
                 let state = match side {
                     Side::Client => client,
@@ -245,21 +232,16 @@ impl TestOp {
                 conn.close(now, error_code.into(), Bytes::new());
             }
             Self::AddHpAddr { side, addr_idx } => {
-                let address = match routing {
-                    RoutingTableKind::Basic => {
-                        let routes = pair.downcast_routes_ref::<BasicRouting>();
-                        match side {
-                            Side::Client => routes.client_addr,
-                            Side::Server => routes.server_addr,
-                        }
-                    }
-                    RoutingTableKind::OG => {
-                        let routes = pair.downcast_routes_ref::<RoutingTable>();
-                        match side {
-                            Side::Client => routes.client_addr(addr_idx)?,
-                            Side::Server => routes.server_addr(addr_idx)?,
-                        }
-                    }
+                let address = match pair.routes {
+                    RoutingTable::Basic(ref routes) => match side {
+                        Side::Client => routes.client_addr,
+                        Side::Server => routes.server_addr,
+                    },
+                    RoutingTable::SimpleFirewall(_) => unimplemented!(),
+                    RoutingTable::ManyToMany(ref routes) => match side {
+                        Side::Client => routes.client_addr(addr_idx)?,
+                        Side::Server => routes.server_addr(addr_idx)?,
+                    },
                 };
                 let state = match side {
                     Side::Client => client,
@@ -371,7 +353,6 @@ fn inc_last_addr_octet(addr: SocketAddr) -> SocketAddr {
 }
 
 pub(super) fn run_random_interaction(
-    routing: RoutingTableKind,
     pair: &mut Pair,
     interactions: Vec<TestOp>,
     client_config: ClientConfig,
@@ -384,7 +365,7 @@ pub(super) fn run_random_interaction(
 
     for interaction in interactions {
         info!(?interaction, "INTERACTION STEP");
-        interaction.run(routing, pair, &mut client, &mut server);
+        interaction.run(pair, &mut client, &mut server);
     }
     (client.handle, server.handle)
 }

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -9,7 +9,7 @@ use crate::{
     tests::{Pair, TestEndpoint},
 };
 
-use super::RoutingTable;
+use super::{BasicRouting, RoutingTable, proptests::RoutingTableKind};
 
 #[derive(Debug, Clone, Copy, Arbitrary)]
 pub(super) enum TestOp {
@@ -104,7 +104,13 @@ pub(super) struct State {
 }
 
 impl TestOp {
-    fn run(self, pair: &mut Pair, client: &mut State, server: &mut State) -> Option<()> {
+    fn run(
+        self,
+        routing: RoutingTableKind,
+        pair: &mut Pair,
+        client: &mut State,
+        server: &mut State,
+    ) -> Option<()> {
         let now = pair.time;
         match self {
             Self::Drive { side: Side::Client } => pair.drive_client(),
@@ -136,26 +142,49 @@ impl TestOp {
             Self::PassiveMigration {
                 side: Side::Client,
                 addr_idx,
-            } => {
-                let routes = pair.downcast_routes_mut::<RoutingTable>()?;
-                routes.sim_client_migration(addr_idx, inc_last_addr_octet);
-            }
+            } => match routing {
+                RoutingTableKind::Basic => {
+                    pair.downcast_routes_mut::<BasicRouting>()
+                        .passive_migration(Side::Client);
+                }
+                RoutingTableKind::OG => {
+                    pair.downcast_routes_mut::<RoutingTable>()
+                        .sim_client_migration(addr_idx, inc_last_addr_octet);
+                }
+            },
             Self::PassiveMigration {
                 side: Side::Server,
                 addr_idx,
-            } => {
-                let routes = pair.downcast_routes_mut::<RoutingTable>()?;
-                routes.sim_server_migration(addr_idx, inc_last_addr_octet);
-            }
+            } => match routing {
+                RoutingTableKind::Basic => {
+                    pair.downcast_routes_mut::<BasicRouting>()
+                        .passive_migration(Side::Server);
+                }
+                RoutingTableKind::OG => {
+                    pair.downcast_routes_mut::<RoutingTable>()
+                        .sim_server_migration(addr_idx, inc_last_addr_octet);
+                }
+            },
             Self::OpenPath {
                 side,
                 status,
                 addr_idx,
             } => {
-                let routes = pair.downcast_routes_ref::<RoutingTable>()?;
-                let remote = match side {
-                    Side::Client => routes.server_addr(addr_idx)?,
-                    Side::Server => routes.client_addr(addr_idx)?,
+                let remote = match routing {
+                    RoutingTableKind::Basic => {
+                        let routes = pair.downcast_routes_ref::<BasicRouting>();
+                        match side {
+                            Side::Client => routes.server_addr,
+                            Side::Server => routes.client_addr,
+                        }
+                    }
+                    RoutingTableKind::OG => {
+                        let routes = pair.downcast_routes_ref::<RoutingTable>();
+                        match side {
+                            Side::Client => routes.server_addr(addr_idx)?,
+                            Side::Server => routes.client_addr(addr_idx)?,
+                        }
+                    }
                 };
                 let state = match side {
                     Side::Client => client,
@@ -216,10 +245,21 @@ impl TestOp {
                 conn.close(now, error_code.into(), Bytes::new());
             }
             Self::AddHpAddr { side, addr_idx } => {
-                let routes = pair.downcast_routes_ref::<RoutingTable>()?;
-                let address = match side {
-                    Side::Client => routes.client_addr(addr_idx)?,
-                    Side::Server => routes.server_addr(addr_idx)?,
+                let address = match routing {
+                    RoutingTableKind::Basic => {
+                        let routes = pair.downcast_routes_ref::<BasicRouting>();
+                        match side {
+                            Side::Client => routes.client_addr,
+                            Side::Server => routes.server_addr,
+                        }
+                    }
+                    RoutingTableKind::OG => {
+                        let routes = pair.downcast_routes_ref::<RoutingTable>();
+                        match side {
+                            Side::Client => routes.client_addr(addr_idx)?,
+                            Side::Server => routes.server_addr(addr_idx)?,
+                        }
+                    }
                 };
                 let state = match side {
                     Side::Client => client,
@@ -331,6 +371,7 @@ fn inc_last_addr_octet(addr: SocketAddr) -> SocketAddr {
 }
 
 pub(super) fn run_random_interaction(
+    routing: RoutingTableKind,
     pair: &mut Pair,
     interactions: Vec<TestOp>,
     client_config: ClientConfig,
@@ -343,7 +384,7 @@ pub(super) fn run_random_interaction(
 
     for interaction in interactions {
         info!(?interaction, "INTERACTION STEP");
-        interaction.run(pair, &mut client, &mut server);
+        interaction.run(routing, pair, &mut client, &mut server);
     }
     (client.handle, server.handle)
 }

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -9,7 +9,7 @@ use crate::{
     tests::{Pair, TestEndpoint},
 };
 
-use super::RoutingTable;
+use super::Routing;
 
 #[derive(Debug, Clone, Copy, Arbitrary)]
 pub(super) enum TestOp {
@@ -137,11 +137,11 @@ impl TestOp {
                 side: Side::Client,
                 addr_idx,
             } => match pair.routes {
-                RoutingTable::Basic(ref mut routes) => {
+                Routing::Basic(ref mut routes) => {
                     routes.passive_migration(Side::Client);
                 }
-                RoutingTable::SimpleFirewall(_) => unimplemented!(),
-                RoutingTable::ManyToMany(ref mut routes) => {
+                Routing::SimpleFirewall(_) => unimplemented!(),
+                Routing::ManyToMany(ref mut routes) => {
                     routes.sim_client_migration(addr_idx, inc_last_addr_octet);
                 }
             },
@@ -149,11 +149,11 @@ impl TestOp {
                 side: Side::Server,
                 addr_idx,
             } => match pair.routes {
-                RoutingTable::Basic(ref mut routes) => {
+                Routing::Basic(ref mut routes) => {
                     routes.passive_migration(Side::Server);
                 }
-                RoutingTable::SimpleFirewall(_) => unimplemented!(),
-                RoutingTable::ManyToMany(ref mut routes) => {
+                Routing::SimpleFirewall(_) => unimplemented!(),
+                Routing::ManyToMany(ref mut routes) => {
                     routes.sim_server_migration(addr_idx, inc_last_addr_octet);
                 }
             },
@@ -163,12 +163,12 @@ impl TestOp {
                 addr_idx,
             } => {
                 let remote = match pair.routes {
-                    RoutingTable::Basic(ref routes) => match side {
+                    Routing::Basic(ref routes) => match side {
                         Side::Client => routes.server_addr,
                         Side::Server => routes.client_addr,
                     },
-                    RoutingTable::SimpleFirewall(_) => unimplemented!(),
-                    RoutingTable::ManyToMany(ref routes) => match side {
+                    Routing::SimpleFirewall(_) => unimplemented!(),
+                    Routing::ManyToMany(ref routes) => match side {
                         Side::Client => routes.server_addr(addr_idx)?,
                         Side::Server => routes.client_addr(addr_idx)?,
                     },
@@ -233,12 +233,12 @@ impl TestOp {
             }
             Self::AddHpAddr { side, addr_idx } => {
                 let address = match pair.routes {
-                    RoutingTable::Basic(ref routes) => match side {
+                    Routing::Basic(ref routes) => match side {
                         Side::Client => routes.client_addr,
                         Side::Server => routes.server_addr,
                     },
-                    RoutingTable::SimpleFirewall(_) => unimplemented!(),
-                    RoutingTable::ManyToMany(ref routes) => match side {
+                    Routing::SimpleFirewall(_) => unimplemented!(),
+                    Routing::ManyToMany(ref routes) => match side {
                         Side::Client => routes.client_addr(addr_idx)?,
                         Side::Server => routes.server_addr(addr_idx)?,
                     },

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -42,7 +42,7 @@ pub(super) struct Pair {
     pub(super) spins: u64,
     /// The routing table used for resolving addresses observed for incoming packets
     /// and determining whether they should get lost.
-    pub(super) routes: Option<Box<dyn PairRoutingTable>>,
+    pub(super) routes: Box<dyn PairRoutingTable>,
     last_spin: bool,
 }
 
@@ -96,7 +96,10 @@ impl Pair {
             spins: 0,
             last_spin: false,
             congestion_experienced: false,
-            routes: None,
+            routes: Box::new(BasicRouting {
+                client_addr,
+                server_addr,
+            }),
         }
     }
 
@@ -127,7 +130,10 @@ impl Pair {
             spins: 0,
             last_spin: false,
             congestion_experienced: false,
-            routes: None,
+            routes: Box::new(BasicRouting {
+                client_addr: Self::CLIENT_ADDR,
+                server_addr: Self::SERVER_ADDR,
+            }),
         }
     }
 
@@ -193,20 +199,7 @@ impl Pair {
                 self.spins += (spin == self.last_spin) as u64;
                 self.last_spin = spin;
             }
-            let outcome = match self.routes.as_mut() {
-                Some(table) => table.route_client_to_server(&packet),
-                None => {
-                    if self.server.addr == packet.destination {
-                        RoutingDecision::Deliver {
-                            src: self.client.addr,
-                            dst: Some(packet.destination.ip()),
-                        }
-                    } else {
-                        RoutingDecision::Drop
-                    }
-                }
-            };
-            match outcome {
+            match self.routes.route_client_to_server(&packet) {
                 RoutingDecision::Deliver { src, dst } => {
                     let ecn = set_congestion_experienced(packet.ecn, self.congestion_experienced);
                     self.server.inbound.push_back(Inbound {
@@ -234,20 +227,7 @@ impl Pair {
                 info!(packet_size, "dropping packet (max size exceeded)");
                 continue;
             }
-            let outcome = match self.routes.as_mut() {
-                Some(table) => table.route_server_to_client(&packet),
-                None => {
-                    if self.client.addr == packet.destination {
-                        RoutingDecision::Deliver {
-                            src: self.server.addr,
-                            dst: Some(packet.destination.ip()),
-                        }
-                    } else {
-                        RoutingDecision::Drop
-                    }
-                }
-            };
-            match outcome {
+            match self.routes.route_server_to_client(&packet) {
                 RoutingDecision::Deliver { src, dst } => {
                     let ecn = set_congestion_experienced(packet.ecn, self.congestion_experienced);
                     self.client.inbound.push_back(Inbound {
@@ -399,23 +379,19 @@ impl Pair {
     }
 
     /// Helper to get access to the test-specific routing table.
-    pub(super) fn downcast_routes_ref<T: PairRoutingTable>(&self) -> Option<&T> {
-        let routes: &dyn std::any::Any = self.routes.as_ref()?.as_ref();
-        Some(
-            routes
-                .downcast_ref::<T>()
-                .expect("downcast type does not match"),
-        )
+    pub(super) fn downcast_routes_ref<T: PairRoutingTable>(&self) -> &T {
+        let routes: &dyn std::any::Any = self.routes.as_ref();
+        routes
+            .downcast_ref::<T>()
+            .expect("downcast type does not match")
     }
 
     /// Helper to get mutable access to the test-specific routing table.
-    pub(super) fn downcast_routes_mut<T: PairRoutingTable>(&mut self) -> Option<&mut T> {
-        let routes: &mut dyn std::any::Any = self.routes.as_mut()?.as_mut();
-        Some(
-            routes
-                .downcast_mut::<T>()
-                .expect("downcast type does not match"),
-        )
+    pub(super) fn downcast_routes_mut<T: PairRoutingTable>(&mut self) -> &mut T {
+        let routes: &mut dyn std::any::Any = self.routes.as_mut();
+        routes
+            .downcast_mut::<T>()
+            .expect("downcast type does not match")
     }
 }
 
@@ -760,30 +736,6 @@ impl ConnPair {
 
     pub(super) fn is_multipath_negotiated(&self, side: Side) -> bool {
         self.conn(side).is_multipath_negotiated()
-    }
-
-    /// Simulate a passive migration by incrementing the last octet of the ip.
-    #[track_caller]
-    pub(super) fn passive_migration(&mut self, side: Side) -> SocketAddr {
-        let address = match side {
-            Side::Client => &mut self.pair.client.addr,
-            Side::Server => &mut self.pair.server.addr,
-        };
-
-        match address {
-            SocketAddr::V4(socket_addr_v4) => {
-                let [a, b, c, d] = socket_addr_v4.ip().octets();
-                socket_addr_v4.set_ip(Ipv4Addr::new(a, b, c, d.overflowing_add(1).0));
-            }
-            SocketAddr::V6(socket_addr_v6) => {
-                let [a, b, c, d, e, f, g, h] = socket_addr_v6.ip().segments();
-                socket_addr_v6.set_ip(Ipv6Addr::new(a, b, c, d, e, f, g, h.overflowing_add(1).0));
-            }
-        }
-
-        let new_port = address.port().checked_add(1).unwrap();
-        address.set_port(new_port);
-        *address
     }
 
     pub(super) fn current_mtu(&self, side: Side) -> u16 {
@@ -1321,6 +1273,8 @@ impl TokenLog for SimpleTokenLog {
 /// This allows implementing different routing strategies.
 pub(super) trait PairRoutingTable: std::any::Any {
     /// Routes a datagram from client to server.
+    ///
+    /// `client_addr` is the current primary address of the client.
     fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision;
     /// Routes a datagram from server to client.
     fn route_server_to_client(&mut self, transmit: &Transmit) -> RoutingDecision;
@@ -1339,6 +1293,74 @@ pub(super) enum RoutingDecision {
         dst: Option<IpAddr>,
     },
     Drop,
+}
+
+/// Routing that is essentially a direct link between the client and server.
+///
+/// Packets set to the wrong destination are still dropped however. But the source IP they
+/// are sent from is ignored, so it is only a primitive kind of routing.
+///
+/// You may change the addresses of either to make it look like they migrated to a new
+/// address.
+pub(super) struct BasicRouting {
+    pub(super) client_addr: SocketAddr,
+    pub(super) server_addr: SocketAddr,
+}
+
+impl BasicRouting {
+    /// Simulate a passive migration, remaining in the same subnet.
+    ///
+    /// This increments the last octet of the IP and the port
+    pub(super) fn passive_migration(&mut self, side: Side) -> SocketAddr {
+        let address = match side {
+            Side::Client => &mut self.client_addr,
+            Side::Server => &mut self.server_addr,
+        };
+        let prev_addr = *address;
+        match address {
+            SocketAddr::V4(socket_addr_v4) => {
+                let [a, b, c, d] = socket_addr_v4.ip().octets();
+                let mut d = d.overflowing_add(1).0;
+                if d == 0 {
+                    // skip the (potential) broadcast address
+                    d = d + 1;
+                }
+                socket_addr_v4.set_ip(Ipv4Addr::new(a, b, c, d));
+            }
+            SocketAddr::V6(socket_addr_v6) => {
+                let [a, b, c, d, e, f, g, h] = socket_addr_v6.ip().segments();
+                socket_addr_v6.set_ip(Ipv6Addr::new(a, b, c, d, e, f, g, h.overflowing_add(1).0));
+            }
+        }
+        let new_port = address.port().checked_add(1).unwrap();
+        address.set_port(new_port);
+        info!(?side, ?prev_addr, new_addr = ?address, "passive migration");
+        *address
+    }
+}
+
+impl PairRoutingTable for BasicRouting {
+    fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision {
+        if transmit.destination == self.server_addr {
+            RoutingDecision::Deliver {
+                src: self.client_addr,
+                dst: Some(transmit.destination.ip()),
+            }
+        } else {
+            RoutingDecision::Drop
+        }
+    }
+
+    fn route_server_to_client(&mut self, transmit: &Transmit) -> RoutingDecision {
+        if transmit.destination == self.client_addr {
+            RoutingDecision::Deliver {
+                src: self.server_addr,
+                dst: Some(transmit.destination.ip()),
+            }
+        } else {
+            RoutingDecision::Drop
+        }
+    }
 }
 
 /// Set of uni-directional links between interfaces of a client and server.

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1320,7 +1320,7 @@ impl BasicRouting {
         match address {
             SocketAddr::V4(socket_addr_v4) => {
                 let [a, b, c, d] = socket_addr_v4.ip().octets();
-                let mut d = d.overflowing_add(1).0;
+                let mut d = d.wrapping_add(1);
                 if d == 0 {
                     // skip the (potential) broadcast address
                     d = d + 1;
@@ -1329,7 +1329,7 @@ impl BasicRouting {
             }
             SocketAddr::V6(socket_addr_v6) => {
                 let [a, b, c, d, e, f, g, h] = socket_addr_v6.ip().segments();
-                socket_addr_v6.set_ip(Ipv6Addr::new(a, b, c, d, e, f, g, h.overflowing_add(1).0));
+                socket_addr_v6.set_ip(Ipv6Addr::new(a, b, c, d, e, f, g, h.wrapping_add(1)));
             }
         }
         let new_port = address.port().checked_add(1).unwrap();

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -42,7 +42,7 @@ pub(super) struct Pair {
     pub(super) spins: u64,
     /// The routing table used for resolving addresses observed for incoming packets
     /// and determining whether they should get lost.
-    pub(super) routes: RoutingTable,
+    pub(super) routes: Routing,
     last_spin: bool,
 }
 
@@ -1255,13 +1255,13 @@ impl TokenLog for SimpleTokenLog {
 }
 
 #[derive(Debug)]
-pub(super) enum RoutingTable {
+pub(super) enum Routing {
     Basic(BasicRouting),
     SimpleFirewall(SimpleFirewallRouting),
     ManyToMany(ManyToManyRouting),
 }
 
-impl RoutingTable {
+impl Routing {
     /// Routes a datagram from client to server.
     fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision {
         match self {
@@ -1282,28 +1282,28 @@ impl RoutingTable {
     pub(super) fn as_basic(&self) -> &BasicRouting {
         match self {
             Self::Basic(inner) => inner,
-            _ => panic!("wrong type"),
+            _ => panic!("cast to BasicRouting failed, a different routing table is set"),
         }
     }
 
-    pub(super) fn mut_basic(&mut self) -> &mut BasicRouting {
+    pub(super) fn as_basic_mut(&mut self) -> &mut BasicRouting {
         match self {
             Self::Basic(inner) => inner,
-            _ => panic!("wrong type"),
+            _ => panic!("cast to BasicRouting failed, a different routing table is set"),
         }
     }
 
     pub(super) fn as_many_to_many(&self) -> &ManyToManyRouting {
         match self {
             Self::ManyToMany(inner) => inner,
-            _ => panic!("wrong type"),
+            _ => panic!("cast to ManyToManyRouting failed, a different routing table is set"),
         }
     }
 
-    pub(super) fn mut_many_to_many(&mut self) -> &mut ManyToManyRouting {
+    pub(super) fn as_many_to_many_mut(&mut self) -> &mut ManyToManyRouting {
         match self {
             Self::ManyToMany(inner) => inner,
-            _ => panic!("wrong type"),
+            _ => panic!("cast to ManyToManyRouting failed, a different routing table is set"),
         }
     }
 }
@@ -1336,7 +1336,7 @@ pub(super) struct BasicRouting {
     pub(super) server_addr: SocketAddr,
 }
 
-impl From<BasicRouting> for RoutingTable {
+impl From<BasicRouting> for Routing {
     fn from(value: BasicRouting) -> Self {
         Self::Basic(value)
     }
@@ -1412,7 +1412,7 @@ pub(super) struct ManyToManyRouting {
     server_routes: Vec<(SocketAddr, usize)>,
 }
 
-impl From<ManyToManyRouting> for RoutingTable {
+impl From<ManyToManyRouting> for Routing {
     fn from(value: ManyToManyRouting) -> Self {
         Self::ManyToMany(value)
     }
@@ -1567,7 +1567,7 @@ pub(super) struct SimpleFirewallRouting {
     server_firewall_open: bool,
 }
 
-impl From<SimpleFirewallRouting> for RoutingTable {
+impl From<SimpleFirewallRouting> for Routing {
     fn from(value: SimpleFirewallRouting) -> Self {
         Self::SimpleFirewall(value)
     }

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -42,7 +42,7 @@ pub(super) struct Pair {
     pub(super) spins: u64,
     /// The routing table used for resolving addresses observed for incoming packets
     /// and determining whether they should get lost.
-    pub(super) routes: Box<dyn PairRoutingTable>,
+    pub(super) routes: RoutingTable,
     last_spin: bool,
 }
 
@@ -96,10 +96,11 @@ impl Pair {
             spins: 0,
             last_spin: false,
             congestion_experienced: false,
-            routes: Box::new(BasicRouting {
+            routes: BasicRouting {
                 client_addr,
                 server_addr,
-            }),
+            }
+            .into(),
         }
     }
 
@@ -130,10 +131,11 @@ impl Pair {
             spins: 0,
             last_spin: false,
             congestion_experienced: false,
-            routes: Box::new(BasicRouting {
+            routes: BasicRouting {
                 client_addr: Self::CLIENT_ADDR,
                 server_addr: Self::SERVER_ADDR,
-            }),
+            }
+            .into(),
         }
     }
 
@@ -376,22 +378,6 @@ impl Pair {
             remote: self.client.addr,
             local_ip: Some(self.server.addr.ip()),
         }
-    }
-
-    /// Helper to get access to the test-specific routing table.
-    pub(super) fn downcast_routes_ref<T: PairRoutingTable>(&self) -> &T {
-        let routes: &dyn std::any::Any = self.routes.as_ref();
-        routes
-            .downcast_ref::<T>()
-            .expect("downcast type does not match")
-    }
-
-    /// Helper to get mutable access to the test-specific routing table.
-    pub(super) fn downcast_routes_mut<T: PairRoutingTable>(&mut self) -> &mut T {
-        let routes: &mut dyn std::any::Any = self.routes.as_mut();
-        routes
-            .downcast_mut::<T>()
-            .expect("downcast type does not match")
     }
 }
 
@@ -1268,16 +1254,58 @@ impl TokenLog for SimpleTokenLog {
     }
 }
 
-/// Generic router interface for the [`Pair::routes`].
-///
-/// This allows implementing different routing strategies.
-pub(super) trait PairRoutingTable: std::any::Any {
+#[derive(Debug)]
+pub(super) enum RoutingTable {
+    Basic(BasicRouting),
+    SimpleFirewall(SimpleFirewallRouting),
+    ManyToMany(ManyToManyRouting),
+}
+
+impl RoutingTable {
     /// Routes a datagram from client to server.
-    ///
-    /// `client_addr` is the current primary address of the client.
-    fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision;
+    fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision {
+        match self {
+            Self::Basic(inner) => inner.route_client_to_server(transmit),
+            Self::SimpleFirewall(inner) => inner.route_client_to_server(transmit),
+            Self::ManyToMany(inner) => inner.route_client_to_server(transmit),
+        }
+    }
     /// Routes a datagram from server to client.
-    fn route_server_to_client(&mut self, transmit: &Transmit) -> RoutingDecision;
+    fn route_server_to_client(&mut self, transmit: &Transmit) -> RoutingDecision {
+        match self {
+            Self::Basic(inner) => inner.route_server_to_client(transmit),
+            Self::SimpleFirewall(inner) => inner.route_server_to_client(transmit),
+            Self::ManyToMany(inner) => inner.route_server_to_client(transmit),
+        }
+    }
+
+    pub(super) fn as_basic(&self) -> &BasicRouting {
+        match self {
+            Self::Basic(inner) => inner,
+            _ => panic!("wrong type"),
+        }
+    }
+
+    pub(super) fn mut_basic(&mut self) -> &mut BasicRouting {
+        match self {
+            Self::Basic(inner) => inner,
+            _ => panic!("wrong type"),
+        }
+    }
+
+    pub(super) fn as_many_to_many(&self) -> &ManyToManyRouting {
+        match self {
+            Self::ManyToMany(inner) => inner,
+            _ => panic!("wrong type"),
+        }
+    }
+
+    pub(super) fn mut_many_to_many(&mut self) -> &mut ManyToManyRouting {
+        match self {
+            Self::ManyToMany(inner) => inner,
+            _ => panic!("wrong type"),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -1302,44 +1330,19 @@ pub(super) enum RoutingDecision {
 ///
 /// You may change the addresses of either to make it look like they migrated to a new
 /// address.
+#[derive(Debug)]
 pub(super) struct BasicRouting {
     pub(super) client_addr: SocketAddr,
     pub(super) server_addr: SocketAddr,
 }
 
-impl BasicRouting {
-    /// Simulate a passive migration, remaining in the same subnet.
-    ///
-    /// This increments the last octet of the IP and the port
-    pub(super) fn passive_migration(&mut self, side: Side) -> SocketAddr {
-        let address = match side {
-            Side::Client => &mut self.client_addr,
-            Side::Server => &mut self.server_addr,
-        };
-        let prev_addr = *address;
-        match address {
-            SocketAddr::V4(socket_addr_v4) => {
-                let [a, b, c, d] = socket_addr_v4.ip().octets();
-                let mut d = d.wrapping_add(1);
-                if d == 0 {
-                    // skip the (potential) broadcast address
-                    d = d + 1;
-                }
-                socket_addr_v4.set_ip(Ipv4Addr::new(a, b, c, d));
-            }
-            SocketAddr::V6(socket_addr_v6) => {
-                let [a, b, c, d, e, f, g, h] = socket_addr_v6.ip().segments();
-                socket_addr_v6.set_ip(Ipv6Addr::new(a, b, c, d, e, f, g, h.wrapping_add(1)));
-            }
-        }
-        let new_port = address.port().checked_add(1).unwrap();
-        address.set_port(new_port);
-        info!(?side, ?prev_addr, new_addr = ?address, "passive migration");
-        *address
+impl From<BasicRouting> for RoutingTable {
+    fn from(value: BasicRouting) -> Self {
+        Self::Basic(value)
     }
 }
 
-impl PairRoutingTable for BasicRouting {
+impl BasicRouting {
     fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision {
         if transmit.destination == self.server_addr {
             RoutingDecision::Deliver {
@@ -1361,6 +1364,36 @@ impl PairRoutingTable for BasicRouting {
             RoutingDecision::Drop
         }
     }
+
+    /// Simulate a passive migration, remaining in the same subnet.
+    ///
+    /// This increments the last octet of the IP and the port
+    pub(super) fn passive_migration(&mut self, side: Side) -> SocketAddr {
+        let address = match side {
+            Side::Client => &mut self.client_addr,
+            Side::Server => &mut self.server_addr,
+        };
+        let prev_addr = *address;
+        match address {
+            SocketAddr::V4(socket_addr_v4) => {
+                let [a, b, c, d] = socket_addr_v4.ip().octets();
+                let mut d = d.wrapping_add(1);
+                if d == 0 {
+                    // skip the (potential) broadcast address
+                    d += 1;
+                }
+                socket_addr_v4.set_ip(Ipv4Addr::new(a, b, c, d));
+            }
+            SocketAddr::V6(socket_addr_v6) => {
+                let [a, b, c, d, e, f, g, h] = socket_addr_v6.ip().segments();
+                socket_addr_v6.set_ip(Ipv6Addr::new(a, b, c, d, e, f, g, h.wrapping_add(1)));
+            }
+        }
+        let new_port = address.port().checked_add(1).unwrap();
+        address.set_port(new_port);
+        info!(?side, ?prev_addr, new_addr = ?address, "passive migration");
+        *address
+    }
 }
 
 /// Set of uni-directional links between interfaces of a client and server.
@@ -1374,12 +1407,52 @@ impl PairRoutingTable for BasicRouting {
 /// outgoing link. However interfaces can have multiple incoming links if multiple
 /// interfaces of the peer have an outgoing link to it.
 #[derive(Debug, Clone)]
-pub(super) struct RoutingTable {
+pub(super) struct ManyToManyRouting {
     client_routes: Vec<(SocketAddr, usize)>,
     server_routes: Vec<(SocketAddr, usize)>,
 }
 
-impl RoutingTable {
+impl From<ManyToManyRouting> for RoutingTable {
+    fn from(value: ManyToManyRouting) -> Self {
+        Self::ManyToMany(value)
+    }
+}
+
+impl ManyToManyRouting {
+    fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision {
+        let Some((_, client_addr_idx)) = self
+            .server_routes
+            .iter()
+            .find(|(addr, _)| *addr == transmit.destination)
+        else {
+            return RoutingDecision::Drop;
+        };
+        let Some((client_addr, _)) = self.client_routes.get(*client_addr_idx) else {
+            return RoutingDecision::Drop;
+        };
+        RoutingDecision::Deliver {
+            src: *client_addr,
+            dst: Some(transmit.destination.ip()),
+        }
+    }
+
+    fn route_server_to_client(&mut self, transmit: &Transmit) -> RoutingDecision {
+        let Some((_, server_addr_idx)) = self
+            .client_routes
+            .iter()
+            .find(|(addr, _)| *addr == transmit.destination)
+        else {
+            return RoutingDecision::Drop;
+        };
+        let Some((server_addr, _)) = self.server_routes.get(*server_addr_idx) else {
+            return RoutingDecision::Drop;
+        };
+        RoutingDecision::Deliver {
+            src: *server_addr,
+            dst: Some(transmit.destination.ip()),
+        }
+    }
+
     pub(super) fn from_routes(
         client_routes: Vec<(SocketAddr, usize)>,
         server_routes: Vec<(SocketAddr, usize)>,
@@ -1465,42 +1538,6 @@ impl RoutingTable {
     }
 }
 
-impl PairRoutingTable for RoutingTable {
-    fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision {
-        let Some((_, client_addr_idx)) = self
-            .server_routes
-            .iter()
-            .find(|(addr, _)| *addr == transmit.destination)
-        else {
-            return RoutingDecision::Drop;
-        };
-        let Some((client_addr, _)) = self.client_routes.get(*client_addr_idx) else {
-            return RoutingDecision::Drop;
-        };
-        RoutingDecision::Deliver {
-            src: *client_addr,
-            dst: Some(transmit.destination.ip()),
-        }
-    }
-
-    fn route_server_to_client(&mut self, transmit: &Transmit) -> RoutingDecision {
-        let Some((_, server_addr_idx)) = self
-            .client_routes
-            .iter()
-            .find(|(addr, _)| *addr == transmit.destination)
-        else {
-            return RoutingDecision::Drop;
-        };
-        let Some((server_addr, _)) = self.server_routes.get(*server_addr_idx) else {
-            return RoutingDecision::Drop;
-        };
-        RoutingDecision::Deliver {
-            src: *server_addr,
-            dst: Some(transmit.destination.ip()),
-        }
-    }
-}
-
 /// A routing table with one open and one firewalled interface.
 ///
 /// This essentially behaves like a Destination Endpoint Independent NAT with address and
@@ -1520,7 +1557,7 @@ impl PairRoutingTable for RoutingTable {
 /// an outgoing transmit has an `src_ip` of an interface that is not linked to the interface
 /// of the destination IP then a transmit is dropped.
 #[derive(Debug)]
-pub(super) struct SimpleFirewallRoutingTable {
+pub(super) struct SimpleFirewallRouting {
     /// Whether the client has sent a packet from `client_nat` to `server_nat`.
     ///
     /// If so packets from `server_nat` to `client_nat` will be allowed. If not they will be
@@ -1530,7 +1567,13 @@ pub(super) struct SimpleFirewallRoutingTable {
     server_firewall_open: bool,
 }
 
-impl SimpleFirewallRoutingTable {
+impl From<SimpleFirewallRouting> for RoutingTable {
+    fn from(value: SimpleFirewallRouting) -> Self {
+        Self::SimpleFirewall(value)
+    }
+}
+
+impl SimpleFirewallRouting {
     /// The address of the client's non-firewalled interface.
     ///
     /// IPv6 address `::1:1`. This is a normal unicast address.
@@ -1564,9 +1607,7 @@ impl SimpleFirewallRoutingTable {
             server_firewall_open: false,
         }
     }
-}
 
-impl PairRoutingTable for SimpleFirewallRoutingTable {
     /// Routes a datagram from client to server.
     ///
     /// Returns the address the server will observe as the sender of the datagram. Or `None`


### PR DESCRIPTION
## Description

This replaces the `Pair::routes = None` with a basic routing table so
that there always is a routing table set.

As part of this it also replaces the PairRoutingTable trait with the RoutingTable enum. This makes it a bit easier for the proptests to invoke the correct variant.

## Breaking Changes

none

## Notes & open questions

none

## Change checklist

- [ ] Self-review.
- [X] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.