### PR TITLE
refactor(tests): Do not use so many star imports

### DIFF
--- a/noq-proto/src/connection/send_buffer.rs
+++ b/noq-proto/src/connection/send_buffer.rs
@@ -585,9 +585,9 @@ mod tests {
 mod proptests {
     use super::*;
 
+    use crate::tests::subscribe;
     use proptest::prelude::*;
     use test_strategy::{Arbitrary, proptest};
-    use crate::tests::subscribe;
     use tracing::trace;
 
     #[derive(Debug, Clone, Arbitrary)]

--- a/noq-proto/src/connection/streams/mod.rs
+++ b/noq-proto/src/connection/streams/mod.rs
@@ -19,8 +19,7 @@ use recv::Recv;
 pub use recv::{Chunks, ReadError, ReadableError};
 
 mod send;
-pub(crate) use send::Written;
-pub(crate) use send::{ByteSlice, BytesArray};
+pub(crate) use send::{ByteSlice, BytesArray, Written};
 use send::{BytesSource, Send, SendState};
 pub use send::{FinishError, WriteError};
 

--- a/noq-proto/src/connection/streams/mod.rs
+++ b/noq-proto/src/connection/streams/mod.rs
@@ -19,10 +19,10 @@ use recv::Recv;
 pub use recv::{Chunks, ReadError, ReadableError};
 
 mod send;
+pub(crate) use send::Written;
 pub(crate) use send::{ByteSlice, BytesArray};
 use send::{BytesSource, Send, SendState};
 pub use send::{FinishError, WriteError};
-pub(crate) use send::Written;
 
 mod state;
 #[allow(unreachable_pub)] // fuzzing only

--- a/noq-proto/src/tests/encode_decode.rs
+++ b/noq-proto/src/tests/encode_decode.rs
@@ -1,6 +1,6 @@
 use bytes::{BufMut, BytesMut};
+use proptest::{prelude::*, prop_assert_ne};
 use test_strategy::proptest;
-use proptest::{prop_assert_ne, prelude::*};
 
 use crate::{
     FrameType,

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1,8 +1,8 @@
 use std::{
     convert::TryInto,
     mem,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
-    sync::{Arc, Mutex},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::Arc,
 };
 
 use assert_matches::assert_matches;
@@ -20,17 +20,28 @@ use rustls::{
 };
 use tracing::info;
 
-use super::*;
 use crate::{
-    Duration, FourTuple, Instant,
+    AckFrequencyConfig, ApplicationClose, ClientConfig, Connection, ConnectionClose,
+    ConnectionError, ConnectionHandle, DEFAULT_SUPPORTED_VERSIONS, Datagram, DatagramEvent, Dir,
+    Duration, Endpoint, EndpointConfig, Event, FinishError, FourTuple, HashedConnectionIdGenerator,
+    Instant, MIN_INITIAL_SIZE, PathEvent, PathId, ReadError, ReadableError, RecvStream,
+    SendDatagramError, ServerConfig,
     Side::*,
+    StreamEvent, Transmit, TransportConfig, TransportErrorCode, VarInt, WriteError,
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
+    coding::{Decodable, Encodable},
     crypto::rustls::{QuicServerConfig, configured_provider},
-    frame::FrameStruct,
+    frame::{self, Frame, FrameStruct},
     transport_parameters::TransportParameters,
 };
+
 mod util;
-pub(crate) use util::*;
+pub(crate) use util::subscribe;
+use util::{
+    CERTIFIED_KEY, ConnPair, DEFAULT_MTU, IncomingConnectionBehavior, Pair, client_config,
+    client_config_with_certs, client_config_with_deterministic_pns, client_crypto_with_alpn,
+    server_config, server_config_with_cert, server_crypto_with_alpn, validate_incoming,
+};
 
 #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 mod encode_decode;
@@ -1357,7 +1368,7 @@ fn idle_timeout() {
         || !pair.server_conn_mut(server_ch).is_closed()
     {
         if !pair.step()
-            && let Some(t) = min_opt(pair.client.next_wakeup(), pair.server.next_wakeup())
+            && let Some(t) = util::min_opt(pair.client.next_wakeup(), pair.server.next_wakeup())
         {
             pair.time = t;
         }
@@ -1831,7 +1842,7 @@ fn keep_alive() {
     let end = pair.time + Duration::from_millis(20 * IDLE_TIMEOUT);
     while pair.time < end {
         if !pair.step()
-            && let Some(time) = min_opt(pair.client.next_wakeup(), pair.server.next_wakeup())
+            && let Some(time) = util::min_opt(pair.client.next_wakeup(), pair.server.next_wakeup())
         {
             pair.time = time;
         }
@@ -1877,7 +1888,8 @@ fn cid_rotation() {
         // Run a while until PushNewCID timer fires
         while pair.time < stop {
             if !pair.step()
-                && let Some(time) = min_opt(pair.client.next_wakeup(), pair.server.next_wakeup())
+                && let Some(time) =
+                    util::min_opt(pair.client.next_wakeup(), pair.server.next_wakeup())
             {
                 pair.time = time;
             }
@@ -2911,7 +2923,7 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
 
     // The ACK delay is properly calculated
     assert_eq!(pair.client.captured_packets.len(), 1);
-    let mut frames = frame::Iter::new(pair.client.captured_packets.remove(0).into())
+    let mut frames = crate::frame::Iter::new(pair.client.captured_packets.remove(0).into())
         .unwrap()
         .collect::<Result<Vec<_>, _>>()
         .unwrap();

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2923,7 +2923,7 @@ fn single_ack_eliciting_packet_triggers_ack_after_delay() {
 
     // The ACK delay is properly calculated
     assert_eq!(pair.client.captured_packets.len(), 1);
-    let mut frames = crate::frame::Iter::new(pair.client.captured_packets.remove(0).into())
+    let mut frames = frame::Iter::new(pair.client.captured_packets.remove(0).into())
         .unwrap()
         .collect::<Result<Vec<_>, _>>()
         .unwrap();

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -9,8 +9,6 @@ use assert_matches::assert_matches;
 use testresult::TestResult;
 use tracing::info;
 
-use crate::tests::ManyToManyRouting;
-use crate::tests::util::ConnPair;
 use crate::{
     ClientConfig, ConnectionId, ConnectionIdGenerator, Endpoint, EndpointConfig, FourTuple,
     LOCAL_CID_COUNT, NetworkChangeHint, PathId, PathStatus, RandomConnectionIdGenerator,
@@ -21,8 +19,10 @@ use crate::{
     n0_nat_traversal,
 };
 
-use super::util::{min_opt, subscribe};
-use super::{Pair, SimpleFirewallRouting, client_config, server_config};
+use super::util::{
+    ConnPair, ManyToManyRouting, Pair, SimpleFirewallRouting, client_config, min_opt,
+    server_config, subscribe,
+};
 
 const MAX_PATHS: u32 = 3;
 

--- a/noq-proto/src/tests/proptests.rs
+++ b/noq-proto/src/tests/proptests.rs
@@ -16,11 +16,8 @@ use tracing::error;
 use crate::{
     ClientConfig, Connection, ConnectionClose, ConnectionError, Event, PathStatus, Side,
     TransportConfig, TransportErrorCode,
-    tests::{
-        ManyToManyRouting, Pair, Routing, client_config,
-        random_interaction::{TestOp, run_random_interaction},
-        server_config, subscribe,
-    },
+    tests::random_interaction::{TestOp, run_random_interaction},
+    tests::util::{ManyToManyRouting, Pair, Routing, client_config, server_config, subscribe},
 };
 
 // These TransportConfig constants are designed to match iroh for now.

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -6,10 +6,9 @@ use tracing::{debug, error, info, trace};
 
 use crate::{
     ClientConfig, Connection, ConnectionHandle, Dir, FourTuple, PathId, PathStatus, Side, StreamId,
-    tests::{Pair, TestEndpoint},
 };
 
-use super::Routing;
+use super::util::{Pair, Routing, TestEndpoint};
 
 #[derive(Debug, Clone, Copy, Arbitrary)]
 pub(super) enum TestOp {

--- a/noq-proto/src/tests/token.rs
+++ b/noq-proto/src/tests/token.rs
@@ -1,7 +1,19 @@
 //! Tests specifically for tokens
 
-use super::*;
+use std::sync::{Arc, Mutex};
 
+use assert_matches::assert_matches;
+
+use crate::{
+    ConnectionError, Duration, Event, SystemTime, TimeSource, TokenStore, TransportErrorCode,
+    VarInt,
+};
+
+use super::util::{
+    IncomingConnectionBehavior, Pair, client_config, server_config, subscribe, validate_incoming,
+};
+
+use bytes::Bytes;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -3,25 +3,32 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     io::{self, Write},
     mem,
-    net::{Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     num::{NonZeroU32, NonZeroUsize},
     str,
     sync::{Arc, LazyLock, Mutex},
 };
 
 use assert_matches::assert_matches;
-use bytes::BytesMut;
-use rand::{SeedableRng, rngs::StdRng};
+use bytes::{Bytes, BytesMut};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use rustls::{
     KeyLogFile,
     client::WebPkiServerVerifier,
     pki_types::{CertificateDer, PrivateKeyDer},
 };
-use tracing::{debug, info_span, trace};
+use tracing::{debug, info, info_span, trace};
 
-use super::crypto::rustls::{QuicClientConfig, QuicServerConfig, configured_provider};
-use super::*;
-use crate::{Duration, Instant, congestion::Controller};
+use crate::crypto::rustls::{QuicClientConfig, QuicServerConfig, configured_provider};
+use crate::{
+    ClientConfig, ClosePathError, ClosedPath, Connection, ConnectionError, ConnectionEvent,
+    ConnectionHandle, ConnectionStats, DatagramEvent, Datagrams, Dir, Duration, EcnCodepoint,
+    Endpoint, EndpointConfig, EndpointEvent, Event, FourTuple, Incoming, Instant,
+    MultipathNotNegotiated, NetworkChangeHint, PathAbandonReason, PathError, PathId, PathStats,
+    PathStatus, RecvStream, SendStream, ServerConfig, SetPathStatusError, Side, StreamId, Streams,
+    SystemTime, TokenLog, TokenReuseError, Transmit, TransportConfig, VarInt,
+    congestion::Controller, n0_nat_traversal,
+};
 
 pub(super) const DEFAULT_MTU: usize = 1452;
 
@@ -196,8 +203,8 @@ impl Pair {
                 info!(packet_size, "dropping packet (max size exceeded)");
                 continue;
             }
-            if buffer[0] & packet::LONG_HEADER_FORM == 0 {
-                let spin = buffer[0] & packet::SPIN_BIT != 0;
+            if buffer[0] & crate::packet::LONG_HEADER_FORM == 0 {
+                let spin = buffer[0] & crate::packet::SPIN_BIT != 0;
                 self.spins += (spin == self.last_spin) as u64;
                 self.last_spin = spin;
             }
@@ -630,7 +637,7 @@ impl ConnPair {
         self.conn_mut(side).force_key_update()
     }
 
-    pub(super) fn crypto_session(&self, side: Side) -> &dyn crypto::Session {
+    pub(super) fn crypto_session(&self, side: Side) -> &dyn crate::crypto::Session {
         self.conn(side).crypto_session()
     }
 
@@ -768,8 +775,8 @@ impl ConnPair {
 
     pub(super) fn is_draining(&self, side: Side) -> bool {
         match side {
-            Client => self.client.draining_connections.contains(&self.client_ch),
-            Server => self.server.draining_connections.contains(&self.server_ch),
+            Side::Client => self.client.draining_connections.contains(&self.client_ch),
+            Side::Server => self.server.draining_connections.contains(&self.server_ch),
         }
     }
 }


### PR DESCRIPTION
## Description

This removes all the star-imports from the tests, making all the
imports much more explicit.

I guess tests/mod.rs' `use super::*` is the equivalent of the usual
test layout, but them not being in the same file makes it really hard
to follow imports. And implicitly relying on imports of 3rd party
crates via star imports is not very nice. So I think it being in a
separate file justifies not using the `use super::*`.

## Breaking Changes

none

## Notes & open questions

I know it is opiniated. I stumbled upon this because I was looking why
dead code was not being flagged in tests. Stand by for another PR...

## Change checklist

- [x] Self-review.