### PR TITLE
feat(proto): Implement backoff for on-path path challenges

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2522,8 +2522,9 @@ impl Connection {
                             let Some(path) = self.paths.get_mut(&path_id) else {
                                 continue;
                             };
-                            trace!("path challenge deemed lost");
+                            trace!(?path.data.on_path_challenges_lost, "path challenge deemed lost");
                             path.data.pending_on_path_challenge = true;
+                            path.data.on_path_challenges_lost += 1;
                         }
                         PathTimer::AbandonFromValidation => {
                             let Some(path) = self.paths.get_mut(&path_id) else {
@@ -6169,7 +6170,7 @@ impl Connection {
 
             self.timers.set(
                 Timer::PerPath(path_id, PathTimer::PathChallengeLost),
-                now + pto,
+                now + path.on_path_challenge_expiry(),
                 self.qlog.with_time(now),
             );
 

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -15,6 +15,7 @@ use crate::{
     TransportErrorCode, VarInt,
     coding::{self, Decodable, Encodable},
     congestion,
+    connection::{MAX_BACKOFF_EXPONENT, MAX_PTO_INTERVAL},
     frame::ObservedAddr,
 };
 
@@ -191,6 +192,11 @@ pub(super) struct PathData {
     ///
     /// This is **not used** for n0 nat traversal challenge sending.
     pub(super) pending_on_path_challenge: bool,
+    /// How often we've deemed a path challenge to be lost.
+    ///
+    /// Similar to [`Self::pto_count`], but for on-path path challenges.
+    /// Used to calculate exponential backoff for retrying path challenges.
+    pub(super) on_path_challenges_lost: u32,
     /// Pending responses to PATH_CHALLENGE frames
     pub(super) path_responses: PathResponses,
     /// Whether we're certain the peer can both send and receive on this address
@@ -319,6 +325,7 @@ impl PathData {
             congestion,
             app_limited: false,
             on_path_challenges_unconfirmed: Default::default(),
+            on_path_challenges_lost: 0,
             pending_on_path_challenge: false,
             path_responses: PathResponses::default(),
             validated: false,
@@ -382,6 +389,7 @@ impl PathData {
             congestion,
             app_limited: false,
             on_path_challenges_unconfirmed: Default::default(),
+            on_path_challenges_lost: 0,
             pending_on_path_challenge: false,
             path_responses: PathResponses::default(),
             validated: false,
@@ -486,11 +494,17 @@ impl PathData {
         if self.on_path_challenges_unconfirmed.is_empty() {
             return None;
         }
-        let pto = self.rtt.pto_base();
+        let duration = self.on_path_challenge_expiry();
         self.on_path_challenges_unconfirmed
             .values()
-            .map(|info| info.sent_instant + pto)
+            .map(|info| info.sent_instant + duration)
             .min()
+    }
+
+    pub(super) fn on_path_challenge_expiry(&self) -> Duration {
+        let backoff = 2u32.pow(self.on_path_challenges_lost.min(MAX_BACKOFF_EXPONENT));
+        let duration = self.rtt.pto_base() * backoff;
+        duration.min(MAX_PTO_INTERVAL)
     }
 
     /// Handle receiving a PATH_RESPONSE.
@@ -523,8 +537,7 @@ impl PathData {
                     trace!("new path validated");
                 }
                 // Clear any other on-path sent challenges and stop sending new ones.
-                self.on_path_challenges_unconfirmed.clear();
-                self.pending_on_path_challenge = false;
+                self.reset_on_path_challenges();
 
                 // This RTT can only be used for the initial RTT, not as a normal
                 // sample: https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2-2.
@@ -563,6 +576,7 @@ impl PathData {
     pub(super) fn reset_on_path_challenges(&mut self) {
         self.on_path_challenges_unconfirmed.clear();
         self.pending_on_path_challenge = false;
+        self.on_path_challenges_lost = 0;
     }
 
     #[cfg(feature = "qlog")]

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1919,3 +1919,115 @@ fn test_peer_may_probe() -> TestResult {
 
     Ok(())
 }
+
+#[test]
+fn on_path_challenge_lost_backoff() {
+    let _guard = subscribe();
+
+    let mut pair = ConnPair::default();
+
+    // We use two helpers so we can "skip over" unrelated stopping points from `next_wakeup`
+
+    /// Attempts to drive the client until it has sent the expected amount of path challenges.
+    ///
+    /// Tries for a maximum of 10 iterations. Panics if that fails.
+    fn drive_client_until_challenge_sent(pair: &mut ConnPair, expected_path_challenges_sent: u64) {
+        for _ in 0..10 {
+            pair.drive_client();
+            if pair.stats(Client).frame_tx.path_challenge == expected_path_challenges_sent {
+                return;
+            }
+            pair.time = pair
+                .client
+                .next_wakeup()
+                .expect("couldn't drive client forward");
+            info!("advancing to {:?} for client", pair.time - pair.epoch);
+        }
+        assert_eq!(
+            pair.stats(Client).frame_tx.path_challenge,
+            expected_path_challenges_sent
+        );
+    }
+
+    /// Attempts to drive the server until it has received the expected amount of path challenges.
+    ///
+    /// Tries for a maximum of 10 iterations. Panics if that fails.
+    fn drive_server_until_challenge_received(
+        pair: &mut ConnPair,
+        expected_path_challenges_received: u64,
+    ) {
+        for _ in 0..10 {
+            // attempt to drive the server until it receives the PATH_CHALLENGE and sends a PATH_RESPONSE
+            pair.time = pair
+                .server
+                .next_wakeup()
+                .expect("couldn't drive server forward");
+            info!("advancing to {:?} for server", pair.time - pair.epoch);
+            pair.drive_server();
+            if pair.stats(Server).frame_rx.path_challenge == expected_path_challenges_received
+                && pair.stats(Server).frame_tx.path_response == expected_path_challenges_received
+            {
+                return;
+            }
+        }
+        assert_eq!(
+            pair.stats(Server).frame_rx.path_challenge,
+            expected_path_challenges_received
+        );
+        assert_eq!(
+            pair.stats(Server).frame_tx.path_response,
+            expected_path_challenges_received
+        );
+    }
+
+    pair.conn_mut(Client).trigger_path_validation();
+
+    // Kickstart the process once to get a reference point for the last_challenge_sent
+    drive_client_until_challenge_sent(&mut pair, 1);
+    let mut last_challenge_send = pair.time;
+    let mut last_duration = Duration::ZERO;
+
+    const MAX_DURATION: Duration = Duration::from_secs(2); // equivalent to MAX_PTO_INTERVAL
+    const MAX_ITERS: u64 = MAX_DURATION.as_millis().ilog2() as u64 + 2;
+
+    for i in 1..=MAX_ITERS {
+        drive_server_until_challenge_received(&mut pair, i);
+        pair.client.inbound.clear(); // we drop the client-inbound PATH_RESPONSE
+        info!("dropped client inbound");
+
+        drive_client_until_challenge_sent(&mut pair, i + 1);
+        let time = pair.time.duration_since(last_challenge_send);
+        info!(?time, ?last_duration, "time since last PATH_CHALLENGE send");
+        assert!(
+            time >= last_duration,
+            "duration between PATH_CHALLENGE sends must be monotonically increasing (backing off)"
+        );
+        assert!(
+            time <= MAX_DURATION,
+            "duration between PATH_CHALLENGE sends must be bound to a maximum of 2s"
+        );
+        if i == MAX_ITERS {
+            assert_eq!(time, MAX_DURATION);
+        }
+        last_duration = time;
+        last_challenge_send = pair.time;
+    }
+
+    // Now we stop dropping the client inbound once and the backoff should return back to normal:
+
+    drive_server_until_challenge_received(&mut pair, MAX_ITERS + 1);
+    pair.drive(); // Ensure the client fully processes the PATH_RESPONSE this time.
+    info!("client should have processed PATH_RESPONSE");
+
+    // The next time challenges are sent, the backoff should be reset.
+
+    pair.conn_mut(Client).trigger_path_validation();
+    drive_client_until_challenge_sent(&mut pair, MAX_ITERS + 2);
+    last_challenge_send = pair.time;
+    drive_server_until_challenge_received(&mut pair, MAX_ITERS + 2);
+    pair.client.inbound.clear(); // we drop the client-inbound PATH_RESPONSE
+    info!("dropped client inbound");
+    drive_client_until_challenge_sent(&mut pair, MAX_ITERS + 3);
+    let duration = pair.time.duration_since(last_challenge_send);
+    assert_eq!(duration, Duration::from_millis(1));
+}

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1943,9 +1943,10 @@ fn on_path_challenge_lost_backoff() {
                 .expect("couldn't drive client forward");
             info!("advancing to {:?} for client", pair.time - pair.epoch);
         }
-        assert_eq!(
-            pair.stats(Client).frame_tx.path_challenge,
-            expected_path_challenges_sent
+        panic!(
+            "client never sent PATH_CHALLENGE #{}, actual: {}",
+            expected_path_challenges_sent,
+            pair.stats(Client).frame_tx.path_challenge
         );
     }
 
@@ -1970,13 +1971,10 @@ fn on_path_challenge_lost_backoff() {
                 return;
             }
         }
-        assert_eq!(
-            pair.stats(Server).frame_rx.path_challenge,
-            expected_path_challenges_received
-        );
-        assert_eq!(
-            pair.stats(Server).frame_tx.path_response,
-            expected_path_challenges_received
+        panic!(
+            "server never received PATH_CHALLENGE #{}, actual: {}",
+            expected_path_challenges_received,
+            pair.stats(Server).frame_rx.path_challenge
         );
     }
 

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -29,7 +29,7 @@ pub(super) struct Pair {
     pub(super) server: TestEndpoint,
     pub(super) client: TestEndpoint,
     /// Start time
-    epoch: Instant,
+    pub(super) epoch: Instant,
     /// Current time
     pub(super) time: Instant,
     /// Simulates the maximum size allowed for UDP payloads by the link (packets exceeding this size will be dropped)


### PR DESCRIPTION
## Description

This implements a simple backoff algorithm for resending the PATH_CHALLENGEs that are sent on-path, very similar to the backoff mechanism in `pto_time_and_space`.

Fixes the proptest failure in #609 

## Notes & open questions

This is one way to "fix" on-path path challenges.

I did look at what a version would look like that perhaps tried to use `Retransmits` or the `LossDetection` timer, but (1) `Retransmits` is used across all paths and so far only used for data that can be transmitted over any valid path (speaking of the data space-kind only), and the `LossDetection` timer is specifically about detecting loss via acknowledgements, not about detecting loss from missing `PATH_RESPONSE`s. It's possible that a `PATH_CHALLENGE` is ACKed, but needs to be retransmitted, because the ACK was sent over a different path than the `PATH_RESPONSE`, and the `PATH_RESPONSE` got lost.
We *could* look into a system that resends both `PATH_CHALLENGE` as well as `PATH_RESPONSE`, but then you'd need to retransmit the `PATH_RESPONSE` using the same token, which would invalidate RTT estimation based on path challenges.
All in all, keeping our own timer and roughly duplicating the backoff algorithm from `pto_time_and_space` seems like the most reasonable move forward.

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.

