### PR TITLE
fix(qnt): distinguish may_probe from may_migrate

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2285,7 +2285,7 @@ impl Connection {
         //    once the client has been probing such a 4-tuple. These probes are currently
         //    not yet recognised and discarded here.
         //    See https://github.com/n0-computer/noq/issues/607.
-        let remote_may_migrate = self.remote_may_migrate();
+        let peer_may_probe = self.peer_may_probe();
 
         let local_ip_may_migrate = self.local_ip_may_migrate();
 
@@ -2293,7 +2293,7 @@ impl Connection {
         // forbids migration, drop the datagram. This could be relaxed to heuristically
         // permit NAT-rebinding-like migration.
         if let Some(known_path) = self.path_mut(path_id) {
-            if network_path.remote != known_path.network_path.remote && !remote_may_migrate {
+            if network_path.remote != known_path.network_path.remote && !peer_may_probe {
                 trace!(
                     %path_id,
                     %network_path,
@@ -2320,7 +2320,33 @@ impl Connection {
         false
     }
 
-    /// Whether a remote is allowed to migrate.
+    /// Whether the peer may probe new paths.
+    ///
+    /// RFC9000 §9 and QNT both have probing packets which may arrive from new paths. This
+    /// indicates whether these are allowed or not. This is a strict superset from
+    /// [`Self::remote_may_migrate`]: every network path that may be migrated to, may also
+    /// be probed. But e.g. servers may not migrate, but can be allowed to probe.
+    // TODO(flub): In RFC9000 the server is allowed to send off-path probing packets
+    //    once the client has been probing such a 4-tuple. These probes are currently
+    //    not yet recognised and will end up being discarded because of this.
+    //    See https://github.com/n0-computer/noq/issues/607.
+    fn peer_may_probe(&self) -> bool {
+        match &self.side {
+            ConnectionSide::Client { .. } => {
+                if let Some(hs) = self.state.as_handshake() {
+                    hs.allow_server_migration
+                } else {
+                    self.n0_nat_traversal.is_negotiated() && self.is_handshake_confirmed()
+                }
+            }
+            ConnectionSide::Server { server_config } => {
+                self.is_handshake_confirmed()
+                    && (server_config.migration || self.n0_nat_traversal.is_negotiated())
+            }
+        }
+    }
+
+    /// Whether the peer's remote address may migrate.
     ///
     /// QUIC relies on stable endpoints during the handshake. So other than the server's
     /// preferred_address transport parameter no side may migrate before the handshake is

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1782,3 +1782,36 @@ fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
 
     Ok(())
 }
+
+/// If the client is not allowed to migrate, it should still be allowed to send NAT
+/// traversal probes.
+#[test]
+fn test_remote_may_probe() {
+    let _guard = subscribe();
+
+    let mut cfg = TransportConfig::default();
+    cfg.max_concurrent_multipath_paths(MAX_PATHS);
+    cfg.mtu_discovery_config(None);
+    cfg.initial_rtt(Duration::from_millis(10));
+    #[cfg(feature = "qlog")]
+    cfg.qlog_from_env("multipath_test");
+    cfg.max_remote_nat_traversal_addresses(8);
+    let transport_cfg = Arc::new(cfg);
+
+    let transport_cfg = Arc::new(TransportConfig {
+        max_concurrent_multipath_paths: NonZeroU32::new(3 as _),
+        // Assume a low-latency connection so pacing doesn't interfere with the test
+        initial_rtt: Duration::from_millis(10),
+        ..TransportConfig::default()
+    });
+    let server_cfg = ServerConfig {
+        transport: transport_cfg.clone(),
+        ..server_config()
+    };
+    let client_cfg = ClientConfig {
+        transport: transport_cfg,
+        ..client_config()
+    };
+
+    let mut pair = ConnPair::with_default_endpoint(server_cfg, client_cfg);
+}


### PR DESCRIPTION
## Description

The QNT impl did re-use may_migrate to see on whether packets are allowed from a remote. But probing packets do not trigger migration and the two need to be treated separately.

Fixes #654.

## Breaking Changes

n/a

## Notes & open questions

This is an early draft, I need to properly sanity check. And server/client migration may be involved.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
