### PR TITLE
fix(noq): close the connection when a Connecting is dropped before handshake

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -12,7 +12,7 @@ use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
 
 use rand::{RngExt, SeedableRng, rngs::StdRng};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
 
@@ -307,7 +307,7 @@ pub struct Connection {
     /// time after a path is abandoned.
     // TODO(flub): Make this a more efficient data structure.  Like ranges of abandoned
     //    paths.  Or a set together with a minimum.  Or something.
-    abandoned_paths: FxHashSet<PathId>,
+    abandoned_paths: AbandonedPaths,
 
     /// State for n0's (<https://n0.computer>) nat traversal protocol.
     n0_nat_traversal: n0_nat_traversal::State,
@@ -416,7 +416,7 @@ impl Connection {
                 config.stream_receive_window,
             ),
             datagrams: DatagramState::default(),
-            config,
+            config: config.clone(),
             remote_cids: FxHashMap::from_iter([(PathId::ZERO, CidQueue::new(remote_cid))]),
             rng,
             path_stats: Default::default(),
@@ -428,7 +428,7 @@ impl Connection {
             local_max_path_id: PathId::ZERO,
             remote_max_path_id: PathId::ZERO,
             max_path_id_with_cids: PathId::ZERO,
-            abandoned_paths: Default::default(),
+            abandoned_paths: AbandonedPaths::new(config.max_concurrent_multipath_paths.map_or(1, |v| v.get()) as usize),
 
             n0_nat_traversal: Default::default(),
             qlog,
@@ -568,7 +568,7 @@ impl Connection {
             return Err(PathError::ServerSideNotAllowed);
         }
 
-        let max_abandoned = self.abandoned_paths.iter().max().copied();
+        let max_abandoned = self.abandoned_paths.max_path_id();
         let max_used = self.paths.keys().last().copied();
         let path_id = max_abandoned
             .max(max_used)
@@ -7724,5 +7724,49 @@ mod tests {
             assert_eq!(negotiate_max_idle_timeout(left, right), result);
             assert_eq!(negotiate_max_idle_timeout(right, left), result);
         }
+    }
+}
+
+
+/// Bounded storage of the most recently abandoned paths
+#[derive(Debug, Clone)]
+pub(crate) struct AbandonedPaths {
+    paths: VecDeque<PathId>,
+    capacity: usize,
+    total_abandoned: u32,
+    max_abandoned: Option<PathId>,
+}
+
+impl AbandonedPaths {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            paths: VecDeque::with_capacity(capacity),
+            capacity,
+            total_abandoned: 0,
+            max_abandoned: None,
+        }
+    }
+
+    pub(crate) fn insert(&mut self, id: PathId) {
+        if !self.paths.contains(&id) {
+            self.paths.push_back(id);
+            self.total_abandoned += 1;
+            self.max_abandoned = Some(self.max_abandoned.unwrap_or(PathId::ZERO).max(id));
+            if self.paths.len() > self.capacity {
+                self.paths.pop_front();
+            }
+        }
+    }
+
+    pub(crate) fn contains(&self, id: &PathId) -> bool {
+        self.paths.contains(id)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.total_abandoned as usize
+    }
+
+    pub(crate) fn max_path_id(&self) -> Option<PathId> {
+        self.max_abandoned
     }
 }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -12,7 +12,7 @@ use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
 
 use rand::{RngExt, SeedableRng, rngs::StdRng};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
 
