### PR TITLE
chore(ci): Switch to force-installing wasm-bindgen-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/noq.wasm | grep 'import "env"'
 
       # Match the version of wasm-bindgen used in Cargo.lock
-      - run: cargo binstall wasm-bindgen-cli@0.2.121 --locked --no-confirm
+      - run: cargo binstall wasm-bindgen-cli@0.2.121 --force --locked --no-confirm
       - name: wasm32 test (noq-proto)
         run: cargo test --locked -p noq-proto --target wasm32-unknown-unknown
 


### PR DESCRIPTION
## Description

The "Build & test wasm32" check has been flaky in recent times.
The pattern seems to be, when it fails, then the `cargo binstall wasm-bindgen-cli` command outputs:
```
 INFO wasm-bindgen-cli v0.2.121 is already installed, use --force to override
 INFO Done in 2.399616ms
```
Whereas when it succeeds, it's always
```
 INFO resolve: Resolving package: 'wasm-bindgen-cli@=0.2.121'
 WARN The package wasm-bindgen-cli v0.2.121 (x86_64-unknown-linux-musl) has been downloaded from github.com
 INFO This will install the following binaries:
 INFO   - wasm-bindgen => /root/.cargo/bin/wasm-bindgen
 INFO   - wasm-bindgen-test-runner => /root/.cargo/bin/wasm-bindgen-test-runner
 INFO   - wasm2es6js => /root/.cargo/bin/wasm2es6js
 INFO Installing binaries...
 INFO Done in 2.149248106s
```

Here are some recent runs, all after #664 was merged:
- Runner name: 'hetz-ci-linux-x64-2': Fail (https://github.com/n0-computer/noq/actions/runs/26168869453/job/76980594957)
- Runner name: 'hetz-ci-linux-x64-5': Success (https://github.com/n0-computer/noq/actions/runs/26165233426/job/76967593091)
- Runner name: 'hetz-ci-linux-x64-1': Success (https://github.com/n0-computer/noq/actions/runs/26164884966/job/76966183329)
- Runner name: 'hetz-ci-linux-x64-1': Fail (https://github.com/n0-computer/noq/actions/runs/26167126491/job/76974283055)
- Runner name: 'hetz-ci-linux-x64-1': Fail (https://github.com/n0-computer/noq/actions/runs/26167190559/job/76974514178?pr=662)

# Notes

It's unfortunate that we loose caching this way (and make ourselves more vulnerable to github releases being flaky!!!), but this is mostly to unblock us in the short term...
