### PR TITLE
deps: update n0-qlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1821,14 +1821,13 @@ dependencies = [
 
 [[package]]
 name = "n0-qlog"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227d9ae7ef1e74f3e9f3e3503b06b58ff507ce754efdc29e4a44af74ad300cc3"
+version = "0.1.1"
+source = "git+https://github.com/n0-computer/n0-qlog?branch=Frando%2Fchase-upstream#6e1d48a31e8ff976a440a4ecbdb311e857ba8c78"
 dependencies = [
+ "humantime",
  "serde",
  "serde_json",
  "serde_with",
- "smallvec",
  "strum",
 ]
 
@@ -1945,7 +1944,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2435,7 +2434,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2494,7 +2493,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2704,9 +2703,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smol"
@@ -2778,18 +2774,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3455,7 +3451,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,8 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "n0-qlog"
-version = "0.1.1"
-source = "git+https://github.com/n0-computer/n0-qlog?branch=Frando%2Fchase-upstream#6e1d48a31e8ff976a440a4ecbdb311e857ba8c78"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1c2fc610d1facce51b0bf5d8245b309c91996a933defdf7742c92ac78a58cb"
 dependencies = [
  "humantime",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4"
 lru-slab = "0.1.2"
 pin-project-lite = "0.2"
 proptest = { version = "1.9.0", default-features = false, features = ["std"] }
-qlog = { package = "n0-qlog", version = "0.1.0", git = "https://github.com/n0-computer/n0-qlog", branch = "Frando/chase-upstream" }
+qlog = { package = "n0-qlog", version = "0.2.0" }
 rand = "0.10"
 rcgen = "0.14"
 ring = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4"
 lru-slab = "0.1.2"
 pin-project-lite = "0.2"
 proptest = { version = "1.9.0", default-features = false, features = ["std"] }
-qlog = { package = "n0-qlog", version = "0.1.0" }
+qlog = { package = "n0-qlog", version = "0.1.0", git = "https://github.com/n0-computer/n0-qlog", branch = "Frando/chase-upstream" }
 rand = "0.10"
 rcgen = "0.14"
 ring = "0.17"

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -770,6 +770,7 @@ impl RecoveryMetrics {
             ssthresh: updated.ssthresh,
             pacing_rate: updated.pacing_rate,
             path_id: Some(path_id.as_u32() as u64),
+            ex_data: Default::default(),
         })
     }
 }

--- a/noq-proto/src/connection/qlog.rs
+++ b/noq-proto/src/connection/qlog.rs
@@ -25,7 +25,7 @@ use qlog::{
     events::{
         ApplicationError, ConnectionClosedFrameError, Event, EventData, RawInfo, TupleEndpointInfo,
         quic::{
-            self, AckedRanges, AddressDiscoveryRole, ConnectionStarted, ErrorSpace, PacketHeader,
+            self, AckRange, AddressDiscoveryRole, ConnectionStarted, ErrorSpace, PacketHeader,
             PacketLost, PacketLostTrigger, PacketReceived, PacketSent, PacketType,
             ParametersRestored, ParametersSet, PreferredAddress, QlogTimerType, QuicFrame,
             StreamType, TimerEventType, TimerType, TimerUpdated, TransportInitiator, TupleAssigned,
@@ -93,6 +93,7 @@ impl QlogStream {
             start_time,
             trace,
             qlog::events::EventImportance::Extra,
+            qlog::streamer::EventTimePrecision::MicroSeconds,
             config.writer,
         );
 
@@ -156,7 +157,7 @@ impl QlogSink {
                 return;
             };
             stream.emit_event(
-                EventData::ConnectionStarted(ConnectionStarted {
+                EventData::QuicConnectionStarted(ConnectionStarted {
                     local: tuple_endpoint_info(local_ip, None, Some(local_cid)),
                     remote: tuple_endpoint_info(
                         Some(remote.ip()),
@@ -168,7 +169,7 @@ impl QlogSink {
             );
 
             let params = transport_params.to_qlog(TransportInitiator::Local);
-            let event = EventData::ParametersSet(params);
+            let event = EventData::QuicParametersSet(Box::new(params));
             stream.emit_event(event, now);
         }
     }
@@ -184,7 +185,7 @@ impl QlogSink {
                 return;
             };
 
-            stream.emit_event(EventData::MetricsUpdated(metrics), now);
+            stream.emit_event(EventData::QuicMetricsUpdated(metrics), now);
         }
     }
 
@@ -219,7 +220,7 @@ impl QlogSink {
                 is_mtu_probe_packet: None,
             };
 
-            stream.emit_event(EventData::PacketLost(event), now);
+            stream.emit_event(EventData::QuicPacketLost(event), now);
         }
     }
 
@@ -230,7 +231,7 @@ impl QlogSink {
                 return;
             };
             let params = conn.peer_params.to_qlog_restored();
-            let event = EventData::ParametersRestored(params);
+            let event = EventData::QuicParametersRestored(params);
             stream.emit_event(event, now);
         }
     }
@@ -242,7 +243,7 @@ impl QlogSink {
                 return;
             };
             let params = conn.peer_params.to_qlog(TransportInitiator::Remote);
-            let event = EventData::ParametersSet(params);
+            let event = EventData::QuicParametersSet(Box::new(params));
             stream.emit_event(event, now);
         }
     }
