### PR TITLE
test(proto): Take `Transmit::src_ip` into account for `ManyToManyRouting`

### DIFF
--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1429,36 +1429,74 @@ impl ManyToManyRouting {
     }
 
     fn route_client_to_server(&mut self, transmit: &Transmit) -> RoutingDecision {
-        let Some((_, client_addr_idx)) = self
-            .server_routes
-            .iter()
-            .find(|(addr, _)| *addr == transmit.destination)
-        else {
-            return RoutingDecision::Drop;
-        };
-        let Some((client_addr, _)) = self.client_routes.get(*client_addr_idx) else {
-            return RoutingDecision::Drop;
-        };
-        RoutingDecision::Deliver {
-            src: *client_addr,
-            dst: Some(transmit.destination.ip()),
+        if let Some(client_interface_ip) = transmit.src_ip {
+            // If we have a client interface IP, then we use that to build the packet coming in on the other side.
+            // But we need to check if that is even connected to the server.
+            let Some(&(client_addr, _)) = self
+                .server_routes
+                .iter()
+                .filter(|(addr, _)| *addr == transmit.destination)
+                .filter_map(|&(_, idx)| self.client_routes.get(idx))
+                .find(|&(addr, _)| addr.ip() == client_interface_ip)
+            else {
+                // There's no route for given four-tuple.
+                return RoutingDecision::Drop;
+            };
+            RoutingDecision::Deliver {
+                src: client_addr,
+                dst: Some(transmit.destination.ip()),
+            }
+        } else {
+            let Some((_, client_addr_idx)) = self
+                .server_routes
+                .iter()
+                .find(|(addr, _)| *addr == transmit.destination)
+            else {
+                return RoutingDecision::Drop;
+            };
+            let Some((client_addr, _)) = self.client_routes.get(*client_addr_idx) else {
+                return RoutingDecision::Drop;
+            };
+            RoutingDecision::Deliver {
+                src: *client_addr,
+                dst: Some(transmit.destination.ip()),
+            }
         }
     }
 
     fn route_server_to_client(&mut self, transmit: &Transmit) -> RoutingDecision {
-        let Some((_, server_addr_idx)) = self
-            .client_routes
-            .iter()
-            .find(|(addr, _)| *addr == transmit.destination)
-        else {
-            return RoutingDecision::Drop;
-        };
-        let Some((server_addr, _)) = self.server_routes.get(*server_addr_idx) else {
-            return RoutingDecision::Drop;
-        };
-        RoutingDecision::Deliver {
-            src: *server_addr,
-            dst: Some(transmit.destination.ip()),
+        if let Some(server_interface_ip) = transmit.src_ip {
+            // If we have a server interface IP, then we use that to build the packet coming in on the other side.
+            // But we need to check if that is even connected to the client.
+            let Some(&(server_addr, _)) = self
+                .client_routes
+                .iter()
+                .filter(|(addr, _)| *addr == transmit.destination)
+                .filter_map(|&(_, idx)| self.server_routes.get(idx))
+                .find(|&(addr, _)| addr.ip() == server_interface_ip)
+            else {
+                // There's no route for given four-tuple.
+                return RoutingDecision::Drop;
+            };
+            RoutingDecision::Deliver {
+                src: server_addr,
+                dst: Some(transmit.destination.ip()),
+            }
+        } else {
+            let Some((_, server_addr_idx)) = self
+                .client_routes
+                .iter()
+                .find(|(addr, _)| *addr == transmit.destination)
+            else {
+                return RoutingDecision::Drop;
+            };
+            let Some((server_addr, _)) = self.server_routes.get(*server_addr_idx) else {
+                return RoutingDecision::Drop;
+            };
+            RoutingDecision::Deliver {
+                src: *server_addr,
+                dst: Some(transmit.destination.ip()),
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This changes the `ManyToManyRouting::route_client_to_server` and `ManyToManyRouting::route_server_to_client` functions to take `Transmit::src_ip` into account.

`Transmit::src_ip` is set when noq-proto wants to pin the traffic sent to a specific interface. In that case, `src_ip` will be the IP address of the local interface that's to be used to send to the remote.
If the routing table changes in between noq-proto assigning a local IP for a path (and thus choosing a `src_ip`) and sending again - the `src_ip` may be different from what the `ManyToManyRouting` table would use otherwise.
In those cases, `src_ip` should force staying on the same 4-tuple.

We also check that the route even exists. It's possible that the `ManyToManyRouting` table is modified in a way that will cut the network path on a certain 4-tuple. In that case, we need to return `RoutingDecision::Drop`.
Thus the logic is the following:
- Look for all local interfaces that are connected to given destination socket address (this may be multiple)
- Filter all these local interfaces for the interfaces with an IP address matching our `src_ip`.
- Choose the first local interface among those interfaces as our route.

That local interface address will then be the remote that the other side will see for the incoming `Transmit`.

This is just some effort in making the `ManyToManyRouting` table a little less weird. Otherwise it would represent a weird OS that completely ignores the `src_ip` setting.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
