### PR TITLE
fix(multipath): Store abandoned paths in bounded memory

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2804,7 +2804,7 @@ impl Connection {
         let in_use_count = self
             .local_max_path_id
             .next()
-            .saturating_sub(self.abandoned_paths.len() as u32)
+            .saturating_sub(self.abandoned_paths.len())
             .as_u32();
         let extra_needed = count.get().saturating_sub(in_use_count);
         let new_max_path_id = self.local_max_path_id.saturating_add(extra_needed);

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7221,8 +7221,11 @@ struct AbandonedPaths {
 
 impl AbandonedPaths {
     /// The number of abandoned paths.
-    fn len(&self) -> usize {
-        self.min.map(|p| p.as_u32().saturating_add(1)).unwrap_or(0) as usize + self.set.len()
+    fn len(&self) -> u32 {
+        self.min
+            .map(|p| p.as_u32().saturating_add(1))
+            .unwrap_or(0)
+            .saturating_add(self.set.len() as u32)
     }
 
     /// The largest abandoned path.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7214,7 +7214,7 @@ impl fmt::Debug for Connection {
 #[derive(Debug, Default)]
 struct AbandonedPaths {
     /// This and any lower numbered paths have been abandoned.
-    min: Option<PathId>,
+    continuous_max: Option<PathId>,
     /// Any abandoned paths which are non-continuous with [`Self::min`].
     set: BTreeSet<PathId>,
 }
@@ -7222,7 +7222,7 @@ struct AbandonedPaths {
 impl AbandonedPaths {
     /// The number of abandoned paths.
     fn len(&self) -> u32 {
-        self.min
+        self.continuous_max
             .map(|p| p.as_u32().saturating_add(1))
             .unwrap_or(0)
             .saturating_add(self.set.len() as u32)
@@ -7230,12 +7230,12 @@ impl AbandonedPaths {
 
     /// The largest abandoned path.
     fn max(&self) -> Option<PathId> {
-        self.set.last().copied().or(self.min)
+        self.set.last().copied().or(self.continuous_max)
     }
 
     /// Whether the the path is already abandoned.
     fn contains(&self, val: &PathId) -> bool {
-        Some(*val) <= self.min || self.set.contains(val)
+        Some(*val) <= self.continuous_max || self.set.contains(val)
     }
 
     /// Adds another abandoned path.
@@ -7246,10 +7246,14 @@ impl AbandonedPaths {
 
     /// Compacts the representation of the abandoned paths.
     fn compact(&mut self) {
-        self.set.retain(|v| match self.min {
+        self.set.retain(|v| match self.continuous_max {
             Some(ref min) if *v <= *min => false,
             Some(ref mut min) if *v == min.next() => {
                 *min = *v;
+                false
+            }
+            None if *v == PathId::ZERO => {
+                self.continuous_max = Some(*v);
                 false
             }
             Some(_) | None => true,
@@ -7773,5 +7777,38 @@ mod tests {
             assert_eq!(negotiate_max_idle_timeout(left, right), result);
             assert_eq!(negotiate_max_idle_timeout(right, left), result);
         }
+    }
+
+    #[test]
+    fn abandoned_paths() {
+        let mut t = AbandonedPaths::default();
+
+        t.insert(PathId(0));
+        t.insert(PathId(1));
+        assert_eq!(t.len(), 2);
+        assert!(t.set.is_empty()); // elements compacted into continuous_max
+        assert!(t.contains(&PathId(0)));
+        assert!(t.contains(&PathId(1)));
+        assert!(!t.contains(&PathId(2)));
+        assert!(!t.contains(&PathId(3)));
+        assert_eq!(t.max(), Some(PathId(1)));
+
+        t.insert(PathId(3));
+        assert_eq!(t.len(), 3);
+        assert_eq!(t.set.len(), 1); // 1 discontinuous element in the set
+        assert!(t.contains(&PathId(0)));
+        assert!(t.contains(&PathId(1)));
+        assert!(!t.contains(&PathId(2)));
+        assert!(t.contains(&PathId(3)));
+        assert_eq!(t.max(), Some(PathId(3)));
+
+        t.insert(PathId(2));
+        assert_eq!(t.len(), 4);
+        assert!(t.set.is_empty()); // elements compacted into continuous_max
+        assert!(t.contains(&PathId(0)));
+        assert!(t.contains(&PathId(1)));
+        assert!(t.contains(&PathId(2)));
+        assert!(t.contains(&PathId(3)));
+        assert_eq!(t.max(), Some(PathId(3)));
     }
 }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp,
-    collections::{BTreeMap, VecDeque, btree_map},
+    collections::{BTreeMap, BTreeSet, VecDeque, btree_map},
     convert::TryFrom,
     fmt, io, mem,
     net::SocketAddr,
@@ -12,7 +12,7 @@ use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
 
 use rand::{RngExt, SeedableRng, rngs::StdRng};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
 
@@ -305,9 +305,7 @@ pub struct Connection {
     /// They may still have some state left in [`Connection::paths`] or
     /// [`Connection::local_cid_state`] since some of this has to be kept around for some
     /// time after a path is abandoned.
-    // TODO(flub): Make this a more efficient data structure.  Like ranges of abandoned
-    //    paths.  Or a set together with a minimum.  Or something.
-    abandoned_paths: FxHashSet<PathId>,
+    abandoned_paths: AbandonedPaths,
 
     /// State for n0's (<https://n0.computer>) nat traversal protocol.
     n0_nat_traversal: n0_nat_traversal::State,
@@ -568,7 +566,7 @@ impl Connection {
             return Err(PathError::ServerSideNotAllowed);
         }
 
-        let max_abandoned = self.abandoned_paths.iter().max().copied();
+        let max_abandoned = self.abandoned_paths.max();
         let max_used = self.paths.keys().last().copied();
         let path_id = max_abandoned
             .max(max_used)
@@ -7205,6 +7203,54 @@ impl fmt::Debug for Connection {
         f.debug_struct("Connection")
             .field("handshake_cid", &self.handshake_cid)
             .finish()
+    }
+}
+
+/// The set of abandoned paths.
+///
+/// This is a simplistic implementation to keep track of the set of abandoned paths in a
+/// space that is constant but proportional to the number of allowed concurrently open
+/// paths.
+#[derive(Debug, Default)]
+struct AbandonedPaths {
+    /// This and any lower numbered paths have been abandoned.
+    min: Option<PathId>,
+    /// Any abandoned paths which are non-continuous with [`Self::min`].
+    set: BTreeSet<PathId>,
+}
+
+impl AbandonedPaths {
+    /// The number of abandoned paths.
+    fn len(&self) -> usize {
+        self.min.map(|p| p.as_u32().saturating_add(1)).unwrap_or(0) as usize + self.set.len()
+    }
+
+    /// The largest abandoned path.
+    fn max(&self) -> Option<PathId> {
+        self.set.last().copied().or(self.min)
+    }
+
+    /// Whether the the path is already abandoned.
+    fn contains(&self, val: &PathId) -> bool {
+        Some(*val) <= self.min || self.set.contains(val)
+    }
+
+    /// Adds another abandoned path.
+    fn insert(&mut self, val: PathId) {
+        self.set.insert(val);
+        self.compact()
+    }
+
+    /// Compacts the representation of the abandoned paths.
+    fn compact(&mut self) {
+        self.set.retain(|v| match self.min {
+            Some(ref min) if *v <= *min => false,
+            Some(ref mut min) if *v == min.next() => {
+                *min = *v;
+                false
+            }
+            Some(_) | None => true,
+        })
     }
 }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -540,7 +540,7 @@ impl Connection {
     ) -> Result<(PathId, bool), PathError> {
         let existing_open_path = self.paths.iter().find(|(id, path)| {
             network_path.is_probably_same_path(&path.data.network_path)
-                && !self.abandoned_paths.contains(*id)
+                && !self.abandoned_paths.contains(id)
         });
         match existing_open_path {
             Some((path_id, _state)) => Ok((*path_id, true)),

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7215,7 +7215,7 @@ impl fmt::Debug for Connection {
 struct AbandonedPaths {
     /// This and any lower numbered paths have been abandoned.
     continuous_max: Option<PathId>,
-    /// Any abandoned paths which are non-continuous with [`Self::min`].
+    /// Any abandoned paths which are non-continuous with [`Self::continuous_max`].
     set: BTreeSet<PathId>,
 }
 
@@ -7233,7 +7233,7 @@ impl AbandonedPaths {
         self.set.last().copied().or(self.continuous_max)
     }
 
-    /// Whether the the path is already abandoned.
+    /// Whether the path is already abandoned.
     fn contains(&self, val: &PathId) -> bool {
         Some(*val) <= self.continuous_max || self.set.contains(val)
     }


### PR DESCRIPTION
## Description

The previous version kept a full set of all abandoned paths. But the
entire set is not sparse, there are only up to
max_concurrent_multipath_paths sparse entries. All paths below that
must always be abandoned.

This bounds the memory taken by this set.

## Breaking Changes

none

## Notes & open questions

A kind of naive implementation, but I like it because it is
simple. You could do slightly more optimised versions. My favourite is
probably a bit vector for the sparse set. But would have to benchmark
to really know if this would have any impact and that seems overkill
for now.

You won't be able to go for a version that does not allocate since we
need to be able to modify the maximum number of allowed concurrent
paths to change during the lifetime of a connection, even if we don't
yet have the API for that today.

Replaces #683 

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.