### PR TITLE
refactor(noq)!: early-return error in open_path and open_path_ensure

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -521,7 +521,7 @@ impl Connection {
     /// Opens a new path only if no path on the same network path currently exists.
     ///
     /// Returns `(path_id, true)` if the path already existed, or `(path_id, false)`
-    /// if was opened.
+    /// if it was opened.
     ///
     /// If `network_path` has no local IP set, then this will open a new path
     /// if no path exists for this remote address, independent of the existing

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -380,10 +380,13 @@ impl Connection {
 
     /// Opens a new path if no path exists yet for `network_path`.
     ///
-    /// If `network_path` has no local IP set, then this will open a new path
-    /// if no path exists for this remote address, independent of the existing
-    /// path's local IP. If a local IP is set, it will match against the full
-    /// four-tuple of existing paths.
+    /// If `network_path` has no local IP set, the comparison ignores the local interface and
+    /// matches any open path with the same remote address. If a local IP is set, only paths
+    /// with the same 4-tuple match.
+    ///
+    /// When a matching path is found, the returned future resolves to that existing path:
+    /// either immediately if the path is already established, or once it finishes opening
+    /// otherwise.
     ///
     /// Otherwise behaves exactly as [`open_path`].
     ///
@@ -392,14 +395,11 @@ impl Connection {
         &self,
         network_path: impl Into<FourTuple>,
         initial_status: PathStatus,
-    ) -> OpenPath {
+    ) -> Result<OpenPath, PathError> {
         let network_path = network_path.into();
         let mut state = self.0.lock_and_wake("open_path");
 
-        let network_path = match normalize_network_path(network_path, &state.inner) {
-            Ok(network_path) => network_path,
-            Err(err) => return OpenPath::rejected(err),
-        };
+        let network_path = normalize_network_path(network_path, &state.inner)?;
 
         let now = state.runtime.now();
         let open_res = state
@@ -410,51 +410,47 @@ impl Connection {
                 let recv = state.open_path.get(&path_id).map(|tx| tx.subscribe());
                 drop(state);
                 match recv {
-                    Some(recv) => OpenPath::new(path_id, recv, self.0.clone()),
-                    None => OpenPath::ready(path_id, self.0.clone()),
+                    Some(recv) => Ok(OpenPath::new(path_id, recv, self.0.clone())),
+                    None => Ok(OpenPath::ready(path_id, self.0.clone())),
                 }
             }
             Ok((path_id, _)) => {
                 let (tx, rx) = watch::channel(Ok(()));
                 state.open_path.insert(path_id, tx);
                 drop(state);
-                OpenPath::new(path_id, rx, self.0.clone())
+                Ok(OpenPath::new(path_id, rx, self.0.clone()))
             }
-            Err(err) => OpenPath::rejected(err),
+            Err(err) => Err(err),
         }
     }
 
     /// Opens an additional path if the multipath extension is negotiated.
     ///
-    /// This function takes a [`FourTuple`], which contains the remote address and an optional
-    /// local IP. If the local IP is set, the path will be opened with this source address,
-    /// and the endpoint must support sending from that IP address. You can also pass a
-    /// [`SocketAddr`] to only set the remote address and leave the local IP interface unspecified.
+    /// `network_path` is a [`FourTuple`] of the remote address and an optional local IP. If
+    /// the local IP is set, the path is opened with that source address, and the endpoint
+    /// must support sending from it. A bare [`SocketAddr`] may be passed to leave the local
+    /// interface unspecified.
     ///
-    /// The returned future completes once the path is either fully opened and ready to
-    /// carry application data, or if there was an error.
+    /// Returns `Err` immediately if the path cannot be allocated (for example, multipath is
+    /// not negotiated, the maximum path id is reached, no connection ids are available for
+    /// the new path, or the remote address is unsupported).
     ///
-    /// Dropping the returned future does not cancel the opening of the path, the
+    /// On success, the returned [`OpenPath`] future resolves once the path is fully opened
+    /// and ready to carry application data, or to [`PathError::ValidationFailed`] if path
+    /// validation later fails.
+    ///
+    /// Dropping the returned future does not cancel the opening of the path. The
     /// [`PathEvent::Established`] event will still be emitted from [`Self::path_events`] if
-    /// the path opens.  The [`PathId`] for the events can be extracted from
-    /// [`OpenPath::path_id`].
-    ///
-    /// Failure to open a path can either occur immediately, before polling the returned
-    /// future, or at a later time.  If the failure is immediate [`OpenPath::path_id`] will
-    /// return `None` and the future will be ready immediately.  If the failure happens
-    /// later, a [`PathEvent`] will be emitted.
+    /// the path opens, and the [`PathId`] is available via [`OpenPath::path_id`].
     pub fn open_path(
         &self,
         network_path: impl Into<FourTuple>,
         initial_status: PathStatus,
-    ) -> OpenPath {
+    ) -> Result<OpenPath, PathError> {
         let network_path = network_path.into();
         let mut state = self.0.lock_and_wake("open_path");
 
-        let network_path = match normalize_network_path(network_path, &state.inner) {
-            Ok(network_path) => network_path,
-            Err(err) => return OpenPath::rejected(err),
-        };
+        let network_path = normalize_network_path(network_path, &state.inner)?;
 
         let (on_open_path_send, on_open_path_recv) = watch::channel(Ok(()));
         let now = state.runtime.now();
@@ -463,9 +459,9 @@ impl Connection {
             Ok(path_id) => {
                 state.open_path.insert(path_id, on_open_path_send);
                 drop(state);
-                OpenPath::new(path_id, on_open_path_recv, self.0.clone())
+                Ok(OpenPath::new(path_id, on_open_path_recv, self.0.clone()))
             }
-            Err(err) => OpenPath::rejected(err),
+            Err(err) => Err(err),
         }
     }
 

--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -16,11 +16,12 @@ use tokio_stream::{Stream, wrappers::WatchStream};
 use crate::connection::ConnectionRef;
 use crate::{Runtime, WeakConnectionHandle};
 
-/// Future produced by [`crate::Connection::open_path`]
+/// Future produced by [`crate::Connection::open_path`] and
+/// [`crate::Connection::open_path_ensure`].
 pub struct OpenPath(OpenPathInner);
 
 enum OpenPathInner {
-    /// Opening a path in underway
+    /// Opening a path is underway.
     ///
     /// This might fail later on.
     Ongoing {
@@ -28,12 +29,7 @@ enum OpenPathInner {
         path_id: PathId,
         conn: ConnectionRef,
     },
-    /// Opening a path failed immediately
-    Rejected {
-        /// The error that occurred
-        err: PathError,
-    },
-    /// The path is already open
+    /// The path is already open.
     Ready {
         path_id: PathId,
         conn: ConnectionRef,
@@ -57,21 +53,11 @@ impl OpenPath {
         Self(OpenPathInner::Ready { path_id, conn })
     }
 
-    pub(crate) fn rejected(err: PathError) -> Self {
-        Self(OpenPathInner::Rejected { err })
-    }
-
     /// Returns the path ID of the new path being opened.
-    ///
-    /// If an error occurred before a path ID was allocated, `None` is returned.  In this
-    /// case the future is ready and polling it will immediately yield the error.
-    ///
-    /// The returned value remains the same for the entire lifetime of this future.
-    pub fn path_id(&self) -> Option<PathId> {
+    pub fn path_id(&self) -> PathId {
         match self.0 {
-            OpenPathInner::Ongoing { path_id, .. } => Some(path_id),
-            OpenPathInner::Rejected { .. } => None,
-            OpenPathInner::Ready { path_id, .. } => Some(path_id),
+            OpenPathInner::Ongoing { path_id, .. } => path_id,
+            OpenPathInner::Ready { path_id, .. } => path_id,
         }
     }
 }
@@ -99,7 +85,6 @@ impl Future for OpenPath {
                 path_id,
                 ref mut conn,
             } => Poll::Ready(Ok(Path::new_unchecked(conn.clone(), path_id))),
-            OpenPathInner::Rejected { err } => Poll::Ready(Err(err)),
         }
     }
 }

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1027,10 +1027,10 @@ async fn test_open_path_ensure_existing_path() {
 
         // Re-ensuring the already-established path (PathId::ZERO) takes the
         // `existed` branch in `open_path_ensure`.
-        let fut = conn.open_path_ensure(FourTuple::from_remote(server_addr), PathStatus::Available);
-        let expected_path_id = fut
-            .path_id()
-            .expect("open_path_ensure should allocate or reuse a path id");
+        let fut = conn
+            .open_path_ensure(FourTuple::from_remote(server_addr), PathStatus::Available)
+            .unwrap();
+        let expected_path_id = fut.path_id();
 
         let path = tokio::time::timeout(Duration::from_millis(200), fut)
             .await
@@ -1082,6 +1082,7 @@ async fn test_multipath_observed_address() {
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
         let path = conn
             .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
+            .unwrap()
             .await
             .unwrap();
         let mut reports = path.observed_external_addr().unwrap();
@@ -1295,11 +1296,8 @@ async fn path_clone_stats_after_abandon() {
         // Open a second path, while giving the remote some time to issue cids.
         let path = tokio::time::timeout(Duration::from_secs(1), async {
             loop {
-                match conn
-                    .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
-                    .await
-                {
-                    Ok(path) => break path,
+                match conn.open_path(FourTuple::from_remote(server_addr), PathStatus::Available) {
+                    Ok(opening) => break opening.await.expect("unexpected path open error"),
                     Err(proto::PathError::RemoteCidsExhausted) => {
                         tokio::time::sleep(Duration::from_millis(20)).await;
                     }
@@ -1382,11 +1380,8 @@ async fn closed_includes_path_stats_for_all_known_paths() -> TestResult {
 
         // Open a second path.
         let path2 = loop {
-            match conn
-                .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
-                .await
-            {
-                Ok(p) => break p,
+            match conn.open_path(FourTuple::from_remote(server_addr), PathStatus::Available) {
+                Ok(p) => break p.await?,
                 Err(proto::PathError::RemoteCidsExhausted) => {
                     tokio::time::sleep(Duration::from_millis(20)).await;
                 }
@@ -1496,11 +1491,8 @@ async fn close_path() -> TestResult {
 
         // Open a second path, retrying until remote CIDs are available
         let path = loop {
-            match conn
-                .open_path(FourTuple::from_remote(server_addr), PathStatus::Available)
-                .await
-            {
-                Ok(path) => break path,
+            match conn.open_path(FourTuple::from_remote(server_addr), PathStatus::Available) {
+                Ok(path) => break path.await?,
                 Err(proto::PathError::RemoteCidsExhausted) => {
                     tokio::time::sleep(Duration::from_millis(20)).await;
                 }


### PR DESCRIPTION
## Description

Makes `noq::Connection::open_path` and `noq::Connection::open_path_ensure` return a `Result<OpenPath>`, early-returning the error before constructing the future. This allows us to get rid of a `now_or_never` thingy in iroh where we poll the future once with empty context to see if there was an immediate error. I suspect other users want the same.

And `OpenPath::path_id` can now return the path id unconditionally, which is also nice IMO.

## Breaking Changes

* `noq::Connection::open_path` and `noq::Connection::open_path_ensure` now return `Result<OpenPath, PathError>` instead of `OpenPath`.
* `noq::OpenPath::path_id`  now returns `PathId` instead of `Option<PathId>`

## Notes & open questions

Not sure if it's too late for this breaking change. I prefer the new API. Feel free to close though ofc if we don't want to do breaking changes anymore.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
