### PR TITLE
fix(multipath): Store abandoned paths in ArrayRangeSet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ socket2 = ">=0.5, <0.7"
 sorted-index-buffer = { version = "0.2.0" }
 test-strategy = "0.4.3"
 thiserror = "2.0.3"
-tinyvec = { version = "1.1", features = ["alloc"] }
+tinyvec = { version = "1.10", features = ["alloc"] }
 tokio = { version = "1.47", features = ["sync"] }
 tracing = { version = "0.1.10", default-features = false, features = ["std"] }
 tracing-futures = { version = "0.2.0", default-features = false, features = ["std-future"] }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2804,7 +2804,7 @@ impl Connection {
         let in_use_count = self
             .local_max_path_id
             .next()
-            .saturating_sub(self.abandoned_paths.len() as u32)
+            .saturating_sub(self.abandoned_paths.len())
             .as_u32();
         let extra_needed = count.get().saturating_sub(in_use_count);
         let new_max_path_id = self.local_max_path_id.saturating_add(extra_needed);

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7221,8 +7221,11 @@ struct AbandonedPaths {
 
 impl AbandonedPaths {
     /// The number of abandoned paths.
-    fn len(&self) -> usize {
-        self.min.map(|p| p.as_u32().saturating_add(1)).unwrap_or(0) as usize + self.set.len()
+    fn len(&self) -> u32 {
+        self.min
+            .map(|p| p.as_u32().saturating_add(1))
+            .unwrap_or(0)
+            .saturating_add(self.set.len() as u32)
     }
 
     /// The largest abandoned path.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7227,7 +7227,7 @@ impl AbandonedPaths {
         self.0.max().map(PathId::from)
     }
 
-    /// Whether the the path is already abandoned.
+    /// Whether the path is already abandoned.
     fn contains(&self, val: &PathId) -> bool {
         self.0.contains(val.as_u32())
     }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3041,7 +3041,7 @@ impl Connection {
                         now,
                         space,
                         path,
-                        newly_acked.len() as u64,
+                        newly_acked.range_count() as u64,
                         ecn,
                         sent,
                         largest_sent_pn,
@@ -7219,7 +7219,7 @@ const ABANDONED_PATH_INLINE_RANGES: usize = 16;
 impl AbandonedPaths {
     /// The number of abandoned paths.
     fn len(&self) -> u32 {
-        self.0.iter().map(|r| r.end - r.start).sum::<u32>()
+        self.0.elts_count()
     }
 
     /// The largest abandoned path.
@@ -7763,7 +7763,7 @@ mod tests {
         t.insert(PathId(0));
         t.insert(PathId(1));
         assert_eq!(t.len(), 2);
-        assert_eq!(t.0.len(), 1); // 2 elements compacted into one range
+        assert_eq!(t.0.range_count(), 1); // 2 elements compacted into one range
         assert!(t.contains(&PathId(0)));
         assert!(t.contains(&PathId(1)));
         assert!(!t.contains(&PathId(2)));
@@ -7772,7 +7772,7 @@ mod tests {
 
         t.insert(PathId(3));
         assert_eq!(t.len(), 3);
-        assert_eq!(t.0.len(), 2); // 3 elements compacted into 2 ranges
+        assert_eq!(t.0.range_count(), 2); // 3 elements compacted into 2 ranges
         assert!(t.contains(&PathId(0)));
         assert!(t.contains(&PathId(1)));
         assert!(!t.contains(&PathId(2)));
@@ -7781,7 +7781,7 @@ mod tests {
 
         t.insert(PathId(2));
         assert_eq!(t.len(), 4);
-        assert_eq!(t.0.len(), 1); // 4 elements compacted into 1 range
+        assert_eq!(t.0.range_count(), 1); // 4 elements compacted into 1 range
         assert!(t.contains(&PathId(0)));
         assert!(t.contains(&PathId(1)));
         assert!(t.contains(&PathId(2)));

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7212,29 +7212,29 @@ impl fmt::Debug for Connection {
 /// space that is constant but proportional to the number of allowed concurrently open
 /// paths.
 #[derive(Debug, Default)]
-struct AbandonedPaths(ArrayRangeSet<ABANDONED_PATH_INLINE_RANGES>);
+struct AbandonedPaths(ArrayRangeSet<ABANDONED_PATH_INLINE_RANGES, u32>);
 
 const ABANDONED_PATH_INLINE_RANGES: usize = 16;
 
 impl AbandonedPaths {
     /// The number of abandoned paths.
     fn len(&self) -> u32 {
-        self.0.iter().map(|r| r.end - r.start).sum::<u64>() as u32
+        self.0.iter().map(|r| r.end - r.start).sum::<u32>()
     }
 
     /// The largest abandoned path.
     fn max(&self) -> Option<PathId> {
-        self.0.max().map(|n| PathId::from(n as u32))
+        self.0.max().map(PathId::from)
     }
 
     /// Whether the the path is already abandoned.
     fn contains(&self, val: &PathId) -> bool {
-        self.0.contains(val.as_u32() as u64)
+        self.0.contains(val.as_u32())
     }
 
     /// Adds another abandoned path.
     fn insert(&mut self, val: PathId) {
-        self.0.insert_one(val.as_u32() as u64);
+        self.0.insert_one(val.as_u32());
     }
 }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7208,9 +7208,9 @@ impl fmt::Debug for Connection {
 
 /// The set of abandoned paths.
 ///
-/// This is a simplistic implementation to keep track of the set of abandoned paths in a
-/// space that is constant but proportional to the number of allowed concurrently open
-/// paths.
+/// Implementation based on ArrayRangeSet to share more code. The memory space is
+/// proportional to the number of concurrently open paths allowed. So does not grow
+/// unbounded.
 #[derive(Debug, Default)]
 struct AbandonedPaths(ArrayRangeSet<ABANDONED_PATH_INLINE_RANGES, u32>);
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7217,7 +7217,7 @@ struct AbandonedPaths(ArrayRangeSet);
 impl AbandonedPaths {
     /// The number of abandoned paths.
     fn len(&self) -> u32 {
-        self.0.elts().count() as u32
+        self.0.iter().map(|r| r.end - r.start).sum::<u64>() as u32
     }
 
     /// The largest abandoned path.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp,
-    collections::{BTreeMap, VecDeque, btree_map},
+    collections::{BTreeMap, BTreeSet, VecDeque, btree_map},
     convert::TryFrom,
     fmt, io, mem,
     net::SocketAddr,
@@ -12,7 +12,7 @@ use bytes::{Bytes, BytesMut};
 use frame::StreamMetaVec;
 
 use rand::{RngExt, SeedableRng, rngs::StdRng};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use thiserror::Error;
 use tracing::{debug, error, trace, trace_span, warn};
 
@@ -305,9 +305,7 @@ pub struct Connection {
     /// They may still have some state left in [`Connection::paths`] or
     /// [`Connection::local_cid_state`] since some of this has to be kept around for some
     /// time after a path is abandoned.
-    // TODO(flub): Make this a more efficient data structure.  Like ranges of abandoned
-    //    paths.  Or a set together with a minimum.  Or something.
-    abandoned_paths: FxHashSet<PathId>,
+    abandoned_paths: AbandonedPaths,
 
     /// State for n0's (<https://n0.computer>) nat traversal protocol.
     n0_nat_traversal: n0_nat_traversal::State,
@@ -568,7 +566,7 @@ impl Connection {
             return Err(PathError::ServerSideNotAllowed);
         }
 
-        let max_abandoned = self.abandoned_paths.iter().max().copied();
+        let max_abandoned = self.abandoned_paths.max();
         let max_used = self.paths.keys().last().copied();
         let path_id = max_abandoned
             .max(max_used)
@@ -7205,6 +7203,54 @@ impl fmt::Debug for Connection {
         f.debug_struct("Connection")
             .field("handshake_cid", &self.handshake_cid)
             .finish()
+    }
+}
+
+/// The set of abandoned paths.
+///
+/// This is a simplistic implementation to keep track of the set of abandoned paths in a
+/// space that is constant but proportional to the number of allowed concurrently open
+/// paths.
+#[derive(Debug, Default)]
+struct AbandonedPaths {
+    /// This and any lower numbered paths have been abandoned.
+    min: Option<PathId>,
+    /// Any abandoned paths which are non-continuous with [`Self::min`].
+    set: BTreeSet<PathId>,
+}
+
+impl AbandonedPaths {
+    /// The number of abandoned paths.
+    fn len(&self) -> usize {
+        self.min.map(|p| p.as_u32().saturating_add(1)).unwrap_or(0) as usize + self.set.len()
+    }
+
+    /// The largest abandoned path.
+    fn max(&self) -> Option<PathId> {
+        self.set.last().copied().or(self.min)
+    }
+
+    /// Whether the the path is already abandoned.
+    fn contains(&self, val: &PathId) -> bool {
+        Some(*val) <= self.min || self.set.contains(val)
+    }
+
+    /// Adds another abandoned path.
+    fn insert(&mut self, val: PathId) {
+        self.set.insert(val);
+        self.compact()
+    }
+
+    /// Compacts the representation of the abandoned paths.
+    fn compact(&mut self) {
+        self.set.retain(|v| match self.min {
+            Some(ref min) if *v <= *min => false,
+            Some(ref mut min) if *v == min.next() => {
+                *min = *v;
+                false
+            }
+            Some(_) | None => true,
+        })
     }
 }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp,
-    collections::{BTreeMap, BTreeSet, VecDeque, btree_map},
+    collections::{BTreeMap, VecDeque, btree_map},
     convert::TryFrom,
     fmt, io, mem,
     net::SocketAddr,
@@ -7212,48 +7212,27 @@ impl fmt::Debug for Connection {
 /// space that is constant but proportional to the number of allowed concurrently open
 /// paths.
 #[derive(Debug, Default)]
-struct AbandonedPaths {
-    /// This and any lower numbered paths have been abandoned.
-    min: Option<PathId>,
-    /// Any abandoned paths which are non-continuous with [`Self::min`].
-    set: BTreeSet<PathId>,
-}
+struct AbandonedPaths(ArrayRangeSet);
 
 impl AbandonedPaths {
     /// The number of abandoned paths.
     fn len(&self) -> u32 {
-        self.min
-            .map(|p| p.as_u32().saturating_add(1))
-            .unwrap_or(0)
-            .saturating_add(self.set.len() as u32)
+        self.0.elts().count() as u32
     }
 
     /// The largest abandoned path.
     fn max(&self) -> Option<PathId> {
-        self.set.last().copied().or(self.min)
+        self.0.max().map(|n| PathId::from(n as u32))
     }
 
     /// Whether the the path is already abandoned.
     fn contains(&self, val: &PathId) -> bool {
-        Some(*val) <= self.min || self.set.contains(val)
+        self.0.contains(val.as_u32() as u64)
     }
 
     /// Adds another abandoned path.
     fn insert(&mut self, val: PathId) {
-        self.set.insert(val);
-        self.compact()
-    }
-
-    /// Compacts the representation of the abandoned paths.
-    fn compact(&mut self) {
-        self.set.retain(|v| match self.min {
-            Some(ref min) if *v <= *min => false,
-            Some(ref mut min) if *v == min.next() => {
-                *min = *v;
-                false
-            }
-            Some(_) | None => true,
-        })
+        self.0.insert_one(val.as_u32() as u64);
     }
 }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2932,7 +2932,7 @@ impl Connection {
         }
 
         // Avoid DoS from unreasonably huge ack ranges by filtering out just the new acks.
-        let mut newly_acked = ArrayRangeSet::new();
+        let mut newly_acked: ArrayRangeSet = ArrayRangeSet::new();
         for range in ack.iter() {
             self.spaces[space].for_path(path).check_ack(range.clone())?;
             for (pn, _) in self.spaces[space]
@@ -7212,7 +7212,9 @@ impl fmt::Debug for Connection {
 /// space that is constant but proportional to the number of allowed concurrently open
 /// paths.
 #[derive(Debug, Default)]
-struct AbandonedPaths(ArrayRangeSet);
+struct AbandonedPaths(ArrayRangeSet<ABANDONED_PATH_INLINE_RANGES>);
+
+const ABANDONED_PATH_INLINE_RANGES: usize = 16;
 
 impl AbandonedPaths {
     /// The number of abandoned paths.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -540,7 +540,7 @@ impl Connection {
     ) -> Result<(PathId, bool), PathError> {
         let existing_open_path = self.paths.iter().find(|(id, path)| {
             network_path.is_probably_same_path(&path.data.network_path)
-                && !self.abandoned_paths.contains(*id)
+                && !self.abandoned_paths.contains(id)
         });
         match existing_open_path {
             Some((path_id, _state)) => Ok((*path_id, true)),

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7214,6 +7214,10 @@ impl fmt::Debug for Connection {
 #[derive(Debug, Default)]
 struct AbandonedPaths(ArrayRangeSet<ABANDONED_PATH_INLINE_RANGES, u32>);
 
+/// Size of the stack-allocated array in the [`ArrayRangeSet`].
+///
+/// A range is 2 u32's, so this is 16 * (4 + 4) = 128 bytes. A good size for inline data,
+/// with plenty of ranges for common multipath use.
 const ABANDONED_PATH_INLINE_RANGES: usize = 16;
 
 impl AbandonedPaths {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -7753,4 +7753,37 @@ mod tests {
             assert_eq!(negotiate_max_idle_timeout(right, left), result);
         }
     }
+
+    #[test]
+    fn abandoned_paths() {
+        let mut t = AbandonedPaths::default();
+
+        t.insert(PathId(0));
+        t.insert(PathId(1));
+        assert_eq!(t.len(), 2);
+        assert_eq!(t.0.len(), 1); // 2 elements compacted into one range
+        assert!(t.contains(&PathId(0)));
+        assert!(t.contains(&PathId(1)));
+        assert!(!t.contains(&PathId(2)));
+        assert!(!t.contains(&PathId(3)));
+        assert_eq!(t.max(), Some(PathId(1)));
+
+        t.insert(PathId(3));
+        assert_eq!(t.len(), 3);
+        assert_eq!(t.0.len(), 2); // 3 elements compacted into 2 ranges
+        assert!(t.contains(&PathId(0)));
+        assert!(t.contains(&PathId(1)));
+        assert!(!t.contains(&PathId(2)));
+        assert!(t.contains(&PathId(3)));
+        assert_eq!(t.max(), Some(PathId(3)));
+
+        t.insert(PathId(2));
+        assert_eq!(t.len(), 4);
+        assert_eq!(t.0.len(), 1); // 4 elements compacted into 1 range
+        assert!(t.contains(&PathId(0)));
+        assert!(t.contains(&PathId(1)));
+        assert!(t.contains(&PathId(2)));
+        assert!(t.contains(&PathId(3)));
+        assert_eq!(t.max(), Some(PathId(3)));
+    }
 }

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -1242,7 +1242,7 @@ impl PendingAcks {
             self.largest_packet = Some((packet, now));
         }
 
-        if self.ranges.len() > MAX_ACK_BLOCKS {
+        if self.ranges.range_count() > MAX_ACK_BLOCKS {
             self.ranges.pop_min();
         }
     }

--- a/noq-proto/src/frame.rs
+++ b/noq-proto/src/frame.rs
@@ -1102,7 +1102,7 @@ impl<'a> Encodable for PathAckEncoder<'a> {
         buf.write(*path_id);
         buf.write_var(largest);
         buf.write_var(*delay);
-        buf.write_var(ranges.len() as u64 - 1);
+        buf.write_var(ranges.range_count() as u64 - 1);
         buf.write_var(first_size - 1);
         let mut prev = first.start;
         for block in rest {
@@ -1201,7 +1201,7 @@ impl<'a> Encodable for AckEncoder<'a> {
         buf.write(kind);
         buf.write_var(largest);
         buf.write_var(*delay);
-        buf.write_var(ranges.len() as u64 - 1);
+        buf.write_var(ranges.range_count() as u64 - 1);
         buf.write_var(first_size - 1);
         let mut prev = first.start;
         for block in rest {

--- a/noq-proto/src/range_set/array_range_set.rs
+++ b/noq-proto/src/range_set/array_range_set.rs
@@ -18,9 +18,11 @@ use tinyvec::TinyVec;
 /// of ranges is usually very low (since ACK numbers are in consecutive fashion
 /// unless reordering or packet loss occur).
 #[derive(Default, PartialEq, Eq)]
-pub(crate) struct ArrayRangeSet(TinyVec<[Range<u64>; ARRAY_RANGE_SET_INLINE_CAPACITY]>);
+pub(crate) struct ArrayRangeSet<const N: usize = ARRAY_RANGE_SET_INLINE_CAPACITY>(
+    TinyVec<[Range<u64>; N]>,
+);
 
-impl fmt::Debug for ArrayRangeSet {
+impl<const N: usize> fmt::Debug for ArrayRangeSet<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('[')?;
         let mut first = true;
@@ -39,9 +41,9 @@ impl fmt::Debug for ArrayRangeSet {
 /// The capacity of elements directly stored in [`ArrayRangeSet`]
 ///
 /// An inline capacity of 2 is chosen to keep `SentFrame` below 128 bytes.
-const ARRAY_RANGE_SET_INLINE_CAPACITY: usize = 2;
+pub(crate) const ARRAY_RANGE_SET_INLINE_CAPACITY: usize = 2;
 
-impl Clone for ArrayRangeSet {
+impl<const N: usize> Clone for ArrayRangeSet<N> {
     fn clone(&self) -> Self {
         // tinyvec keeps the heap representation after clones.
         // We rather prefer the inline representation for clones if possible,
@@ -56,7 +58,7 @@ impl Clone for ArrayRangeSet {
     }
 }
 
-impl ArrayRangeSet {
+impl<const N: usize> ArrayRangeSet<N> {
     pub(crate) fn new() -> Self {
         Default::default()
     }

--- a/noq-proto/src/range_set/array_range_set.rs
+++ b/noq-proto/src/range_set/array_range_set.rs
@@ -77,10 +77,6 @@ where
         self.0.iter().cloned()
     }
 
-    // pub(crate) fn elts(&self) -> impl Iterator<Item = T> + '_ {
-    //     self.iter().flatten()
-    // }
-
     pub(crate) fn len(&self) -> usize {
         self.0.len()
     }

--- a/noq-proto/src/range_set/array_range_set.rs
+++ b/noq-proto/src/range_set/array_range_set.rs
@@ -22,7 +22,7 @@ pub(crate) struct ArrayRangeSet<const N: usize = ARRAY_RANGE_SET_INLINE_CAPACITY
     TinyVec<[Range<T>; N]>,
 );
 
-impl<const N: usize> fmt::Debug for ArrayRangeSet<N> {
+impl<const N: usize, T: fmt::Debug + Default> fmt::Debug for ArrayRangeSet<N, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_char('[')?;
         let mut first = true;

--- a/noq-proto/src/range_set/array_range_set.rs
+++ b/noq-proto/src/range_set/array_range_set.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Write};
-use std::ops::Range;
+use std::ops::{Add, Range, Sub};
 
 use tinyvec::TinyVec;
 
@@ -18,8 +18,8 @@ use tinyvec::TinyVec;
 /// of ranges is usually very low (since ACK numbers are in consecutive fashion
 /// unless reordering or packet loss occur).
 #[derive(Default, PartialEq, Eq)]
-pub(crate) struct ArrayRangeSet<const N: usize = ARRAY_RANGE_SET_INLINE_CAPACITY>(
-    TinyVec<[Range<u64>; N]>,
+pub(crate) struct ArrayRangeSet<const N: usize = ARRAY_RANGE_SET_INLINE_CAPACITY, T: Default = u64>(
+    TinyVec<[Range<T>; N]>,
 );
 
 impl<const N: usize> fmt::Debug for ArrayRangeSet<N> {
@@ -58,24 +58,34 @@ impl<const N: usize> Clone for ArrayRangeSet<N> {
     }
 }
 
-impl<const N: usize> ArrayRangeSet<N> {
+impl<const N: usize, T> ArrayRangeSet<N, T>
+where
+    T: Default
+        + Clone
+        + Copy
+        + PartialOrd
+        + Ord
+        + From<u32>
+        + Add<T, Output = T>
+        + Sub<T, Output = T>,
+{
     pub(crate) fn new() -> Self {
         Default::default()
     }
 
-    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = Range<u64>> + '_ {
+    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = Range<T>> + '_ {
         self.0.iter().cloned()
     }
 
-    pub(crate) fn elts(&self) -> impl Iterator<Item = u64> + '_ {
-        self.iter().flatten()
-    }
+    // pub(crate) fn elts(&self) -> impl Iterator<Item = T> + '_ {
+    //     self.iter().flatten()
+    // }
 
     pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 
-    pub(crate) fn contains(&self, x: u64) -> bool {
+    pub(crate) fn contains(&self, x: T) -> bool {
         for range in self.0.iter() {
             if range.start > x {
                 // We only get here if there was no prior range that contained x
@@ -87,7 +97,7 @@ impl<const N: usize> ArrayRangeSet<N> {
         false
     }
 
-    pub(crate) fn iter_range(&self, range: Range<u64>) -> impl Iterator<Item = Range<u64>> + '_ {
+    pub(crate) fn iter_range(&self, range: Range<T>) -> impl Iterator<Item = Range<T>> + '_ {
         self.iter().filter_map(move |r| {
             if r.end > range.start && r.start < range.end {
                 Some(r.start.max(range.start)..r.end.min(range.end))
@@ -97,11 +107,11 @@ impl<const N: usize> ArrayRangeSet<N> {
         })
     }
 
-    pub(crate) fn insert_one(&mut self, x: u64) -> bool {
-        self.insert(x..x + 1)
+    pub(crate) fn insert_one(&mut self, x: T) -> bool {
+        self.insert(x..x + T::from(1u32))
     }
 
-    pub(crate) fn insert(&mut self, x: Range<u64>) -> bool {
+    pub(crate) fn insert(&mut self, x: Range<T>) -> bool {
         let mut result = false;
 
         if x.is_empty() {
@@ -163,7 +173,7 @@ impl<const N: usize> ArrayRangeSet<N> {
         true
     }
 
-    pub(crate) fn remove(&mut self, x: Range<u64>) -> bool {
+    pub(crate) fn remove(&mut self, x: Range<T>) -> bool {
         let mut result = false;
 
         if x.is_empty() {
@@ -211,7 +221,7 @@ impl<const N: usize> ArrayRangeSet<N> {
         self.0.is_empty()
     }
 
-    pub(crate) fn pop_min(&mut self) -> Option<Range<u64>> {
+    pub(crate) fn pop_min(&mut self) -> Option<Range<T>> {
         if !self.0.is_empty() {
             Some(self.0.remove(0))
         } else {
@@ -219,12 +229,24 @@ impl<const N: usize> ArrayRangeSet<N> {
         }
     }
 
-    pub(crate) fn min(&self) -> Option<u64> {
+    pub(crate) fn min(&self) -> Option<T> {
         self.iter().next().map(|x| x.start)
     }
 
-    pub(crate) fn max(&self) -> Option<u64> {
-        self.iter().next_back().map(|x| x.end - 1)
+    pub(crate) fn max(&self) -> Option<T> {
+        self.iter().next_back().map(|x| x.end - T::from(1))
+    }
+}
+
+/// Functions which need `Range<T>` to impl IntoIterator for u64.
+///
+/// `Range<T>` only implements [`IntoIterator`] for types implementing `std::iter::Step`,
+/// but that trait is unstable. We can work around this by duplicating these functions for
+/// [`u32`] and [`u64`]. Only we don't currently use the u32 version so it is u64-only for
+/// now.
+impl<const N: usize> ArrayRangeSet<N, u64> {
+    pub(crate) fn elts(&self) -> impl Iterator<Item = u64> + '_ {
+        self.iter().flatten()
     }
 }
 

--- a/noq-proto/src/range_set/array_range_set.rs
+++ b/noq-proto/src/range_set/array_range_set.rs
@@ -73,7 +73,6 @@ impl ArrayRangeSet {
         self.0.len()
     }
 
-    #[cfg(test)]
     pub(crate) fn contains(&self, x: u64) -> bool {
         for range in self.0.iter() {
             if range.start > x {

--- a/noq-proto/src/range_set/array_range_set.rs
+++ b/noq-proto/src/range_set/array_range_set.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Write};
+use std::iter::Sum;
 use std::ops::{Add, Range, Sub};
 
 use tinyvec::TinyVec;
@@ -67,7 +68,8 @@ where
         + Ord
         + From<u32>
         + Add<T, Output = T>
-        + Sub<T, Output = T>,
+        + Sub<T, Output = T>
+        + Sum,
 {
     pub(crate) fn new() -> Self {
         Default::default()
@@ -77,8 +79,12 @@ where
         self.0.iter().cloned()
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) fn range_count(&self) -> usize {
         self.0.len()
+    }
+
+    pub(crate) fn elts_count(&self) -> T {
+        self.0.iter().map(|r| r.end - r.start).sum()
     }
 
     pub(crate) fn contains(&self, x: T) -> bool {

--- a/noq-proto/src/range_set/tests.rs
+++ b/noq-proto/src/range_set/tests.rs
@@ -7,7 +7,7 @@ mod array_range_set {
 
     #[test]
     fn merge_and_split() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(2..4));
         assert!(!set.insert(1..3));
@@ -22,7 +22,7 @@ mod array_range_set {
 
     #[test]
     fn double_merge_exact() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
         assert_eq!(set.len(), 2);
@@ -33,7 +33,7 @@ mod array_range_set {
 
     #[test]
     fn single_merge_low() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
         assert_eq!(set.len(), 2);
@@ -44,7 +44,7 @@ mod array_range_set {
 
     #[test]
     fn single_merge_high() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
         assert_eq!(set.len(), 2);
@@ -55,7 +55,7 @@ mod array_range_set {
 
     #[test]
     fn double_merge_wide() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
         assert_eq!(set.len(), 2);
@@ -66,7 +66,7 @@ mod array_range_set {
 
     #[test]
     fn double_remove() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
         assert!(set.remove(1..5));
@@ -76,7 +76,7 @@ mod array_range_set {
 
     #[test]
     fn insert_multiple() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..1));
         assert!(set.insert(2..3));
         assert!(set.insert(4..5));
@@ -86,7 +86,7 @@ mod array_range_set {
 
     #[test]
     fn remove_multiple() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..1));
         assert!(set.insert(2..3));
         assert!(set.insert(4..5));
@@ -96,7 +96,7 @@ mod array_range_set {
 
     #[test]
     fn double_insert() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(!set.insert(0..2));
         assert!(set.insert(2..4));
@@ -110,7 +110,7 @@ mod array_range_set {
 
     #[test]
     fn skip_empty_ranges() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(!set.insert(2..2));
         assert_eq!(set.len(), 0);
         assert!(!set.insert(4..4));
@@ -147,7 +147,7 @@ mod array_range_set {
 
     #[test]
     fn min_max() {
-        let mut set = ArrayRangeSet::new();
+        let mut set: ArrayRangeSet = ArrayRangeSet::new();
         set.insert(1..3);
         set.insert(4..5);
         set.insert(6..10);

--- a/noq-proto/src/range_set/tests.rs
+++ b/noq-proto/src/range_set/tests.rs
@@ -11,11 +11,11 @@ mod array_range_set {
         assert!(set.insert(0..2));
         assert!(set.insert(2..4));
         assert!(!set.insert(1..3));
-        assert_eq!(set.len(), 1);
+        assert_eq!(set.range_count(), 1);
         assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3]);
         assert!(!set.contains(4));
         assert!(set.remove(2..3));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert!(!set.contains(2));
         assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 3]);
     }
@@ -25,9 +25,9 @@ mod array_range_set {
         let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert!(set.insert(2..4));
-        assert_eq!(set.len(), 1);
+        assert_eq!(set.range_count(), 1);
         assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3, 4, 5]);
     }
 
@@ -36,9 +36,9 @@ mod array_range_set {
         let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert!(set.insert(2..3));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 4, 5]);
     }
 
@@ -47,9 +47,9 @@ mod array_range_set {
         let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert!(set.insert(3..4));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 3, 4, 5]);
     }
 
@@ -58,9 +58,9 @@ mod array_range_set {
         let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert!(set.insert(1..5));
-        assert_eq!(set.len(), 1);
+        assert_eq!(set.range_count(), 1);
         assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 1, 2, 3, 4, 5]);
     }
 
@@ -70,7 +70,7 @@ mod array_range_set {
         assert!(set.insert(0..2));
         assert!(set.insert(4..6));
         assert!(set.remove(1..5));
-        assert_eq!(set.len(), 2);
+        assert_eq!(set.range_count(), 2);
         assert_eq!(&set.elts().collect::<Vec<_>>()[..], [0, 5]);
     }
 
@@ -81,7 +81,7 @@ mod array_range_set {
         assert!(set.insert(2..3));
         assert!(set.insert(4..5));
         assert!(set.insert(0..5));
-        assert_eq!(set.len(), 1);
+        assert_eq!(set.range_count(), 1);
     }
 
     #[test]
@@ -105,18 +105,18 @@ mod array_range_set {
         assert!(!set.insert(1..2));
         assert!(!set.insert(1..3));
         assert!(!set.insert(1..4));
-        assert_eq!(set.len(), 1);
+        assert_eq!(set.range_count(), 1);
     }
 
     #[test]
     fn skip_empty_ranges() {
         let mut set: ArrayRangeSet = ArrayRangeSet::new();
         assert!(!set.insert(2..2));
-        assert_eq!(set.len(), 0);
+        assert_eq!(set.range_count(), 0);
         assert!(!set.insert(4..4));
-        assert_eq!(set.len(), 0);
+        assert_eq!(set.range_count(), 0);
         assert!(!set.insert(0..0));
-        assert_eq!(set.len(), 0);
+        assert_eq!(set.range_count(), 0);
     }
 
     #[test]
@@ -176,7 +176,7 @@ mod array_range_set {
     }
 
     fn assert_sets_equal(set: &ArrayRangeSet, reference: &RefRangeSet) {
-        assert_eq!(set.len(), reference.len());
+        assert_eq!(set.range_count(), reference.len());
         assert_eq!(set.is_empty(), reference.is_empty());
         assert_eq!(set.elts().collect::<Vec<_>>()[..], reference.elts()[..]);
     }


### PR DESCRIPTION
## Description

This stores the abandoned paths in an ArrayRangeSet, which results
that the memory is bounded by the number of allowed concurrent
multipath paths.

## Breaking Changes


## Notes & open questions

Mainly for comparison with #688.

- ~~AbandonedPaths::len is kind of sad, needing to construct a full
  iter. Could be optimised to iterate over the ranges only and doing
  the sums of each range end - start. That's probably reasonable.~~
  done now.
  
- ~~All the casts to u32 are a bit unfortunate, but they are correct I
  think.~~ They are gone now that the ArrayRangeSet can contain a u32.
  
- ~~The ARRAY_RANGE_SET_INLINE_CAPACITY (2) is not really a suitable
  value for this use. It'll almost always allocate in practice. This
  could probably be fixed by making it a const generic so we can pick
  a different value for the use here.
  Doing this might give this version an advantage?~~
  This is now done.

- ~~Making the ArrayRangeSet generic over u32 (or PathId) or u64 would
  save space in the inline vec. But some traits range depends on are
  not public or unstable and it's a bit tricky.~~
  done

Question is, which version would we prefer? I've not benchmarked these
against each other, it's hard to say which would be better and
probably doesn't really matter. Memory and allocation wise I don't
think it makes much difference, I think only CPU might be interesting
but suspect it doesn't matter much.

It is kind of nice that the compaction only needs to exist once. I
think this version is more complex but also it's already written. So
I'm undecided.

I'll still add tests, both versions need them anyway.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.