### PR TITLE
refactor(proto): simplify AddressDiscovery::Role

### DIFF
--- a/noq-proto/src/address_discovery.rs
+++ b/noq-proto/src/address_discovery.rs
@@ -16,15 +16,24 @@ pub(crate) struct Role {
 
 impl Role {
     pub(crate) const fn send_only() -> Self {
-        Self { send: true, receive: false }
+        Self {
+            send: true,
+            receive: false,
+        }
     }
 
     pub(crate) const fn receive_only() -> Self {
-        Self { send: false, receive: true }
+        Self {
+            send: false,
+            receive: true,
+        }
     }
 
     pub(crate) const fn both() -> Self {
-        Self { send: true, receive: true }
+        Self {
+            send: true,
+            receive: true,
+        }
     }
 }
 

--- a/noq-proto/src/address_discovery.rs
+++ b/noq-proto/src/address_discovery.rs
@@ -7,18 +7,25 @@ use crate::VarInt;
 ///
 /// When enabled, this is reported as a transport parameter.
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
-pub(crate) enum Role {
-    /// Is able to report observer addresses to other peers, but it's not interested in receiving
-    /// reports about its own address.
-    SendOnly,
-    /// Is interested on reports about its own observed address, but will not report back to other
-    /// peers.
-    ReceiveOnly,
-    /// Will both report and receive reports of observed addresses.
-    Both,
-    /// Address discovery is disabled.
-    #[default]
-    Disabled,
+pub(crate) struct Role {
+    /// Whether this peer reports observed addresses to other peers.
+    pub(crate) send: bool,
+    /// Whether this peer wants to receive observed address reports from other peers.
+    pub(crate) receive: bool,
+}
+
+impl Role {
+    pub(crate) const fn send_only() -> Self {
+        Self { send: true, receive: false }
+    }
+
+    pub(crate) const fn receive_only() -> Self {
+        Self { send: false, receive: true }
+    }
+
+    pub(crate) const fn both() -> Self {
+        Self { send: true, receive: true }
+    }
 }
 
 impl TryFrom<VarInt> for Role {
@@ -26,9 +33,9 @@ impl TryFrom<VarInt> for Role {
 
     fn try_from(value: VarInt) -> Result<Self, Self::Error> {
         match value.0 {
-            0 => Ok(Self::SendOnly),
-            1 => Ok(Self::ReceiveOnly),
-            2 => Ok(Self::Both),
+            0 => Ok(Self::send_only()),
+            1 => Ok(Self::receive_only()),
+            2 => Ok(Self::both()),
             _ => Err(crate::transport_parameters::Error::IllegalValue),
         }
     }
@@ -37,90 +44,21 @@ impl TryFrom<VarInt> for Role {
 impl Role {
     /// Whether address discovery is disabled.
     pub(crate) fn is_disabled(&self) -> bool {
-        matches!(self, Self::Disabled)
-    }
-
-    /// Whether this peer's role allows for address reporting to other peers.
-    fn is_reporter(&self) -> bool {
-        matches!(self, Self::SendOnly | Self::Both)
-    }
-
-    /// Whether this peer's role accepts observed address reports.
-    fn receives_reports(&self) -> bool {
-        matches!(self, Self::ReceiveOnly | Self::Both)
+        !self.send && !self.receive
     }
 
     /// Whether this peer should report observed addresses to the other peer.
     pub(crate) fn should_report(&self, other: &Self) -> bool {
-        self.is_reporter() && other.receives_reports()
-    }
-
-    /// Sets whether this peer should provide observed addresses to other peers.
-    pub(crate) fn send_reports_to_peers(&mut self, provide: bool) {
-        if provide {
-            self.enable_sending_reports_to_peers()
-        } else {
-            self.disable_sending_reports_to_peers()
-        }
-    }
-
-    /// Enables sending reports of observed addresses to other peers.
-    fn enable_sending_reports_to_peers(&mut self) {
-        match self {
-            Self::SendOnly => {} // already enabled
-            Self::ReceiveOnly => *self = Self::Both,
-            Self::Both => {} // already enabled
-            Self::Disabled => *self = Self::SendOnly,
-        }
-    }
-
-    /// Disables sending reports of observed addresses to other peers.
-    fn disable_sending_reports_to_peers(&mut self) {
-        match self {
-            Self::SendOnly => *self = Self::Disabled,
-            Self::ReceiveOnly => {} // already disabled
-            Self::Both => *self = Self::ReceiveOnly,
-            Self::Disabled => {} // already disabled
-        }
-    }
-
-    /// Sets whether this peer should accept received reports of observed addresses from other
-    /// peers.
-    pub(crate) fn receive_reports_from_peers(&mut self, receive: bool) {
-        if receive {
-            self.enable_receiving_reports_from_peers()
-        } else {
-            self.disable_receiving_reports_from_peers()
-        }
-    }
-
-    /// Enables receiving reports of observed addresses from other peers.
-    fn enable_receiving_reports_from_peers(&mut self) {
-        match self {
-            Self::SendOnly => *self = Self::Both,
-            Self::ReceiveOnly => {} // already enabled
-            Self::Both => {}        // already enabled
-            Self::Disabled => *self = Self::ReceiveOnly,
-        }
-    }
-
-    /// Disables receiving reports of observed addresses from other peers.
-    fn disable_receiving_reports_from_peers(&mut self) {
-        match self {
-            Self::SendOnly => {} // already disabled
-            Self::ReceiveOnly => *self = Self::Disabled,
-            Self::Both => *self = Self::SendOnly,
-            Self::Disabled => {} // already disabled
-        }
+        self.send && other.receive
     }
 
     /// Gives the [`VarInt`] representing this [`Role`] as a transport parameter.
     pub(crate) fn as_transport_parameter(&self) -> Option<VarInt> {
-        match self {
-            Self::SendOnly => Some(VarInt(0)),
-            Self::ReceiveOnly => Some(VarInt(1)),
-            Self::Both => Some(VarInt(2)),
-            Self::Disabled => None,
+        match (self.send, self.receive) {
+            (false, false) => None,
+            (true, false) => Some(VarInt(0)),
+            (false, true) => Some(VarInt(1)),
+            (true, true) => Some(VarInt(2)),
         }
     }
 }

--- a/noq-proto/src/config/transport.rs
+++ b/noq-proto/src/config/transport.rs
@@ -370,7 +370,7 @@ impl TransportConfig {
     /// This will aid peers in inferring their reachable address, which in most NATd networks
     /// will not be easily available to them.
     pub fn send_observed_address_reports(&mut self, enabled: bool) -> &mut Self {
-        self.address_discovery_role.send_reports_to_peers(enabled);
+        self.address_discovery_role.send = enabled;
         self
     }
 
@@ -381,8 +381,7 @@ impl TransportConfig {
     /// reports cannot be trusted. This, however, can aid the current endpoint in inferring its
     /// reachable address, which in most NATd networks will not be easily available.
     pub fn receive_observed_address_reports(&mut self, enabled: bool) -> &mut Self {
-        self.address_discovery_role
-            .receive_reports_from_peers(enabled);
+        self.address_discovery_role.receive = enabled;
         self
     }
 

--- a/noq-proto/src/connection/qlog.rs
+++ b/noq-proto/src/connection/qlog.rs
@@ -1287,11 +1287,11 @@ impl From<&crate::transport_parameters::PreferredAddress> for PreferredAddress {
 #[cfg(feature = "qlog")]
 impl crate::address_discovery::Role {
     fn to_qlog(self) -> Option<AddressDiscoveryRole> {
-        match self {
-            Self::SendOnly => Some(AddressDiscoveryRole::SendOnly),
-            Self::ReceiveOnly => Some(AddressDiscoveryRole::ReceiveOnly),
-            Self::Both => Some(AddressDiscoveryRole::Both),
-            Self::Disabled => None,
+        match (self.send, self.receive) {
+            (false, false) => None,
+            (true, false) => Some(AddressDiscoveryRole::SendOnly),
+            (false, true) => Some(AddressDiscoveryRole::ReceiveOnly),
+            (true, true) => Some(AddressDiscoveryRole::Both),
         }
     }
 }

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3843,13 +3843,7 @@ fn address_discovery_zero_rtt_accepted() {
 #[test]
 fn address_discovery_zero_rtt_rejection() {
     let _guard = subscribe();
-    let server_cfg = ServerConfig {
-        transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::default(),
-            ..TransportConfig::default()
-        }),
-        ..server_config()
-    };
+    let server_cfg = server_config();
     let alt_server_cfg = ServerConfig {
         transport: Arc::new(TransportConfig {
             address_discovery_role: crate::address_discovery::Role::send_only(),

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3709,7 +3709,7 @@ fn address_discovery() {
 
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             ..TransportConfig::default()
         }),
         ..server_config()
@@ -3717,7 +3717,7 @@ fn address_discovery() {
     let mut pair = Pair::new(Default::default(), server);
     let client_config = ClientConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             ..TransportConfig::default()
         }),
         ..client_config()
@@ -3756,7 +3756,7 @@ fn address_discovery_zero_rtt_accepted() {
     let _guard = subscribe();
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             ..TransportConfig::default()
         }),
         ..server_config()
@@ -3766,14 +3766,14 @@ fn address_discovery_zero_rtt_accepted() {
     pair.server.handle_incoming = Box::new(|_| IncomingConnectionBehavior::Accept);
     let client_cfg = ClientConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             ..TransportConfig::default()
         }),
         ..client_config()
     };
     let alt_client_cfg = ClientConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Disabled,
+            address_discovery_role: crate::address_discovery::Role::default(),
             ..TransportConfig::default()
         }),
         ..client_cfg.clone()
@@ -3845,14 +3845,14 @@ fn address_discovery_zero_rtt_rejection() {
     let _guard = subscribe();
     let server_cfg = ServerConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Disabled,
+            address_discovery_role: crate::address_discovery::Role::default(),
             ..TransportConfig::default()
         }),
         ..server_config()
     };
     let alt_server_cfg = ServerConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::SendOnly,
+            address_discovery_role: crate::address_discovery::Role::send_only(),
             ..TransportConfig::default()
         }),
         ..server_cfg.clone()
@@ -3860,7 +3860,7 @@ fn address_discovery_zero_rtt_rejection() {
     let mut pair = Pair::new(Default::default(), server_cfg);
     let client_cfg = ClientConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             ..TransportConfig::default()
         }),
         ..client_config()
@@ -3913,7 +3913,7 @@ fn address_discovery_retransmission() {
 
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
             ..TransportConfig::default()
@@ -3923,7 +3923,7 @@ fn address_discovery_retransmission() {
     let mut pair = Pair::new(Default::default(), server);
     let client_config = ClientConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
             ..TransportConfig::default()
@@ -3957,7 +3957,7 @@ fn address_discovery_rebind_retransmission() {
 
     let server = ServerConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
             mtu_discovery_config: None,
@@ -3968,7 +3968,7 @@ fn address_discovery_rebind_retransmission() {
     let mut pair = Pair::new(Default::default(), server);
     let client_config = ClientConfig {
         transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::Both,
+            address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
             mtu_discovery_config: None,

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -639,7 +639,7 @@ fn per_path_observed_address() -> TestResult {
     // create the endpoint pair with both address discovery and multipath enabled
     let transport_cfg = TransportConfig {
         max_concurrent_multipath_paths: NonZeroU32::new(MAX_PATHS),
-        address_discovery_role: crate::address_discovery::Role::Both,
+        address_discovery_role: crate::address_discovery::Role::both(),
         ..TransportConfig::default()
     };
     let mut pair = ConnPair::builder()

--- a/noq-proto/src/transport_parameters.rs
+++ b/noq-proto/src/transport_parameters.rs
@@ -145,7 +145,7 @@ macro_rules! make_struct {
                     preferred_address: None,
                     grease_transport_parameter: None,
                     write_order: None,
-                    address_discovery_role: address_discovery::Role::Disabled,
+                    address_discovery_role: address_discovery::Role::default(),
                     initial_max_path_id: None,
                     max_remote_nat_traversal_addresses: None,
                 }
@@ -840,7 +840,7 @@ mod test {
             }),
             grease_quic_bit: true,
             min_ack_delay: Some(2_000u32.into()),
-            address_discovery_role: address_discovery::Role::SendOnly,
+            address_discovery_role: address_discovery::Role::send_only(),
             initial_max_path_id: Some(PathId::MAX),
             max_remote_nat_traversal_addresses: Some(5u8.try_into().unwrap()),
             ..TransportParameters::default()


### PR DESCRIPTION
## Description

This is simply a LOC reduction PR. This is a change the quinn maintainers
wanted and I finally got to do it for when we decide to upstream this. Simple
refactor, nothing fancy. Just less lines of code.

## Breaking Changes


## Notes & open questions


## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