@@ -266,7 +267,7 @@ impl QlogSink {
                 )),
             };
 
-            stream.emit_event(EventData::TupleAssigned(event), now);
+            stream.emit_event(EventData::QuicTupleAssigned(event), now);
         }
     }
 
@@ -277,7 +278,7 @@ impl QlogSink {
                 return;
             };
             let tuple_id = packet.inner.header.path_id.map(fmt_tuple_id);
-            stream.emit_event_with_tuple_id(EventData::PacketSent(packet.inner), now, tuple_id);
+            stream.emit_event_with_tuple_id(EventData::QuicPacketSent(packet.inner), now, tuple_id);
         }
     }
 
@@ -291,7 +292,7 @@ impl QlogSink {
             packet.emit_padding();
             let tuple_id = packet.inner.header.path_id.map(fmt_tuple_id);
             let event = packet.inner;
-            stream.emit_event_with_tuple_id(EventData::PacketReceived(event), now, tuple_id);
+            stream.emit_event_with_tuple_id(EventData::QuicPacketReceived(event), now, tuple_id);
         }
     }
 
@@ -361,7 +362,7 @@ impl QlogSink {
             event_type,
             delta,
         };
-        stream.emit_event(EventData::TimerUpdated(event), now);
+        stream.emit_event(EventData::QuicTimerUpdated(event), now);
     }
 
     /// Returns a [`QlogSinkWithTime`] that passes along a `now` timestamp.
