### PR TITLE
fix(multipath): ignore PATH_RESPONSE once the path is abandoned

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5022,7 +5022,7 @@ impl Connection {
                             .data
                             .on_path_response_received(now, response.0, network_path)
                         {
-                            OnPath { was_open } => {
+                            OnPath { was_open } if !self.abandoned_paths.contains(&path_id) => {
                                 let qlog = self.qlog.with_time(now);
 
                                 self.timers.stop(
@@ -5045,13 +5045,7 @@ impl Connection {
                                 );
 
                                 if !was_open {
-                                    // A PATH_ABANDON for this path may have been received before
-                                    // this PATH_RESPONSE (e.g. if the former was sent over a faster
-                                    // path). Only emit the `Established` event if the path has not
-                                    // been abandoned already.
-                                    if is_multipath_negotiated
-                                        && !self.abandoned_paths.contains(&path_id)
-                                    {
+                                    if is_multipath_negotiated {
                                         self.events.push_back(Event::Path(
                                             PathEvent::Established { id: path_id },
                                         ));
@@ -5074,6 +5068,12 @@ impl Connection {
                                     // re-validate the previous path.
                                     prev.reset_on_path_challenges();
                                 }
+                            }
+                            OnPath { .. } => {
+                                trace!(
+                                    %response,
+                                    "ignoring PATH_RESPONSE received after path is abandoned"
+                                );
                             }
                             Ignored {
                                 sent_on,


### PR DESCRIPTION
## Description

The fix in #695 was only gating emitting the event to the
application. However the entire frame should be ignored: the timers
are already all cancelled when the path is
abandoned (Connection::abandon_path). And this branch *could*
accidentally set a new timer if there are still other path challenges
without a response on the path. Which would then lead to spurious
firing of timers for an abandoned path.

## Breaking Changes

none

## Notes & open questions

I'm choosing to do this in the match branches so that the received
challenge is removed from the `PathData::on_path_challenges_unconfirmed`
field. This probably no longer matters, but it seems tidier than
entirely ignoring the frame.

Follow up to
https://github.com/n0-computer/noq/pull/695/files#r3386765693

I'm hoping the existing test is sufficient. Testing this particular
anomaly would be very tricky as we can't yet inject a custom packet
when we want it.

## Change checklist

- [x] Self-review.