### PR TITLE
fix(quic): tail-loss probes in Initial space must be padded

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1592,7 +1592,7 @@ impl Connection {
             last_packet_number = Some(builder.packet_number);
 
             if space_id == SpaceId::Initial
-                && (self.side.is_client() || can_send.is_ack_eliciting())
+                && (self.side.is_client() || can_send.is_ack_eliciting() || needs_loss_probe)
             {
                 // https://www.rfc-editor.org/rfc/rfc9000.html#section-14.1
                 pad_datagram |= PadDatagram::ToMinMtu;

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -4390,3 +4390,44 @@ fn timely_graceful_close() {
     info!(?client_draining_delay);
     assert_eq!(client_draining_delay, ONE_WAY_LATENCY * 2);
 }
+
+/// Server sends correct tail-loss probes for a lost Initial.
+///
+/// The server's first response during the handshake is lost. It should send 2 tail-loss
+/// probes correctly.
+#[test]
+fn initial_tail_loss_probe() {
+    let _guard = subscribe();
+    let (mut pair, client_cfg) = ConnPair::builder().disable_mtud_discovery().build_pair();
+
+    pair.begin_connect(client_cfg);
+    pair.step();
+
+    // Drop the first response by the server.
+    pair.client.inbound.clear();
+    info!("dropped client inbound queue");
+
+    // Neither peers have anything to send right now, but steps time forward to next timeout
+    // which is on the client-side.
+    pair.step();
+
+    // Client PTO fires: sends 2 tail-loss probes, padded because Initial and ack-eliciting.
+    info!("client tail-loss probes");
+    pair.drive_client();
+    assert_eq!(pair.server.inbound.len(), 2,);
+    assert_eq!(pair.server.inbound[0].packet.len(), 1200);
+    assert_eq!(pair.server.inbound[1].packet.len(), 1200);
+
+    // Server PTO fires: sends 2 tail-loss probes in the Initial space, padded because
+    // Initial and ack-eliciting.
+    info!("server tail-loss probes");
+    pair.drive_server();
+    assert_eq!(pair.client.inbound.len(), 2,);
+    assert_eq!(pair.client.inbound[0].packet.len(), 1200,);
+    assert_eq!(pair.client.inbound[1].packet.len(), 1200);
+
+    // Continue until connection established.
+    info!("continue connection establishment");
+    pair.drive();
+    pair.server.assert_accept();
+}

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -485,8 +485,11 @@ impl ConnPairBuilder {
         self
     }
 
-    /// Builds the [`ConnPair`] and connects the two endpoints.
-    pub(super) fn connect(self) -> ConnPair {
+    /// Builds an unconnected [`Pair`] and corresponding [`ClientConfig`].
+    ///
+    /// This is useful if you want to construct a [`ConnPair`] while manually controlling
+    /// the connection establishment. Otherwise [`Self::connect`] should be used.
+    pub(super) fn build_pair(self) -> (Pair, ClientConfig) {
         let Self {
             latency,
             mtu,
@@ -524,6 +527,13 @@ impl ConnPairBuilder {
         if let Some(routes) = routes {
             pair.routes = routes;
         }
+
+        (pair, client_cfg)
+    }
+
+    /// Builds the [`ConnPair`] and connects the two endpoints.
+    pub(super) fn connect(self) -> ConnPair {
+        let (pair, client_cfg) = self.build_pair();
         ConnPair::connect_with(pair, client_cfg)
     }
 }


### PR DESCRIPTION
## Description

When the server sends a tail-loss probe in the Initial space it was not padded to 1200-bytes. However a tail-loss probe is by-definition ack-eliciting, so it MUST be padded to 1200 bytes.

Because of how space_can_send works it does not give us accurate information for tail-loss probes. Which is why this bug occurred. We do want to eventually get rid of space_can_send in #507 which would be a more systematic fix, hence I'm fine with just the simple fix of catering for this exception here.

## Breaking Changes

none

## Notes & open questions

I believe this will effectively fix #690. This is the reason that a packet of an invalid size gets produced.

That issue has a secondary problem that the data scheduled for the 2nd tail-loss probe than does not fit all in the 2nd tail-loss probe. This will also be fixed as a side effect of the first tail-loss probe being padded so the 2nd bug won't trigger.

That 2nd bug of not tracking the exact size needs is also an already known bug that so far doesn't cause too much real-life trouble. It's other symptom is tail-loss probes sending an entire GSO batch of empty packets.

If you inspect the output of the test carefully there are still some inefficient and minor bugs happening after "continue connection establishment". Though none of them seem to be very critical right away.

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