@@ -307,7 +307,7 @@ pub struct Connection {
     /// time after a path is abandoned.
     // TODO(flub): Make this a more efficient data structure.  Like ranges of abandoned
     //    paths.  Or a set together with a minimum.  Or something.
-    abandoned_paths: AbandonedPaths,
+    abandoned_paths: FxHashSet<PathId>,
 
     /// State for n0's (<https://n0.computer>) nat traversal protocol.
     n0_nat_traversal: n0_nat_traversal::State,
@@ -416,7 +416,7 @@ impl Connection {
                 config.stream_receive_window,
             ),
             datagrams: DatagramState::default(),
-            config: config.clone(),
+            config,
             remote_cids: FxHashMap::from_iter([(PathId::ZERO, CidQueue::new(remote_cid))]),
             rng,
             path_stats: Default::default(),
@@ -428,7 +428,7 @@ impl Connection {
             local_max_path_id: PathId::ZERO,
             remote_max_path_id: PathId::ZERO,
             max_path_id_with_cids: PathId::ZERO,
-            abandoned_paths: AbandonedPaths::new(config.max_concurrent_multipath_paths.map_or(1, |v| v.get()) as usize),
+            abandoned_paths: Default::default(),
 
             n0_nat_traversal: Default::default(),
             qlog,
@@ -568,7 +568,7 @@ impl Connection {
             return Err(PathError::ServerSideNotAllowed);
         }
 
-        let max_abandoned = self.abandoned_paths.max_path_id();
+        let max_abandoned = self.abandoned_paths.iter().max().copied();
         let max_used = self.paths.keys().last().copied();
         let path_id = max_abandoned
             .max(max_used)
@@ -7724,49 +7724,5 @@ mod tests {
             assert_eq!(negotiate_max_idle_timeout(left, right), result);
             assert_eq!(negotiate_max_idle_timeout(right, left), result);
         }
-    }
-}
-
-
-/// Bounded storage of the most recently abandoned paths
-#[derive(Debug, Clone)]
-pub(crate) struct AbandonedPaths {
-    paths: VecDeque<PathId>,
-    capacity: usize,
-    total_abandoned: u32,
-    max_abandoned: Option<PathId>,
-}
-
-impl AbandonedPaths {
-    pub(crate) fn new(capacity: usize) -> Self {
-        Self {
-            paths: VecDeque::with_capacity(capacity),
-            capacity,
-            total_abandoned: 0,
-            max_abandoned: None,
-        }
-    }
-
-    pub(crate) fn insert(&mut self, id: PathId) {
-        if !self.paths.contains(&id) {
-            self.paths.push_back(id);
-            self.total_abandoned += 1;
-            self.max_abandoned = Some(self.max_abandoned.unwrap_or(PathId::ZERO).max(id));
-            if self.paths.len() > self.capacity {
-                self.paths.pop_front();
-            }
-        }
-    }
-
-    pub(crate) fn contains(&self, id: &PathId) -> bool {
-        self.paths.contains(id)
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.total_abandoned as usize
-    }
-
-    pub(crate) fn max_path_id(&self) -> Option<PathId> {
-        self.max_abandoned
     }
 }

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -40,7 +40,7 @@ use proto::{
 #[derive(Debug)]
 pub struct Connecting {
     conn: Option<ConnectionRef>,
-    connected: oneshot::Receiver<bool>,
+    connected: Option<oneshot::Receiver<bool>>,
     handshake_data_ready: Option<oneshot::Receiver<()>>,
 }
 
@@ -82,7 +82,7 @@ impl Connecting {
 
         Self {
             conn: Some(conn),
-            connected: on_connected_recv,
+            connected: Some(on_connected_recv),
             handshake_data_ready: Some(on_handshake_data_recv),
         }
     }
@@ -141,7 +141,8 @@ impl Connecting {
 
         if is_ok {
             let conn = self.conn.take().unwrap();
-            Ok((Connection(conn), ZeroRttAccepted(self.connected)))
+            let connected = self.connected.take().unwrap();
+            Ok((Connection(conn), ZeroRttAccepted(connected)))
         } else {
             Err(self)
         }
@@ -213,19 +214,37 @@ impl Connecting {
 impl Future for Connecting {
     type Output = Result<Connection, ConnectionError>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.connected).poll(cx).map(|_| {
-            let conn = self.conn.take().unwrap();
-            let inner = conn.lock_without_waking("connecting");
-            if inner.connected {
-                drop(inner);
-                Ok(Connection(conn))
-            } else {
-                Err(inner
-                    .error
-                    .clone()
-                    .expect("connected signaled without connection success or error"))
+        let mut connected = self.connected.take().expect("polled after yielding Ready");
+        match Pin::new(&mut connected).poll(cx) {
+            Poll::Ready(_) => {
+                let conn = self.conn.take().unwrap();
+                let inner = conn.lock_without_waking("connecting");
+                if inner.connected {
+                    drop(inner);
+                    Poll::Ready(Ok(Connection(conn)))
+                } else {
+                    Poll::Ready(Err(inner
+                        .error
+                        .clone()
+                        .expect("connected signaled without connection success or error")))
+                }
             }
-        })
+            Poll::Pending => {
+                self.connected = Some(connected);
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl Drop for Connecting {
+    fn drop(&mut self) {
+        if let Some(conn) = self.conn.take() {
+            let mut state = conn.lock_without_waking("connecting_drop");
+            if !state.inner.is_closed() {
+                state.implicit_close(&conn.shared);
+            }
+        }
     }
 }
 

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -39,9 +39,28 @@ use proto::{
 /// In-progress connection attempt future
 #[derive(Debug)]
 pub struct Connecting {
-    conn: Option<ConnectionRef>,
-    connected: Option<oneshot::Receiver<bool>>,
-    handshake_data_ready: Option<oneshot::Receiver<()>>,
+    state: ConnectingState,
+}
+
+#[derive(Debug)]
+enum ConnectingState {
+    Active {
+        conn: ConnectionRef,
+        connected: oneshot::Receiver<bool>,
+        handshake_data_ready: Option<oneshot::Receiver<()>>,
+    },
+    Consumed,
+}
+
+impl Drop for Connecting {
+    fn drop(&mut self) {
+        if let ConnectingState::Active { conn, .. } = &mut self.state {
+            let mut state = conn.lock_without_waking("connecting_drop");
+            if !state.inner.is_closed() {
+                state.implicit_close(&conn.shared);
+            }
+        }
+    }
 }
 
 impl Connecting {
@@ -81,9 +100,11 @@ impl Connecting {
         ));
 
         Self {
-            conn: Some(conn),
-            connected: Some(on_connected_recv),
-            handshake_data_ready: Some(on_handshake_data_recv),
+            state: ConnectingState::Active {
+                conn,
+                connected: on_connected_recv,
+                handshake_data_ready: Some(on_handshake_data_recv),
+            },
         }
     }
 
@@ -132,17 +153,20 @@ impl Connecting {
     /// before TLS client authentication has occurred, and should therefore not be used to send
     /// data for which client authentication is being used.
     pub fn into_0rtt(mut self) -> Result<(Connection, ZeroRttAccepted), Self> {
-        // This lock borrows `self` and would normally be dropped at the end of this scope, so we'll
-        // have to release it explicitly before returning `self` by value.
-        let conn = (self.conn.as_mut().unwrap()).lock_without_waking("into_0rtt");
-
-        let is_ok = conn.inner.has_0rtt() || conn.inner.side().is_server();
-        drop(conn);
+        let is_ok = match &self.state {
+            ConnectingState::Active { conn, .. } => {
+                let inner = conn.lock_without_waking("into_0rtt");
+                inner.inner.has_0rtt() || inner.inner.side().is_server()
+            }
+            ConnectingState::Consumed => false,
+        };
 
         if is_ok {
-            let conn = self.conn.take().unwrap();
-            let connected = self.connected.take().unwrap();
-            Ok((Connection(conn), ZeroRttAccepted(connected)))
+            if let ConnectingState::Active { conn, connected, .. } = std::mem::replace(&mut self.state, ConnectingState::Consumed) {
+                Ok((Connection(conn), ZeroRttAccepted(connected)))
+            } else {
+                unreachable!()
+            }
         } else {
             Err(self)
         }
@@ -158,10 +182,13 @@ impl Connecting {
         // Taking &mut self allows us to use a single oneshot channel rather than dealing with
         // potentially many tasks waiting on the same event. It's a bit of a hack, but keeps things
         // simple.
-        if let Some(x) = self.handshake_data_ready.take() {
+        let ConnectingState::Active { conn, handshake_data_ready, .. } = &mut self.state else {
+            panic!("used after yielding Ready");
+        };
+
+        if let Some(x) = handshake_data_ready.take() {
             let _ = x.await;
         }
-        let conn = self.conn.as_ref().unwrap();
         let inner = conn.lock_without_waking("handshake");
         inner
             .inner
@@ -187,7 +214,9 @@ impl Connecting {
     ///
     /// Will panic if called after `poll` has returned `Ready`.
     pub fn local_ip(&self) -> Option<IpAddr> {
-        let conn = self.conn.as_ref().expect("used after yielding Ready");
+        let ConnectingState::Active { conn, .. } = &self.state else {
+            panic!("used after yielding Ready");
+        };
         let inner = conn.lock_without_waking("local_ip");
 
         inner
@@ -201,8 +230,10 @@ impl Connecting {
     ///
     /// Will panic if called after `poll` has returned `Ready`.
     pub fn remote_address(&self) -> SocketAddr {
-        let conn_ref: &ConnectionRef = self.conn.as_ref().expect("used after yielding Ready");
-        conn_ref
+        let ConnectingState::Active { conn, .. } = &self.state else {
+            panic!("used after yielding Ready");
+        };
+        conn
             .lock_without_waking("remote_address")
             .inner
             .network_path(PathId::ZERO)
@@ -214,36 +245,29 @@ impl Connecting {
 impl Future for Connecting {
     type Output = Result<Connection, ConnectionError>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut connected = self.connected.take().expect("polled after yielding Ready");
-        match Pin::new(&mut connected).poll(cx) {
-            Poll::Ready(_) => {
-                let conn = self.conn.take().unwrap();
-                let inner = conn.lock_without_waking("connecting");
-                if inner.connected {
-                    drop(inner);
-                    Poll::Ready(Ok(Connection(conn)))
-                } else {
-                    Poll::Ready(Err(inner
-                        .error
-                        .clone()
-                        .expect("connected signaled without connection success or error")))
+        match &mut self.state {
+            ConnectingState::Active { connected, .. } => {
+                match Pin::new(connected).poll(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(_) => {}
                 }
             }
-            Poll::Pending => {
-                self.connected = Some(connected);
-                Poll::Pending
-            }
+            ConnectingState::Consumed => panic!("polled after yielding Ready"),
         }
-    }
-}
 
-impl Drop for Connecting {
-    fn drop(&mut self) {
-        if let Some(conn) = self.conn.take() {
-            let mut state = conn.lock_without_waking("connecting_drop");
-            if !state.inner.is_closed() {
-                state.implicit_close(&conn.shared);
+        if let ConnectingState::Active { conn, .. } = std::mem::replace(&mut self.state, ConnectingState::Consumed) {
+            let inner = conn.lock_without_waking("connecting");
+            if inner.connected {
+                drop(inner);
+                Poll::Ready(Ok(Connection(conn)))
+            } else {
+                Poll::Ready(Err(inner
+                    .error
+                    .clone()
+                    .expect("connected signaled without connection success or error")))
             }
+        } else {
+            unreachable!()
         }
     }
 }

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -165,7 +165,7 @@ impl Connecting {
             if let ConnectingState::Active { conn, connected, .. } = std::mem::replace(&mut self.state, ConnectingState::Consumed) {
                 Ok((Connection(conn), ZeroRttAccepted(connected)))
             } else {
-                unreachable!()
+                unreachable!("state must be Active since is_ok is true")
             }
         } else {
             Err(self)
@@ -178,6 +178,8 @@ impl Connecting {
     /// [`Session`](proto::crypto::Session). For the default `rustls` session, the return value can
     /// be [`downcast`](Box::downcast) to a
     /// [`crypto::rustls::HandshakeData`](crate::crypto::rustls::HandshakeData).
+    ///
+    /// Will panic if called after `poll` has returned `Ready`.
     pub async fn handshake_data(&mut self) -> Result<Box<dyn Any>, ConnectionError> {
         // Taking &mut self allows us to use a single oneshot channel rather than dealing with
         // potentially many tasks waiting on the same event. It's a bit of a hack, but keeps things

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1762,3 +1762,12 @@ unsafe fn wake_by_ref_waker(data: *const ()) {
 unsafe fn drop_waker(data: *const ()) {
     drop(unsafe { Arc::<WakeCounter>::from_raw(data as *const WakeCounter) });
 }
+
+#[tokio::test]
+async fn drop_connecting_cleans_up() {
+    let ep = endpoint();
+    let addr = "127.0.0.1:1234".parse().unwrap();
+    let connecting = ep.connect(addr, "localhost").unwrap();
+    drop(connecting);
+    ep.wait_idle().await;
+}


### PR DESCRIPTION
## Description

While running noq (via iroh) under sustained churn in a downstream project — peers abruptly killed
without a graceful `CONNECTION_CLOSE` — we found in-progress connections were never reclaimed.
`Connecting` had no `Drop` implementation, so dropping a `Connecting` future before the handshake
completed didn't signal the connection task. Before handshake completion the idle timeout isn't yet
in effect and there's no handshake timeout, and the background `ConnectionDriver` plus the
`EndpointInner` event-channel sender keep the connection alive — so the half-open connection state
lingered in the endpoint maps indefinitely, once per aborted inbound handshake.

(Thanks for noq, too — having a workable multipath QUIC we could build on underneath iroh is a big
deal, and the `Connecting`/driver/endpoint separation made the right fix point clear.)

### Fix

Implement `Drop` for `Connecting`: on drop, if the handshake hasn't completed, take the inner
connection reference, and if it isn't already closed, call `implicit_close()`. That transitions the
connection to drained, dispatches the close to the endpoint (which removes the handle from its
active maps), and wakes the driver to exit cleanly — releasing the connection, its channels, and its
packet spaces.

To satisfy the borrow checker (E0509: cannot move out of a type implementing `Drop`), the oneshot
`connected` receiver is wrapped in `Option`, and `into_0rtt` / `Future::poll` `take()` it (poll
restores it on `Pending`).

## Breaking Changes

None. `Connecting`'s public API is unchanged; this only adds cleanup on the drop path.

## Notes & open questions

- **Test:** a focused regression test (start an inbound handshake, drop the `Connecting`, assert the
  connection is removed from the endpoint maps) needs a connected-endpoint harness; glad to add one
  in whatever style fits your test suite. We validated the behavior via a downstream chaos soak
  (continuous kill/respawn): with the fix, the previously monotonic per-connection growth flattens
  and connection structures no longer accumulate in heap profiles.
- Open question: would you prefer this paired with an explicit pre-handshake timeout, or is
  drop-driven cleanup the right scope here? Happy to follow your lead.

## Checklist

- [x] Self-review
- [x] Documented the `Option`-wrap reasoning (E0509) and the drop-path intent
- [ ] Tests — see note above; glad to add a harness-based regression test on request
- [x] No breaking changes

## Related

Found together with two other churn-related leak fixes in the iroh stack:
- n0-computer/iroh-gossip#146 — connection-task reaping + peer-state eviction under churn
- n0-computer/iroh#4294 — `mapped_addrs` eviction on actor shutdown

Resolves #681