@@ -448,11 +449,11 @@ impl QlogSentPacket {
     pub(crate) fn frame_padding(&mut self, count: usize) {
         #[cfg(feature = "qlog")]
         self.frame_raw(QuicFrame::Padding {
-            raw: Some(RawInfo {
+            raw: Some(Box::new(RawInfo {
                 length: Some(count as u64),
                 payload_length: Some(count as u64),
                 data: None,
-            }),
+            })),
         });
     }
 
@@ -544,11 +545,11 @@ impl QlogRecvPacket {
                 .frames
                 .get_or_insert_default()
                 .push(QuicFrame::Padding {
-                    raw: Some(RawInfo {
+                    raw: Some(Box::new(RawInfo {
                         length: Some(self.padding as u64),
                         payload_length: Some(self.padding as u64),
                         data: None,
-                    }),
+                    })),
                 });
             self.padding = 0;
         }
@@ -566,12 +567,12 @@ impl<'a> ToQlog for frame::AckEncoder<'a> {
     fn to_qlog(&self) -> QuicFrame {
         QuicFrame::Ack {
             ack_delay: Some(self.delay as f32),
-            acked_ranges: Some(AckedRanges::Double(
+            acked_ranges: Some(
                 self.ranges
                     .iter()
-                    .map(|range| (range.start, range.end))
+                    .map(|range| AckRange::new(range.start, range.end))
                     .collect(),
-            )),
+            ),
             ect1: self.ecn.map(|e| e.ect1),
             ect0: self.ecn.map(|e| e.ect0),
             ce: self.ecn.map(|e| e.ce),
@@ -628,7 +629,7 @@ impl ToQlog for frame::Close {
                     ConnectionClosedFrameError::TransportError(transport_error)
                 });
                 QuicFrame::ConnectionClose {
-                    error_space: Some(ErrorSpace::TransportError),
+                    error_space: Some(ErrorSpace::Transport),
                     error,
                     error_code,
                     reason: String::from_utf8(f.reason.to_vec()).ok(),
@@ -637,7 +638,7 @@ impl ToQlog for frame::Close {
                 }
             }
             Self::Application(f) => QuicFrame::ConnectionClose {
-                error_space: Some(ErrorSpace::ApplicationError),
+                error_space: Some(ErrorSpace::Application),
                 error: None,
                 error_code: Some(f.error_code.into_inner()),
                 reason: String::from_utf8(f.reason.to_vec()).ok(),
@@ -653,10 +654,10 @@ impl ToQlog for frame::Crypto {
     fn to_qlog(&self) -> QuicFrame {
         QuicFrame::Crypto {
             offset: self.offset,
-            raw: Some(RawInfo {
+            raw: Some(Box::new(RawInfo {
                 length: Some(self.data.len() as u64),
                 ..Default::default()
-            }),
+            })),
         }
     }
 }
@@ -665,10 +666,10 @@ impl ToQlog for frame::Crypto {
 impl ToQlog for frame::Datagram {
     fn to_qlog(&self) -> QuicFrame {
         QuicFrame::Datagram {
-            raw: Some(RawInfo {
+            raw: Some(Box::new(RawInfo {
                 length: Some(self.data.len() as u64),
                 ..Default::default()
-            }),
+            })),
         }
     }
 }
@@ -772,7 +773,7 @@ impl ToQlog for frame::NewToken {
             token: qlog::Token {
                 ty: Some(TokenType::Retry),
                 raw: Some(RawInfo {
-                    data: HexSlice::maybe_string(Some(&self.token)),
+                    data: HexSlice::maybe_string(Some(&self.token)).map(Box::new),
                     length: Some(self.token.len() as u64),
                     payload_length: None,
                 }),
@@ -819,12 +820,12 @@ impl ToQlog for frame::PathAckEncoder<'_> {
         QuicFrame::PathAck {
             path_id: self.path_id.as_u32() as u64,
             ack_delay: Some(self.delay as f32),
-            acked_ranges: Some(AckedRanges::Double(
+            acked_ranges: Some(
                 self.ranges
                     .iter()
-                    .map(|range| (range.start, range.end))
+                    .map(|range| AckRange::new(range.start, range.end))
                     .collect(),
-            )),
+            ),
             ect1: self.ecn.map(|e| e.ect1),
             ect0: self.ecn.map(|e| e.ect0),
             ce: self.ecn.map(|e| e.ce),
@@ -981,10 +982,10 @@ impl ToQlog for frame::StreamMetaEncoder {
             stream_id: meta.id.into(),
             offset: Some(meta.offsets.start),
             fin: Some(meta.fin),
-            raw: Some(RawInfo {
+            raw: Some(Box::new(RawInfo {
                 length: Some(meta.offsets.end - meta.offsets.start),
                 ..Default::default()
-            }),
+            })),
         }
     }
 }
@@ -995,18 +996,20 @@ impl Frame {
     pub(crate) fn to_qlog(&self) -> QuicFrame {
         match self {
             Self::Padding => QuicFrame::Padding {
-                raw: Some(RawInfo {
+                raw: Some(Box::new(RawInfo {
                     length: None,
                     payload_length: Some(1),
                     data: None,
-                }),
+                })),
             },
             Self::Ping => frame::Ping.to_qlog(),
             Self::Ack(f) => QuicFrame::Ack {
                 ack_delay: Some(f.delay as f32),
-                acked_ranges: Some(AckedRanges::Double(
-                    f.iter().map(|range| (range.start, range.end)).collect(),
-                )),
+                acked_ranges: Some(
+                    f.iter()
+                        .map(|range| AckRange::new(range.start, range.end))
+                        .collect(),
+                ),
                 ect1: f.ecn.as_ref().map(|e| e.ect1),
                 ect0: f.ecn.as_ref().map(|e| e.ect0),
                 ce: f.ecn.as_ref().map(|e| e.ce),
@@ -1020,10 +1023,10 @@ impl Frame {
                 stream_id: s.id.into(),
                 offset: Some(s.offset),
                 fin: Some(s.fin),
-                raw: Some(RawInfo {
+                raw: Some(Box::new(RawInfo {
                     length: Some(s.data.len() as u64),
                     ..Default::default()
-                }),
+                })),
             },
             Self::MaxData(v) => v.to_qlog(),
             Self::MaxStreamData(f) => f.to_qlog(),
@@ -1058,12 +1061,12 @@ impl Frame {
                 ect0: ack.ecn.as_ref().map(|e| e.ect0),
                 ce: ack.ecn.as_ref().map(|e| e.ce),
                 raw: None,
-                acked_ranges: Some(AckedRanges::Double(
+                acked_ranges: Some(
                     ack.ranges
                         .iter()
-                        .map(|range| (range.start, range.end))
+                        .map(|range| AckRange::new(range.start, range.end))
                         .collect(),
-                )),
+                ),
             },
             Self::PathAbandon(frame) => frame.to_qlog(),
             Self::PathStatusAvailable(frame) => frame.to_qlog(),


### PR DESCRIPTION
## Description

This updates `n0-qlog` to `0.2.0`, which merges in changes from upstream `qlog` and brings us up-to-date to the latest draft standards. See https://github.com/n0-computer/n0-qlog/pull/16 for all changes.

## Change checklist

- [x] Self-review.