### PR TITLE
refactor(noq): change the way a disabled token store or token log is represented internally

### DIFF
--- a/noq-proto/src/config/mod.rs
+++ b/noq-proto/src/config/mod.rs
@@ -502,6 +502,12 @@ impl ValidationTokenConfig {
         self
     }
 
+    /// Disable the [`TokenLog`], making the server ignore all address validation tokens
+    pub fn disable_token_log(&mut self) -> &mut Self {
+        self.log = None;
+        self
+    }
+
     /// Number of address validation tokens sent to a client when its path is validated
     ///
     /// This refers only to tokens sent in NEW_TOKEN frames, in contrast to retry tokens.
@@ -601,6 +607,12 @@ impl ClientConfig {
     /// Defaults to [`TokenMemoryCache`], which is suitable for most internet applications.
     pub fn token_store(&mut self, store: Arc<dyn TokenStore>) -> &mut Self {
         self.token_store = Some(store);
+        self
+    }
+
+    /// Disable the [`TokenStore`], so that no validation tokens are stored
+    pub fn disable_token_store(&mut self) -> &mut Self {
+        self.token_store = None;
         self
     }
 

--- a/noq-proto/src/config/mod.rs
+++ b/noq-proto/src/config/mod.rs
@@ -13,8 +13,6 @@ use thiserror::Error;
 
 #[cfg(feature = "bloom")]
 use crate::BloomTokenLog;
-#[cfg(not(feature = "bloom"))]
-use crate::NoneTokenLog;
 #[cfg(all(feature = "rustls", any(feature = "aws-lc-rs", feature = "ring")))]
 use crate::crypto::rustls::{QuicServerConfig, configured_provider};
 use crate::{
@@ -475,7 +473,7 @@ impl fmt::Debug for ServerConfig {
 #[derive(Clone)]
 pub struct ValidationTokenConfig {
     pub(crate) lifetime: Duration,
-    pub(crate) log: Arc<dyn TokenLog>,
+    pub(crate) log: Option<Arc<dyn TokenLog>>,
     pub(crate) sent: u32,
 }
 
@@ -500,7 +498,7 @@ impl ValidationTokenConfig {
     /// which makes the server ignore all address validation tokens (that is, tokens originating
     /// from NEW_TOKEN frames--retry tokens are not affected).
     pub fn log(&mut self, log: Arc<dyn TokenLog>) -> &mut Self {
-        self.log = log;
+        self.log = Some(log);
         self
     }
 
@@ -519,9 +517,9 @@ impl ValidationTokenConfig {
 impl Default for ValidationTokenConfig {
     fn default() -> Self {
         #[cfg(feature = "bloom")]
-        let log = Arc::new(BloomTokenLog::default());
+        let log = Some(Arc::new(BloomTokenLog::default()) as Arc<dyn TokenLog>);
         #[cfg(not(feature = "bloom"))]
-        let log = Arc::new(NoneTokenLog);
+        let log = None;
         Self {
             lifetime: Duration::from_secs(2 * 7 * 24 * 60 * 60),
             log,
@@ -553,7 +551,7 @@ pub struct ClientConfig {
     pub(crate) crypto: Arc<dyn crypto::ClientConfig>,
 
     /// Validation token store to use
-    pub(crate) token_store: Arc<dyn TokenStore>,
+    pub(crate) token_store: Option<Arc<dyn TokenStore>>,
 
     /// Provider that populates the destination connection ID of Initial Packets
     pub(crate) initial_dst_cid_provider: Arc<dyn Fn() -> ConnectionId + Send + Sync>,
@@ -568,7 +566,7 @@ impl ClientConfig {
         Self {
             transport: Default::default(),
             crypto,
-            token_store: Arc::new(TokenMemoryCache::default()),
+            token_store: Some(Arc::new(TokenMemoryCache::default())),
             initial_dst_cid_provider: Arc::new(|| {
                 RandomConnectionIdGenerator::new(MAX_CID_SIZE).generate_cid()
             }),
@@ -602,7 +600,7 @@ impl ClientConfig {
     ///
     /// Defaults to [`TokenMemoryCache`], which is suitable for most internet applications.
     pub fn token_store(&mut self, store: Arc<dyn TokenStore>) -> &mut Self {
-        self.token_store = store;
+        self.token_store = Some(store);
         self
     }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5269,7 +5269,9 @@ impl Connection {
                         return Err(TransportError::FRAME_ENCODING_ERROR("empty token"));
                     }
                     trace!("got new token");
-                    token_store.insert(server_name, token);
+                    if let Some(token_store) = token_store {
+                        token_store.insert(server_name, token);
+                    }
                 }
                 Frame::Datagram(datagram) => {
                     if self
@@ -7347,7 +7349,7 @@ enum ConnectionSide {
     Client {
         /// Sent in every outgoing Initial packet. Always empty after Initial keys are discarded
         token: Bytes,
-        token_store: Arc<dyn TokenStore>,
+        token_store: Option<Arc<dyn TokenStore>>,
         server_name: String,
     },
     Server {
@@ -7379,7 +7381,10 @@ impl From<SideArgs> for ConnectionSide {
                 token_store,
                 server_name,
             } => Self::Client {
-                token: token_store.take(&server_name).unwrap_or_default(),
+                token: token_store
+                    .as_ref()
+                    .and_then(|token_store| token_store.take(&server_name))
+                    .unwrap_or_default(),
                 token_store,
                 server_name,
             },
@@ -7395,7 +7400,7 @@ impl From<SideArgs> for ConnectionSide {
 /// Parameters to `Connection::new` specific to it being client-side or server-side
 pub(crate) enum SideArgs {
     Client {
-        token_store: Arc<dyn TokenStore>,
+        token_store: Option<Arc<dyn TokenStore>>,
         server_name: String,
     },
     Server {

--- a/noq-proto/src/lib.rs
+++ b/noq-proto/src/lib.rs
@@ -101,7 +101,9 @@ pub use crate::cid_generator::{
 
 mod token;
 use token::ResetToken;
-pub use token::{NoneTokenLog, NoneTokenStore, TokenLog, TokenReuseError, TokenStore};
+#[allow(deprecated)]
+pub use token::{NoneTokenLog, NoneTokenStore};
+pub use token::{TokenLog, TokenReuseError, TokenStore};
 
 mod address_discovery;
 

--- a/noq-proto/src/token.rs
+++ b/noq-proto/src/token.rs
@@ -66,8 +66,10 @@ pub trait TokenLog: Send + Sync {
 pub struct TokenReuseError;
 
 /// Null implementation of [`TokenLog`], which never accepts tokens
+#[deprecated(note = "use `ValidationTokenConfig::disable_token_log` instead")]
 pub struct NoneTokenLog;
 
+#[allow(deprecated)]
 impl TokenLog for NoneTokenLog {
     fn check_and_insert(&self, _: u128, _: SystemTime, _: Duration) -> Result<(), TokenReuseError> {
         Err(TokenReuseError)
@@ -92,8 +94,10 @@ pub trait TokenStore: Send + Sync {
 }
 
 /// Null implementation of [`TokenStore`], which does not store any tokens
+#[deprecated(note = "use `ClientConfig::disable_token_store` instead")]
 pub struct NoneTokenStore;
 
+#[allow(deprecated)]
 impl TokenStore for NoneTokenStore {
     fn insert(&self, _: &str, _: Bytes) {}
     fn take(&self, _: &str) -> Option<Bytes> {

--- a/noq-proto/src/token.rs
+++ b/noq-proto/src/token.rs
@@ -170,9 +170,10 @@ impl IncomingToken {
                 {
                     return Ok(unvalidated);
                 }
-                if server_config
-                    .validation_token
-                    .log
+                let Some(log) = &server_config.validation_token.log else {
+                    return Ok(unvalidated);
+                };
+                if log
                     .check_and_insert(retry.nonce, issued, server_config.validation_token.lifetime)
                     .is_err()
                 {

--- a/noq/src/lib.rs
+++ b/noq/src/lib.rs
@@ -65,12 +65,13 @@ pub use proto::{
     ClosedStream, ConfigError, ConnectError, ConnectionClose, ConnectionError, ConnectionId,
     ConnectionIdGenerator, ConnectionStats, DecryptedInitial, Dir, EcnCodepoint, EndpointConfig,
     FourTuple, FrameStats, FrameType, IdleTimeout, InvalidCid, MtuDiscoveryConfig,
-    NetworkChangeHint, NoneTokenLog, NoneTokenStore, PathError, PathEvent, PathId, PathStats,
-    PathStatus, ServerConfig, SetPathStatusError, Side, StdSystemTime, StreamId, TimeSource,
-    TokenLog, TokenMemoryCache, TokenReuseError, TokenStore, Transmit, TransportConfig,
-    TransportErrorCode, UdpStats, ValidationTokenConfig, VarInt, VarIntBoundsExceeded, congestion,
-    crypto,
+    NetworkChangeHint, PathError, PathEvent, PathId, PathStats, PathStatus, ServerConfig,
+    SetPathStatusError, Side, StdSystemTime, StreamId, TimeSource, TokenLog, TokenMemoryCache,
+    TokenReuseError, TokenStore, Transmit, TransportConfig, TransportErrorCode, UdpStats,
+    ValidationTokenConfig, VarInt, VarIntBoundsExceeded, congestion, crypto,
 };
+#[allow(deprecated)]
+pub use proto::{NoneTokenLog, NoneTokenStore};
 #[cfg(feature = "qlog")]
 pub use proto::{QlogConfig, QlogFactory, QlogFileFactory};
 #[cfg(feature = "rustls")]


### PR DESCRIPTION
## Description

Change the way a disabled token store or token log is represented internally from `Arc<dyn Token...>` with a `Noop` impl to `Option<Arc<dyn Token...>>` that is `None`.

This allows the code that uses the store/log to recognise if the mechanism is disabled and to exit early. It also avoids a dyn call to a noop fn, but that is a tiny benefit.

## Breaking Changes

None

## Notes & open questions

Note: the way this is implemented is via deprecating, not removing, the NoopToken... impls, and *adding* a builder fn to disable the store/log. A more idiomatic impl would remove the Noop impls and change the builder setter to take an Option.

Note: Given that neither the token store nor the token log provide much benefit for iroh connections, I would like to disable both in iroh. But since they do provide a lot of benefit for traditional QUIC connections, they would have to be *enabled* by default in noq, as is the case now. So we need a way to clear them.

But the latter would require a breaking change.

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
