### PR TITLE
fix(migration): Only trigger migration for remote changes

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5323,7 +5323,7 @@ impl Connection {
                     }
 
                     let path = self.path_data_mut(path_id);
-                    if path.network_path.is_probably_same_path(&network_path) {
+                    if path.network_path.remote == network_path.remote {
                         if let Some(updated) = path.update_observed_addr_report(observed)
                             && path.open_status == paths::OpenStatus::Informed
                         {

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3947,6 +3947,7 @@ fn address_discovery_rebind_retransmission() {
             address_discovery_role: crate::address_discovery::Role::Both,
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
+            mtu_discovery_config: None,
             ..TransportConfig::default()
         }),
         ..server_config()
@@ -3957,6 +3958,7 @@ fn address_discovery_rebind_retransmission() {
             address_discovery_role: crate::address_discovery::Role::Both,
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
+            mtu_discovery_config: None,
             ..TransportConfig::default()
         }),
         ..client_config()


### PR DESCRIPTION
## Description

Migration only gets triggered if the remote address changes. Not if
the local_ip changes. This check was too strict, which resulted in the
notification for an observed address being suprpressed if the local IP
changes, because it would assume it was emitted later as part of the
migration. Yet the migration would never run because the remote
address did not change.

This is basically correcting the wrong fix that was applied in #635.

## Breaking Changes

n/a

## Notes & open questions

No direct test, this was visible as flakyness in
address_discovery_rebind_retransmission. Which is now no longer
flaky. The test, nor it's flakyness, did not rely on MTU discovery so
that's disabled now to keep things a little cleaner.

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.