### PR TITLE
fix(bbr3): Call on_packet_sent when ACK-eliciting data is sent

### DIFF
--- a/noq-proto/src/connection/packet_builder.rs
+++ b/noq-proto/src/connection/packet_builder.rs
@@ -311,6 +311,9 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
                     conn.reset_idle_timeout(now, space_id.kind(), path_id);
                 }
                 conn.path_data_mut(path_id).permit_idle_reset = false;
+                conn.path_data_mut(path_id)
+                    .congestion
+                    .on_packet_sent(now, size, packet_number)
             }
             conn.set_loss_detection_timer(now, path_id);
             conn.path_data_mut(path_id).pacing.on_transmit(size);


### PR DESCRIPTION
## Description

It seems this was missed when this was ported from the upstream
PR. This is different from #657 which was doing this unconditionally,
regardless when the packet needed to be accounted for congestion
control or whether it was ack-eliciting.

I did not continue the tests. It's something extremely specific and
artificial that is being tested. It's like testing everything with a
mock, I'm not sure the value it provides is worth all the stuff that
is setup. Ideally we figure out a better way to test that congestion
controllers actually behave correctly sometime.

## Breaking Changes

none

## Notes & open questions

Replaces #657, I considered taking it over. But this way I can't
approve my own PR.

## Change checklist

- [x] Self-review.