### PR TITLE
tests: Add tests for easy-hard NAT combinations

### DIFF
--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1695,10 +1695,10 @@ fn test_simple_nat_traveral_opens_path() -> TestResult {
     let mut pair = ConnPair::builder()
         .enable_multipath()
         .enable_nat_traversal()
+        .with_routes(SimpleFirewallRouting::new().into())
         .connect();
 
-    info!("setting routes, adding addrs");
-    pair.routes = SimpleFirewallRouting::new().into();
+    info!("adding addrs");
     pair.add_nat_traversal_address(Server, SimpleFirewallRouting::SERVER_FW_ADDR)?;
     pair.add_nat_traversal_address(Client, SimpleFirewallRouting::CLIENT_FW_ADDR)?;
     pair.drive();
@@ -1774,6 +1774,99 @@ fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
     );
 
     // Continue till the end.
+    pair.drive();
+
+    let event = pair.poll(Client).expect("should have event");
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
+
+    let event = pair.poll(Server).expect("should have event");
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
+
+    Ok(())
+}
+
+/// Tests a "very easy NAT" for the server with a "hard NAT" for the client.
+#[test]
+fn test_hard_nat_client_opens_path() -> TestResult {
+    let _guard = subscribe();
+    let mut routing = SimpleFirewallRouting::new();
+    // By configuring the server side to be open it emulates an EIM+EIF NAT: the QAD probe
+    // already opened the firewall.
+    routing.server_firewall_open = true;
+    let mut pair = ConnPair::builder()
+        .enable_multipath()
+        .enable_nat_traversal()
+        .with_routes(routing.into())
+        .connect();
+
+    info!("adding addrs");
+    pair.add_nat_traversal_address(Server, SimpleFirewallRouting::SERVER_FW_ADDR)?;
+    // By adding a dummy address the client can start NAT traversal but does not advertise
+    // its real public interface, thus emulating a hard NAT. Choose the last addr in the
+    // client subnet.
+    let dummy_addr: SocketAddr = "[::1:ffff]:1".parse()?;
+    pair.add_nat_traversal_address(Client, dummy_addr)?;
+    pair.drive();
+
+    let event = pair.poll(Client).expect("should have event");
+    assert_matches!(
+        event,
+        Event::NatTraversal(n0_nat_traversal::Event::AddressAdded(_))
+    );
+
+    info!("init NAT traversal");
+    pair.initiate_nat_traversal_round(Client)?;
+
+    // Ensure we have no more events queued
+    assert_matches!(pair.poll(Client), None);
+    assert_matches!(pair.poll(Server), None);
+
+    pair.drive();
+
+    let event = pair.poll(Client).expect("should have event");
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
+
+    let event = pair.poll(Server).expect("should have event");
+    assert_matches!(event, Event::Path(PathEvent::Established { .. }));
+
+    Ok(())
+}
+/// Tests a "very easy NAT" for the client with a "hard NAT" for the client.
+#[test]
+fn test_hard_nat_server_opens_path() -> TestResult {
+    let _guard = subscribe();
+    let mut routing = SimpleFirewallRouting::new();
+    // By configuring the client side to be open it emulates an EIM+EIF NAT: the QAD probe
+    // already opened the firewall.
+    routing.client_firewall_open = true;
+    let mut pair = ConnPair::builder()
+        .enable_multipath()
+        .enable_nat_traversal()
+        .with_routes(routing.into())
+        .connect();
+
+    info!("adding addrs");
+    // By adding a dummy address the client can start NAT traversal but does not advertise
+    // its real public interface, thus emulating a hard NAT. Choose the last addr in the
+    // server subnet.
+    let dummy_addr: SocketAddr = "[::2:ffff]:1".parse()?;
+    pair.add_nat_traversal_address(Server, dummy_addr)?;
+    pair.add_nat_traversal_address(Client, SimpleFirewallRouting::CLIENT_FW_ADDR)?;
+    pair.drive();
+
+    let event = pair.poll(Client).expect("should have event");
+    assert_matches!(
+        event,
+        Event::NatTraversal(n0_nat_traversal::Event::AddressAdded(_))
+    );
+
+    info!("init NAT traversal");
+    pair.initiate_nat_traversal_round(Client)?;
+
+    // Ensure we have no more events queued
+    assert_matches!(pair.poll(Client), None);
+    assert_matches!(pair.poll(Server), None);
+
     pair.drive();
 
     let event = pair.poll(Client).expect("should have event");

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1786,6 +1786,9 @@ fn test_simple_nat_traversal_challenge_with_response() -> TestResult {
 }
 
 /// Tests a "very easy NAT" for the server with a "hard NAT" for the client.
+///
+/// Here "very easy NAT" is an EIM+EIF NAT. The port is opened by the QAD probe. "hard NAT"
+/// is an EDM NAT.
 #[test]
 fn test_hard_nat_client_opens_path() -> TestResult {
     let _guard = subscribe();
@@ -1833,6 +1836,9 @@ fn test_hard_nat_client_opens_path() -> TestResult {
 }
 
 /// Tests a "very easy NAT" for the client with a "hard NAT" for the server.
+///
+/// Here "very easy NAT" is an EIM+EIF NAT. The port is opened by the QAD probe. "hard NAT"
+/// is an EDM NAT.
 #[test]
 fn test_hard_nat_server_opens_path() -> TestResult {
     let _guard = subscribe();

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1831,7 +1831,8 @@ fn test_hard_nat_client_opens_path() -> TestResult {
 
     Ok(())
 }
-/// Tests a "very easy NAT" for the client with a "hard NAT" for the client.
+
+/// Tests a "very easy NAT" for the client with a "hard NAT" for the server.
 #[test]
 fn test_hard_nat_server_opens_path() -> TestResult {
     let _guard = subscribe();

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1702,8 +1702,14 @@ impl ManyToManyRouting {
 
 /// A routing table with one open and one firewalled interface.
 ///
-/// This essentially behaves like a Destination Endpoint Independent NAT with address and
-/// port filtering. But without having to simulate the public side of the network.
+/// This essentially behaves like a Destination Endpoint Independent Mapping NAT with
+/// address and port filtering: EIM + ADF in [RFC4748] terminology. But without having to
+/// simulate the public side of the network.
+///
+/// This same routing can be used for EIM + EIF: Endpoint-Independent filtering. In this
+/// case the filtering is effectively opened by the QAD probe, so all that is needed is
+/// configure it with [`Self::client_firewall_open`] and/or [`Self::server_firewall_open`]
+/// from the start.
 ///
 /// This is pretty simplistic, but tests the basics.
 ///
@@ -1718,15 +1724,17 @@ impl ManyToManyRouting {
 /// destination. This is the same as the kernel selecting the correct outbound interface. If
 /// an outgoing transmit has an `src_ip` of an interface that is not linked to the interface
 /// of the destination IP then a transmit is dropped.
+///
+/// [RFC4748]: https://www.rfc-editor.org/info/rfc4787/#section-4.1
 #[derive(Debug)]
 pub(super) struct SimpleFirewallRouting {
     /// Whether the client has sent a packet from `client_nat` to `server_nat`.
     ///
     /// If so packets from `server_nat` to `client_nat` will be allowed. If not they will be
     /// dropped.
-    client_firewall_open: bool,
+    pub(super) client_firewall_open: bool,
     /// Whether the server has sent a packet from `server_nat` to `client_nat`.
-    server_firewall_open: bool,
+    pub(super) server_firewall_open: bool,
 }
 
 impl From<SimpleFirewallRouting> for Routing {


### PR DESCRIPTION
## Description

We should be able to traverse NATs with a combination of a "very easy"
and "hard" NAT. Adjust the SimpleFirewallRouting to allow emulating
that behaviour.

Verified by reverting c20a684349c2efb620f364a7d34df721ece489a5 and
then test_hard_nat_server_opens_path fails.

## Breaking Changes

none

## Notes & open questions

Look how simple this was. #675 was a red herring.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.