### PR TITLE
fix(noq-proto): Never emit `PathEvent::Established` after a path has been abandoned

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5045,7 +5045,13 @@ impl Connection {
                                 );
 
                                 if !was_open {
-                                    if is_multipath_negotiated {
+                                    // A PATH_ABANDON for this path may have been received before
+                                    // this PATH_RESPONSE (e.g. if the former was sent over a faster
+                                    // path). Only emit the `Established` event if the path has not
+                                    // been abandoned already.
+                                    if is_multipath_negotiated
+                                        && !self.abandoned_paths.contains(&path_id)
+                                    {
                                         self.events.push_back(Event::Path(
                                             PathEvent::Established { id: path_id },
                                         ));

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1063,10 +1063,13 @@ pub enum PathEvent {
     },
     /// A path was abandoned and is no longer usable.
     ///
+    /// Note that this may be the first event for a path: If a path is abandoned
+    /// before having been validated, no [`Self::Established`] event is emitted.
+    ///
     /// This event will always be followed by [`Self::Discarded`] after some time.
     #[non_exhaustive]
     Abandoned {
-        /// With path was abandoned.
+        /// The path that was abandoned.
         id: PathId,
         /// Reason why this path was abandoned.
         reason: PathAbandonReason,

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1064,7 +1064,7 @@ pub enum PathEvent {
     /// A path was abandoned and is no longer usable.
     ///
     /// Note that this may be the first event for a path: If a path is abandoned
-    /// before having been validated, no [`Self::Established`] event is emitted.
+    /// before having been established, no [`Self::Established`] event is emitted.
     ///
     /// This event will always be followed by [`Self::Discarded`] after some time.
     #[non_exhaustive]

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -606,6 +606,89 @@ fn close_path() -> TestResult {
     Ok(())
 }
 
+/// Regression: We never emit [`PathEvent::Established`] after [`PathEvent::Abandoned`].
+///
+/// It may happen that a PATH_RESPONSE validating a path is received after a
+/// PATH_ABANDON (due to reordering or the different path latencies). We used to
+/// emit a [`PathEvent::Establish`] *after* [`PathEvent::Abandoned`], which makes
+/// no sense. This was fixed, and this test ensures that this doesn't happen again.
+#[test]
+fn no_establish_after_abandon() -> TestResult {
+    let _guard = subscribe();
+    let mut pair = ConnPair::builder().enable_multipath().connect();
+
+    let server_addr = pair.routes.public_server_addr();
+    let path_id = pair.open_path(
+        Client,
+        FourTuple::from_remote(server_addr),
+        PathStatus::Available,
+    )?;
+    assert_ne!(path_id, PathId::ZERO);
+
+    // Client sends PATH_CHALLENGE
+    pair.drive_client();
+    pair.advance_time();
+    // Server receives PATH_CHALLENGE and replies with PATH_RESPONSE and its
+    // own PATH_CHALLENGE. Server has *not* validated the path yet.
+    pair.drive_server();
+    pair.advance_time();
+    // Client receives PATH_RESPONSE and PATH_CHALLENGE. It has now validated
+    // the path, and sends a PATH_RESPONSE. We hold back the packet containing
+    // the PATH_RESPONSE.
+    pair.drive_client();
+    let withheld: Vec<_> = pair.server.inbound.drain(..).collect();
+    assert!(
+        !withheld.is_empty(),
+        "expected the client's PATH_RESPONSE to be in flight"
+    );
+
+    // Now abandon the path on the client and deliver the PATH_ABANDON frame to
+    // the server.
+    pair.close_path(Client, path_id, 0u8.into())?;
+    pair.advance_time();
+    pair.drive_client();
+    pair.drive_server();
+
+    // Now deliver the withheld PATH_RESPONSE. It validates the *already
+    // abandoned* path.
+    for pkt in withheld {
+        pair.server.inbound.push_back(pkt);
+    }
+    pair.advance_time();
+    pair.drive_client();
+    pair.drive_server();
+
+    // On the client, we get Established and then Abandoned
+    assert_matches!(
+        pair.poll(Client),
+        Some(Event::Path(PathEvent::Established { id }))
+        if id == path_id
+    );
+    assert_matches!(
+        pair.poll(Client),
+        Some(Event::Path(PathEvent::Abandoned {
+            id,
+            reason: PathAbandonReason::ApplicationClosed { .. }
+        }))
+        if id == path_id
+    );
+    assert_matches!(pair.poll(Client), None);
+
+    // Server only gets a PathEvent::Abandoned. This is the actual regression test:
+    // Before the fix, we would get a PathEvent::Established after Abandoned.
+    assert_matches!(
+        pair.poll(Server),
+        Some(Event::Path(PathEvent::Abandoned {
+            id,
+            reason: PathAbandonReason::RemoteAbandoned { .. }
+        }))
+        if id == path_id
+    );
+    assert_matches!(pair.poll(Server), None);
+
+    Ok(())
+}
+
 #[test]
 fn close_last_path() -> TestResult {
     let _guard = subscribe();


### PR DESCRIPTION
## Description

This change makes sure that we never emit a `PathEvent::Established` for a path that has already been abandoned.

It may happen that a PATH_RESPONSE frame which validates a path is received after a PATH_ABANDON frame was received for the same path. In this case, before this fix we used to emit a `PathEvent::Established` *after* a `PathEvent::Abandoned`. This ordering makes no sense for applications, and it makes state tracking e.g. for iroh difficult and error-prone.

This PR fixes this by not emitting `PathEvent::Established` for paths that are already abandoned. Comes with a regression test that fails without the fix.


## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.