### PR TITLE
refactor(noq)!: Use FourTuple in open_path

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -520,18 +520,18 @@ impl Connection {
 
     /// Opens a new path only if no path on the same network path currently exists.
     ///
-    /// This comparison will use [`FourTuple::is_probably_same_path`] on the given `network_path`
-    /// and pass it existing path's network paths.
+    /// Returns `(path_id, true)` if the path already existed, or `(path_id, false)`
+    /// if was opened.
     ///
-    /// This means that you can pass `local_ip: None` to make the comparison only compare
-    /// remote addresses.
+    /// If `network_path` has no local IP set, then this will open a new path
+    /// if no path exists for this remote address, independent of the existing
+    /// path's local IP. If a local IP is set, it will match against the full
+    /// four-tuple of existing paths. Not setting the local IP avoids having to
+    /// guess which local interface will be used to communicate with the remote,
+    /// should it not be known yet. We assume that if we already have a path to
+    /// the remote, the OS is likely to use the same interface to talk to said remote.
     ///
-    /// This avoids having to guess which local interface will be used to communicate with the
-    /// remote, should it not be known yet. We assume that if we already have a path to the remote,
-    /// the OS is likely to use the same interface to talk to said remote.
-    ///
-    /// See also [`open_path`]. Returns `(path_id, true)` if the path already existed. `(path_id,
-    /// false)` if was opened.
+    /// See also [`open_path`].
     ///
     /// [`open_path`]: Connection::open_path
     pub fn open_path_ensure(

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7066,10 +7066,10 @@ impl Connection {
     }
 
     /// Returns whether this connection has a socket that supports IPv6.
-    //
-    // TODO(matheus23): This is related to noq endpoint state's `ipv6` bool. We should move that info
-    // here instead of trying to hack around not knowing it exactly.
-    pub fn is_ipv6(&self) -> bool {
+    ///
+    /// TODO(matheus23): This is related to noq endpoint state's `ipv6` bool. We should move that info
+    /// here instead of trying to hack around not knowing it exactly.
+    pub(crate) fn is_ipv6(&self) -> bool {
         self.paths
             .values()
             .any(|p| p.data.network_path.remote.is_ipv6())

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7066,10 +7066,10 @@ impl Connection {
     }
 
     /// Returns whether this connection has a socket that supports IPv6.
-    ///
-    /// TODO(matheus23): This is related to noq endpoint state's `ipv6` bool. We should move that info
-    /// here instead of trying to hack around not knowing it exactly.
-    fn is_ipv6(&self) -> bool {
+    //
+    // TODO(matheus23): This is related to noq endpoint state's `ipv6` bool. We should move that info
+    // here instead of trying to hack around not knowing it exactly.
+    pub fn is_ipv6(&self) -> bool {
         self.paths
             .values()
             .any(|p| p.data.network_path.remote.is_ipv6())

--- a/noq-proto/src/lib.rs
+++ b/noq-proto/src/lib.rs
@@ -366,6 +366,8 @@ const MAX_STREAM_COUNT: u64 = 1 << 60;
 /// Including the local ensures good behavior when the host has multiple IP addresses on the same
 /// subnet and zero-length connection IDs are in use or when multipath is enabled and multiple
 /// paths exist with the same remote, but different local IP interfaces.
+///
+/// `FourTuple` implements `From<SocketAddr>`, which expands to [`Self::from_remote`].
 #[derive(Hash, Eq, PartialEq, Copy, Clone)]
 pub struct FourTuple {
     /// The remote side of this tuple.
@@ -431,7 +433,7 @@ impl FourTuple {
     /// Note that because of this, the following calls might differ:
     /// - `a.is_probably_same_path(b)`
     /// - `b.is_probably_same_path(a)`
-    pub fn is_probably_same_path(&self, other: &Self) -> bool {
+    pub(crate) fn is_probably_same_path(&self, other: &Self) -> bool {
         self.remote == other.remote && (self.local_ip.is_none() || self.local_ip == other.local_ip)
     }
 
@@ -441,7 +443,7 @@ impl FourTuple {
     /// - the other tuple has a local address set.
     ///
     /// Returns whether this and the other remote are now fully equal.
-    pub fn update_local_if_same_remote(&mut self, other: &Self) -> bool {
+    pub(crate) fn update_local_if_same_remote(&mut self, other: &Self) -> bool {
         if self.remote != other.remote {
             return false;
         }
@@ -474,6 +476,7 @@ impl fmt::Debug for FourTuple {
     }
 }
 
+/// Converts a [`SocketAddr`] to a [`FourTuple`] via [`FourTuple::from_remote`].
 impl From<SocketAddr> for FourTuple {
     fn from(value: SocketAddr) -> Self {
         Self::from_remote(value)

--- a/noq-proto/src/lib.rs
+++ b/noq-proto/src/lib.rs
@@ -473,3 +473,9 @@ impl fmt::Debug for FourTuple {
         fmt::Display::fmt(&self, f)
     }
 }
+
+impl From<SocketAddr> for FourTuple {
+    fn from(value: SocketAddr) -> Self {
+        Self::from_remote(value)
+    }
+}

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -380,8 +380,10 @@ impl Connection {
 
     /// Opens a new path if no path exists yet for `network_path`.
     ///
-    /// Path equality uses [`FourTuple::is_probably_same_path`], so passing
-    /// `local_ip: None` makes the comparison ignore the local interface.
+    /// If `network_path` has no local IP set, then this will open a new path
+    /// if no path exists for this remote address, independent of the existing
+    /// path's local IP. If a local IP is set, it will match against the full
+    /// four-tuple of existing paths.
     ///
     /// Otherwise behaves exactly as [`open_path`].
     ///
@@ -926,9 +928,18 @@ fn normalize_network_path(
 ) -> Result<FourTuple, PathError> {
     // If endpoint::State::ipv6 is true we want to keep all our IP addresses as IPv6.
     // If not, we do not support IPv6.  We can not access endpoint::State from here
-    // however, but [`proto::Connection::is_ipv6`] returns whether any of our paths use
-    // an IPv6 address, which provides us the necessary information.
-    let ipv6 = conn.is_ipv6();
+    // however, but either all our paths use an IPv6 address, or all our paths use an
+    // IPv4 address.  So we can use that information.
+    let ipv6 = conn
+        .paths()
+        .iter()
+        .filter_map(|id| {
+            conn.network_path(*id)
+                .map(|addrs| addrs.remote().is_ipv6())
+                .ok()
+        })
+        .next()
+        .unwrap_or_default();
     let remote = network_path.remote();
     if remote.is_ipv6() && !ipv6 {
         Err(PathError::InvalidRemoteAddress(remote))

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -378,45 +378,30 @@ impl Connection {
         }
     }
 
-    /// Opens a new path if no path exists yet for the remote address.
+    /// Opens a new path if no path exists yet for `network_path`.
+    ///
+    /// Path equality uses [`FourTuple::is_probably_same_path`], so passing
+    /// `local_ip: None` makes the comparison ignore the local interface.
     ///
     /// Otherwise behaves exactly as [`open_path`].
     ///
     /// [`open_path`]: Self::open_path
-    pub fn open_path_ensure(&self, addr: SocketAddr, initial_status: PathStatus) -> OpenPath {
+    pub fn open_path_ensure(
+        &self,
+        network_path: FourTuple,
+        initial_status: PathStatus,
+    ) -> OpenPath {
         let mut state = self.0.lock_and_wake("open_path");
 
-        // If endpoint::State::ipv6 is true we want to keep all our IP addresses as IPv6.
-        // If not, we do not support IPv6.  We can not access endpoint::State from here
-        // however, but either all our paths use an IPv6 address, or all our paths use an
-        // IPv4 address.  So we can use that information.
-        let ipv6 = state
-            .inner
-            .paths()
-            .iter()
-            .filter_map(|id| {
-                state
-                    .inner
-                    .network_path(*id)
-                    .map(|addrs| addrs.remote().is_ipv6())
-                    .ok()
-            })
-            .next()
-            .unwrap_or_default();
-        if addr.is_ipv6() && !ipv6 {
-            return OpenPath::rejected(PathError::InvalidRemoteAddress(addr));
-        }
-        let addr = if ipv6 {
-            SocketAddr::V6(ensure_ipv6(addr))
-        } else {
-            addr
+        let network_path = match normalize_network_path(&state, network_path) {
+            Ok(network_path) => network_path,
+            Err(err) => return OpenPath::rejected(err),
         };
 
         let now = state.runtime.now();
-        // TODO(matheus23): For now this means it's impossible to make use of short-circuiting path validation currently.
-        // However, changing that would mean changing the API.
-        let addrs = FourTuple::from_remote(addr);
-        let open_res = state.inner.open_path_ensure(addrs, initial_status, now);
+        let open_res = state
+            .inner
+            .open_path_ensure(network_path, initial_status, now);
         match open_res {
             Ok((path_id, existed)) if existed => {
                 let recv = state.open_path.get(&path_id).map(|tx| tx.subscribe());
@@ -450,41 +435,17 @@ impl Connection {
     /// future, or at a later time.  If the failure is immediate [`OpenPath::path_id`] will
     /// return `None` and the future will be ready immediately.  If the failure happens
     /// later, a [`PathEvent`] will be emitted.
-    pub fn open_path(&self, addr: SocketAddr, initial_status: PathStatus) -> OpenPath {
+    pub fn open_path(&self, network_path: FourTuple, initial_status: PathStatus) -> OpenPath {
         let mut state = self.0.lock_and_wake("open_path");
 
-        // If endpoint::State::ipv6 is true we want to keep all our IP addresses as IPv6.
-        // If not, we do not support IPv6.  We can not access endpoint::State from here
-        // however, but either all our paths use an IPv6 address, or all our paths use an
-        // IPv4 address.  So we can use that information.
-        let ipv6 = state
-            .inner
-            .paths()
-            .iter()
-            .filter_map(|id| {
-                state
-                    .inner
-                    .network_path(*id)
-                    .map(|addrs| addrs.remote().is_ipv6())
-                    .ok()
-            })
-            .next()
-            .unwrap_or_default();
-        if addr.is_ipv6() && !ipv6 {
-            return OpenPath::rejected(PathError::InvalidRemoteAddress(addr));
-        }
-        let addr = if ipv6 {
-            SocketAddr::V6(ensure_ipv6(addr))
-        } else {
-            addr
+        let network_path = match normalize_network_path(&state, network_path) {
+            Ok(network_path) => network_path,
+            Err(err) => return OpenPath::rejected(err),
         };
 
         let (on_open_path_send, on_open_path_recv) = watch::channel(Ok(()));
         let now = state.runtime.now();
-        // TODO(matheus23): For now this means it's impossible to make use of short-circuiting path validation currently.
-        // However, changing that would mean changing the API.
-        let addrs = FourTuple::from_remote(addr);
-        let open_res = state.inner.open_path(addrs, initial_status, now);
+        let open_res = state.inner.open_path(network_path, initial_status, now);
         match open_res {
             Ok(path_id) => {
                 state.open_path.insert(path_id, on_open_path_send);
@@ -499,7 +460,44 @@ impl Connection {
     pub fn path(&self, id: PathId) -> Option<Path> {
         Path::new(&self.0, id)
     }
+}
 
+/// Normalizes a [`FourTuple`] against the connection's address family.
+///
+/// If the connection already uses IPv6 paths, the remote is canonicalised via
+/// [`ensure_ipv6`]. If it uses IPv4 and the requested remote is IPv6, this returns
+/// [`PathError::InvalidRemoteAddress`].
+fn normalize_network_path(state: &State, network_path: FourTuple) -> Result<FourTuple, PathError> {
+    // If endpoint::State::ipv6 is true we want to keep all our IP addresses as IPv6.
+    // If not, we do not support IPv6.  We can not access endpoint::State from here
+    // however, but either all our paths use an IPv6 address, or all our paths use an
+    // IPv4 address.  So we can use that information.
+    let ipv6 = state
+        .inner
+        .paths()
+        .iter()
+        .filter_map(|id| {
+            state
+                .inner
+                .network_path(*id)
+                .map(|addrs| addrs.remote().is_ipv6())
+                .ok()
+        })
+        .next()
+        .unwrap_or_default();
+    let remote = network_path.remote();
+    if remote.is_ipv6() && !ipv6 {
+        return Err(PathError::InvalidRemoteAddress(remote));
+    }
+    let network_path = if ipv6 {
+        FourTuple::new(SocketAddr::V6(ensure_ipv6(remote)), network_path.local_ip())
+    } else {
+        network_path
+    };
+    Ok(network_path)
+}
+
+impl Connection {
     /// A stream of [`PathEvent`]s for all paths in this connection.
     ///
     /// The stream will yield a [`PathEvent`] whenever there is a change in the state of any path in this connection.

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -388,12 +388,13 @@ impl Connection {
     /// [`open_path`]: Self::open_path
     pub fn open_path_ensure(
         &self,
-        network_path: FourTuple,
+        network_path: impl Into<FourTuple>,
         initial_status: PathStatus,
     ) -> OpenPath {
+        let network_path = network_path.into();
         let mut state = self.0.lock_and_wake("open_path");
 
-        let network_path = match normalize_network_path(&state, network_path) {
+        let network_path = match normalize_network_path(network_path, &state.inner) {
             Ok(network_path) => network_path,
             Err(err) => return OpenPath::rejected(err),
         };
@@ -423,6 +424,11 @@ impl Connection {
 
     /// Opens an additional path if the multipath extension is negotiated.
     ///
+    /// This function takes a [`FourTuple`], which contains the remote address and an optional
+    /// local IP. If the local IP is set, the path will be opened with this source address,
+    /// and the endpoint must support sending from that IP address. You can also pass a
+    /// [`SocketAddr`] to only set the remote address and leave the local IP interface unspecified.
+    ///
     /// The returned future completes once the path is either fully opened and ready to
     /// carry application data, or if there was an error.
     ///
@@ -435,10 +441,15 @@ impl Connection {
     /// future, or at a later time.  If the failure is immediate [`OpenPath::path_id`] will
     /// return `None` and the future will be ready immediately.  If the failure happens
     /// later, a [`PathEvent`] will be emitted.
-    pub fn open_path(&self, network_path: FourTuple, initial_status: PathStatus) -> OpenPath {
+    pub fn open_path(
+        &self,
+        network_path: impl Into<FourTuple>,
+        initial_status: PathStatus,
+    ) -> OpenPath {
+        let network_path = network_path.into();
         let mut state = self.0.lock_and_wake("open_path");
 
-        let network_path = match normalize_network_path(&state, network_path) {
+        let network_path = match normalize_network_path(network_path, &state.inner) {
             Ok(network_path) => network_path,
             Err(err) => return OpenPath::rejected(err),
         };
@@ -460,44 +471,7 @@ impl Connection {
     pub fn path(&self, id: PathId) -> Option<Path> {
         Path::new(&self.0, id)
     }
-}
 
-/// Normalizes a [`FourTuple`] against the connection's address family.
-///
-/// If the connection already uses IPv6 paths, the remote is canonicalised via
-/// [`ensure_ipv6`]. If it uses IPv4 and the requested remote is IPv6, this returns
-/// [`PathError::InvalidRemoteAddress`].
-fn normalize_network_path(state: &State, network_path: FourTuple) -> Result<FourTuple, PathError> {
-    // If endpoint::State::ipv6 is true we want to keep all our IP addresses as IPv6.
-    // If not, we do not support IPv6.  We can not access endpoint::State from here
-    // however, but either all our paths use an IPv6 address, or all our paths use an
-    // IPv4 address.  So we can use that information.
-    let ipv6 = state
-        .inner
-        .paths()
-        .iter()
-        .filter_map(|id| {
-            state
-                .inner
-                .network_path(*id)
-                .map(|addrs| addrs.remote().is_ipv6())
-                .ok()
-        })
-        .next()
-        .unwrap_or_default();
-    let remote = network_path.remote();
-    if remote.is_ipv6() && !ipv6 {
-        return Err(PathError::InvalidRemoteAddress(remote));
-    }
-    let network_path = if ipv6 {
-        FourTuple::new(SocketAddr::V6(ensure_ipv6(remote)), network_path.local_ip())
-    } else {
-        network_path
-    };
-    Ok(network_path)
-}
-
-impl Connection {
     /// A stream of [`PathEvent`]s for all paths in this connection.
     ///
     /// The stream will yield a [`PathEvent`] whenever there is a change in the state of any path in this connection.
@@ -938,6 +912,31 @@ impl Connection {
         let mut conn = self.0.lock_and_wake("initiate_nat_traversal_round");
         let now = conn.runtime.now();
         conn.inner.initiate_nat_traversal_round(now)
+    }
+}
+
+/// Normalizes a [`FourTuple`] against the connection's address family.
+///
+/// If the connection already uses IPv6 paths, the remote is canonicalised via
+/// [`ensure_ipv6`]. If it uses IPv4 and the requested remote is IPv6, this returns
+/// [`PathError::InvalidRemoteAddress`].
+fn normalize_network_path(
+    network_path: FourTuple,
+    conn: &proto::Connection,
+) -> Result<FourTuple, PathError> {
+    // If endpoint::State::ipv6 is true we want to keep all our IP addresses as IPv6.
+    // If not, we do not support IPv6.  We can not access endpoint::State from here
+    // however, but [`proto::Connection::is_ipv6`] returns whether any of our paths use
+    // an IPv6 address, which provides us the necessary information.
+    let ipv6 = conn.is_ipv6();
+    let remote = network_path.remote();
+    if remote.is_ipv6() && !ipv6 {
+        Err(PathError::InvalidRemoteAddress(remote))
+    } else if ipv6 {
+        let remote = SocketAddr::V6(ensure_ipv6(remote));
+        Ok(FourTuple::new(remote, network_path.local_ip()))
+    } else {
+        Ok(network_path)
     }
 }
 

--- a/noq/src/lib.rs
+++ b/noq/src/lib.rs
@@ -64,11 +64,12 @@ pub use proto::{
     AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosePathError, ClosedPath,
     ClosedStream, ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionId,
     ConnectionIdGenerator, ConnectionStats, DecryptedInitial, Dir, EcnCodepoint, EndpointConfig,
-    FrameStats, FrameType, IdleTimeout, InvalidCid, MtuDiscoveryConfig, NetworkChangeHint,
-    NoneTokenLog, NoneTokenStore, PathError, PathEvent, PathId, PathStats, PathStatus,
-    ServerConfig, SetPathStatusError, Side, StdSystemTime, StreamId, TimeSource, TokenLog,
-    TokenMemoryCache, TokenReuseError, TokenStore, Transmit, TransportConfig, TransportErrorCode,
-    UdpStats, ValidationTokenConfig, VarInt, VarIntBoundsExceeded, congestion, crypto,
+    FourTuple, FrameStats, FrameType, IdleTimeout, InvalidCid, MtuDiscoveryConfig,
+    NetworkChangeHint, NoneTokenLog, NoneTokenStore, PathError, PathEvent, PathId, PathStats,
+    PathStatus, ServerConfig, SetPathStatusError, Side, StdSystemTime, StreamId, TimeSource,
+    TokenLog, TokenMemoryCache, TokenReuseError, TokenStore, Transmit, TransportConfig,
+    TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt, VarIntBoundsExceeded, congestion,
+    crypto,
 };
 #[cfg(feature = "qlog")]
 pub use proto::{QlogConfig, QlogFactory, QlogFileFactory};

--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -7,7 +7,7 @@ use std::task::{Context, Poll, ready};
 use std::time::Duration;
 
 use proto::{
-    ClosePathError, ClosedPath, PathError, PathEvent, PathId, PathStats, PathStatus,
+    ClosePathError, ClosedPath, FourTuple, PathError, PathEvent, PathId, PathStats, PathStatus,
     SetPathStatusError, TransportErrorCode,
 };
 use tokio::sync::watch;
@@ -267,6 +267,14 @@ impl Path {
     pub fn local_ip(&self) -> Result<Option<IpAddr>, ClosedPath> {
         let state = self.conn.lock_without_waking("per_path_local_ip");
         Ok(state.inner.network_path(self.id())?.local_ip())
+    }
+
+    /// The network path used for this path.
+    ///
+    /// Returns a [`FourTuple`], combining [`Self::remote_address`] and [`Self::local_ip`].
+    pub fn network_path(&self) -> Result<FourTuple, ClosedPath> {
+        let state = self.conn.lock_without_waking("per_path_local_ip");
+        state.inner.network_path(self.id())
     }
 
     /// Ping the remote endpoint over this path.

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -23,7 +23,10 @@ use std::{
 use crate::runtime::TokioRuntime;
 use crate::{Duration, Instant};
 use bytes::Bytes;
-use proto::{ConnectionError, PathId, RandomConnectionIdGenerator, crypto::rustls::QuicClientConfig};
+use proto::{
+    ConnectionError, FourTuple, PathId, PathStatus, RandomConnectionIdGenerator,
+    crypto::rustls::QuicClientConfig,
+};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use rustls::{
     RootCertStore,
@@ -1024,7 +1027,7 @@ async fn test_open_path_ensure_existing_path() {
 
         // Re-ensuring the already-established path (PathId::ZERO) takes the
         // `existed` branch in `open_path_ensure`.
-        let fut = conn.open_path_ensure(server_addr, proto::PathStatus::Available);
+        let fut = conn.open_path_ensure(FourTuple::from_remote(server_addr), PathStatus::Available);
         let expected_path_id = fut
             .path_id()
             .expect("open_path_ensure should allocate or reuse a path id");
@@ -1078,7 +1081,7 @@ async fn test_multipath_observed_address() {
         // this sleep after the poll_transmit unwraps have been addressed
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
         let path = conn
-            .open_path(server_addr, proto::PathStatus::Available)
+            .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
             .await
             .unwrap();
         let mut reports = path.observed_external_addr().unwrap();
@@ -1293,7 +1296,7 @@ async fn path_clone_stats_after_abandon() {
         let path = tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 match conn
-                    .open_path(server_addr, proto::PathStatus::Available)
+                    .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
                     .await
                 {
                     Ok(path) => break path,
@@ -1380,7 +1383,7 @@ async fn closed_includes_path_stats_for_all_known_paths() -> TestResult {
         // Open a second path.
         let path2 = loop {
             match conn
-                .open_path(server_addr, proto::PathStatus::Available)
+                .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
                 .await
             {
                 Ok(p) => break p,
@@ -1494,7 +1497,7 @@ async fn close_path() -> TestResult {
         // Open a second path, retrying until remote CIDs are available
         let path = loop {
             match conn
-                .open_path(server_addr, proto::PathStatus::Available)
+                .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
                 .await
             {
                 Ok(path) => break path,


### PR DESCRIPTION
## Description

This changes  `noq::Connection::open_path` and `noq::Connection::open_path_ensure` to take a `Impl Into<FourTuple>` instead of a `SocketAddr`. This lets callers specify the local IP for the new path, which previously could only be discovered after the path was opened. Call sites can stay as-is because `FourTuple` impls `From<SocketAddr>`, but it is now possible to also set the local IP if desired.

The proto-side API is unchanged; both `noq-proto::Connection::open_path` and `noq-proto::Connection::open_path_ensure` already took a `FourTuple`.

## Breaking Changes

* changed: `noq::Connection::open_path` now takes a   `impl Into<FourTuple>` argument. Existing call-sites can stay as-is because `FourTuple` impls `From<SocketAddr>`.
* changed `noq::Connection::open_path_ensure` now takes a   `impl Into<FourTuple>` argument. Existing call-sites can stay as-is because `FourTuple` impls `From<SocketAddr>`.

## Change checklist

- [x] Self-review.
- [x] All breaking changes documented.
