### PR TITLE
fix(qlog): Avoid another panic for an invariant

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2492,15 +2492,12 @@ impl Connection {
                         }
                         PathTimer::LossDetection => {
                             self.on_loss_detection_timeout(now, path_id);
-                            self.qlog.emit_recovery_metrics(
-                                path_id,
-                                &mut self
-                                    .paths
-                                    .get_mut(&path_id)
-                                    .expect("loss-detection timer fires only on live paths")
-                                    .data,
-                                now,
-                            );
+                            if let Some(path) = self.paths.get_mut(&path_id) {
+                                self.qlog
+                                    .emit_recovery_metrics(path_id, &mut path.data, now);
+                            } else {
+                                error!("LossDetection fired for unknown path");
+                            }
                         }
                         PathTimer::PathValidationFailed => {
                             let Some(path) = self.paths.get_mut(&path_id) else {


### PR DESCRIPTION
## Description

We really can not afford these panics for broken
invariants. Especially not in auxiliary code like qlog.

## Breaking Changes

none

## Notes & open questions

none

## Change checklist

- [x] Self-review.