### PR TITLE
refactor(tests): Do not allow dead code by default

### DIFF
--- a/noq-proto/src/lib.rs
+++ b/noq-proto/src/lib.rs
@@ -13,7 +13,6 @@
 //! managing a single connection and all the related state (such as streams).
 
 #![cfg_attr(not(fuzzing), warn(missing_docs))]
-#![cfg_attr(test, allow(dead_code))]
 // Fixes welcome:
 #![allow(clippy::too_many_arguments)]
 #![warn(unreachable_pub)]

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -391,6 +391,7 @@ impl Default for ConnPair {
     }
 }
 
+#[allow(dead_code)]
 impl ConnPair {
     pub(super) fn connect_with(mut pair: Pair, client_cfg: ClientConfig) -> Self {
         let (client_ch, server_ch) = pair.connect_with(client_cfg);
@@ -1009,14 +1010,6 @@ impl TestEndpoint {
     }
 
     #[track_caller]
-    pub(super) fn assert_accept_error(&mut self) -> ConnectionError {
-        self.accepted
-            .take()
-            .expect("server didn't try connecting")
-            .expect_err("server did unexpectedly connect without error")
-    }
-
-    #[track_caller]
     pub(super) fn assert_no_accept(&self) {
         assert!(self.accepted.is_none(), "server did unexpectedly connect")
     }
@@ -1290,20 +1283,6 @@ impl Routing {
         match self {
             Self::Basic(inner) => inner,
             _ => panic!("cast to BasicRouting failed, a different routing table is set"),
-        }
-    }
-
-    pub(super) fn as_many_to_many(&self) -> &ManyToManyRouting {
-        match self {
-            Self::ManyToMany(inner) => inner,
-            _ => panic!("cast to ManyToManyRouting failed, a different routing table is set"),
-        }
-    }
-
-    pub(super) fn as_many_to_many_mut(&mut self) -> &mut ManyToManyRouting {
-        match self {
-            Self::ManyToMany(inner) => inner,
-            _ => panic!("cast to ManyToManyRouting failed, a different routing table is set"),
         }
     }
 }


### PR DESCRIPTION
## Description

This really surprised me that this wasn't calling me out on dead
code. I don't think this is very helpful.

ConnPair has loads of dead code, I assume if we'd convert all the Pair
usage to ConnPair they would go away so that is kind of intentional?
So I allowed it just there for now.

## Breaking Changes

none

## Notes & open questions

none

## Change checklist

- [x] Self-review.