### PR TITLE
fix(proto): ObservedAddr retransmission by creating a path-specific retransmittable data queue

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -979,6 +979,10 @@ impl Connection {
         // To open a path locally we need to send a packet on the path. Sending a challenge
         // guarantees this.
         data.pending_on_path_challenge = true;
+        data.pending.observed_address = self
+            .config
+            .address_discovery_role
+            .should_report(&self.peer_params.address_discovery_role);
 
         let path = vacant_entry.insert(PathState { data, prev: None });
 
@@ -3447,7 +3451,7 @@ impl Connection {
                 }
                 self.spaces[pn_space].pending |= info.retransmits;
                 let path = self.path_data_mut(path_id);
-                path.requeue_path_retransmits(&info.path_retransmits);
+                path.pending |= info.path_retransmits;
                 path.mtud.on_non_probe_lost(packet, info.size);
                 path.congestion.on_packet_lost(info.size, packet, now);
 
@@ -5761,6 +5765,10 @@ impl Connection {
             }));
         }
         new_path_data.pending_on_path_challenge = true;
+        new_path_data.pending.observed_address = self
+            .config
+            .address_discovery_role
+            .should_report(&self.peer_params.address_discovery_role);
 
         let mut prev_path_data = mem::replace(&mut path.data, new_path_data);
 
@@ -6203,7 +6211,7 @@ impl Connection {
 
                     self.next_observed_addr_seq_no =
                         self.next_observed_addr_seq_no.saturating_add(1u8);
-                    path.pending_observed_addr = false;
+                    path.pending.observed_address = false;
                 }
             }
         }
@@ -6240,7 +6248,7 @@ impl Connection {
 
                     self.next_observed_addr_seq_no =
                         self.next_observed_addr_seq_no.saturating_add(1u8);
-                    path.pending_observed_addr = false;
+                    path.pending.observed_address = false;
                 }
             }
         }
@@ -6293,11 +6301,7 @@ impl Connection {
         if !scheduling_info.is_abandoned
             && scheduling_info.may_send_data
             && space_id == SpaceId::Data
-            && self
-                .config
-                .address_discovery_role
-                .should_report(&self.peer_params.address_discovery_role)
-            && path.pending_observed_addr
+            && path.pending.observed_address
         {
             let frame =
                 frame::ObservedAddr::new(path.network_path.remote, self.next_observed_addr_seq_no);
@@ -6305,7 +6309,7 @@ impl Connection {
                 builder.write_frame(frame, stats);
 
                 self.next_observed_addr_seq_no = self.next_observed_addr_seq_no.saturating_add(1u8);
-                path.pending_observed_addr = false;
+                path.pending.observed_address = false;
             }
         }
 
@@ -6739,8 +6743,14 @@ impl Connection {
         self.peer_params = params;
         let peer_max_udp_payload_size =
             u16::try_from(self.peer_params.max_udp_payload_size.into_inner()).unwrap_or(u16::MAX);
-        self.path_data_mut(PathId::ZERO)
-            .mtud
+        let address_discovery_negotiated = self
+            .config
+            .address_discovery_role
+            .should_report(&self.peer_params.address_discovery_role);
+
+        let path = self.path_data_mut(PathId::ZERO);
+        path.pending.observed_address = address_discovery_negotiated;
+        path.mtud
             .on_peer_max_udp_payload_size_received(peer_max_udp_payload_size);
     }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -25,8 +25,8 @@ use crate::{
     config::{ServerConfig, TransportConfig},
     congestion::Controller,
     connection::{
-        qlog::{QlogRecvPacket, QlogSink},
         paths::PathRetransmits,
+        qlog::{QlogRecvPacket, QlogSink},
         spaces::LostPacket,
         stats::PathStatsMap,
         timer::{ConnTimer, PathTimer},

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -26,7 +26,8 @@ use crate::{
     congestion::Controller,
     connection::{
         qlog::{QlogRecvPacket, QlogSink},
-        spaces::{LostPacket, PathRetransmits},
+        paths::PathRetransmits,
+        spaces::LostPacket,
         stats::PathStatsMap,
         timer::{ConnTimer, PathTimer},
     },

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2127,7 +2127,7 @@ impl Connection {
         })
     }
 
-    /// Indicate what types of frames are ready to send for the given space.
+    /// Indicate what types of frames are ready to send for the given packet number space.
     ///
     /// Only for on-path data.
     ///
@@ -6964,7 +6964,9 @@ impl Connection {
     /// may need to be sent.
     fn can_send_1rtt(&self, path_id: PathId, max_size: usize) -> SendableFrames {
         let space_specific = self.paths.get(&path_id).is_some_and(|path| {
-            path.data.pending_on_path_challenge || !path.data.path_responses.is_empty()
+            path.data.pending_on_path_challenge
+                || !path.data.path_responses.is_empty()
+                || !path.data.pending.is_empty()
         });
 
         // Stream control frames are checked in PacketSpace::can_send, only check data here.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     congestion::Controller,
     connection::{
         qlog::{QlogRecvPacket, QlogSink},
-        spaces::LostPacket,
+        spaces::{LostPacket, PathRetransmits},
         stats::PathStatsMap,
         timer::{ConnTimer, PathTimer},
     },
@@ -3446,6 +3446,7 @@ impl Connection {
                 }
                 self.spaces[pn_space].pending |= info.retransmits;
                 let path = self.path_data_mut(path_id);
+                path.requeue_path_retransmits(&info.path_retransmits);
                 path.mtud.on_non_probe_lost(packet, info.size);
                 path.congestion.on_packet_lost(info.size, packet, now);
 
@@ -6201,9 +6202,7 @@ impl Connection {
 
                     self.next_observed_addr_seq_no =
                         self.next_observed_addr_seq_no.saturating_add(1u8);
-                    path.observed_addr_sent = true;
-
-                    space.pending.observed_addr = false;
+                    path.pending_observed_addr = false;
                 }
             }
         }
@@ -6240,9 +6239,7 @@ impl Connection {
 
                     self.next_observed_addr_seq_no =
                         self.next_observed_addr_seq_no.saturating_add(1u8);
-                    path.observed_addr_sent = true;
-
-                    space.pending.observed_addr = false;
+                    path.pending_observed_addr = false;
                 }
             }
         }
@@ -6299,7 +6296,7 @@ impl Connection {
                 .config
                 .address_discovery_role
                 .should_report(&self.peer_params.address_discovery_role)
-            && (!path.observed_addr_sent || space.pending.observed_addr)
+            && (!path.pending_observed_addr)
         {
             let frame =
                 frame::ObservedAddr::new(path.network_path.remote, self.next_observed_addr_seq_no);
@@ -6307,9 +6304,7 @@ impl Connection {
                 builder.write_frame(frame, stats);
 
                 self.next_observed_addr_seq_no = self.next_observed_addr_seq_no.saturating_add(1u8);
-                path.observed_addr_sent = true;
-
-                space.pending.observed_addr = false;
+                path.pending_observed_addr = false;
             }
         }
 
@@ -7631,6 +7626,7 @@ const MAX_HANDSHAKE_OR_0RTT_HEADER_SIZE: usize =
 #[derive(Default)]
 struct SentFrames {
     retransmits: ThinRetransmits,
+    path_retransmits: PathRetransmits,
     /// The packet number of the largest acknowledged packet for each path
     largest_acked: FxHashMap<PathId, u64>,
     stream_frames: StreamMetaVec,
@@ -7670,7 +7666,7 @@ impl SentFrames {
             PathResponse(_) => self.non_retransmits = true,
             HandshakeDone(_) => self.retransmits_mut().handshake_done = true,
             ReachOut(frame) => self.retransmits_mut().reach_out.push(frame),
-            ObservedAddr(_) => self.retransmits_mut().observed_addr = true,
+            ObservedAddr(_) => self.path_retransmits.observed_address = true,
             Ping(_) => self.non_retransmits = true,
             ImmediateAck(_) => self.non_retransmits = true,
             AckFrequency(_) => self.retransmits_mut().ack_frequency = true,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -6296,7 +6296,7 @@ impl Connection {
                 .config
                 .address_discovery_role
                 .should_report(&self.peer_params.address_discovery_role)
-            && (!path.pending_observed_addr)
+            && path.pending_observed_addr
         {
             let frame =
                 frame::ObservedAddr::new(path.network_path.remote, self.next_observed_addr_seq_no);

--- a/noq-proto/src/connection/packet_builder.rs
+++ b/noq-proto/src/connection/packet_builder.rs
@@ -293,6 +293,7 @@ impl<'a, 'b> PacketBuilder<'a, 'b> {
             size,
             ack_eliciting,
             retransmits: sent.retransmits,
+            path_retransmits: sent.path_retransmits,
             stream_frames: sent.stream_frames,
         };
 

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1143,7 +1143,7 @@ pub struct ClosedPath {
     pub(super) _private: (),
 }
 
-/// Path-specific retransmittable data lost in a packet.
+/// Retransmittable data specific to a [`Path::generation`].
 #[derive(Debug, Default, Clone)]
 pub(super) struct PathRetransmits {
     /// Whether this path needs to report its remote address back to the peer.

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -220,7 +220,7 @@ pub(super) struct PathData {
     pub(super) in_flight: InFlight,
     /// Whether this path has had it's remote address reported back to the peer. This only happens
     /// if both peers agree to so based on their transport parameters.
-    pub(super) observed_addr_sent: bool,
+    pub(super) pending_observed_addr: bool,
     /// Observed address frame with the largest sequence number received from the peer on this path.
     pub(super) last_observed_addr_report: Option<ObservedAddr>,
     /// The QUIC-MULTIPATH path status
@@ -348,7 +348,7 @@ impl PathData {
                 ),
             first_packet_after_rtt_sample: None,
             in_flight: InFlight::new(),
-            observed_addr_sent: false,
+            pending_observed_addr: true,
             last_observed_addr_report: None,
             status: Default::default(),
             first_packet: None,
@@ -398,7 +398,7 @@ impl PathData {
             mtud: prev.mtud.clone(),
             first_packet_after_rtt_sample: prev.first_packet_after_rtt_sample,
             in_flight: InFlight::new(),
-            observed_addr_sent: false,
+            pending_observed_addr: true,
             last_observed_addr_report: None,
             status: prev.status.clone(),
             first_packet: None,
@@ -651,6 +651,12 @@ impl PathData {
                 Some(addr)
             }
         }
+    }
+
+    /// Handles lost retransmittable data that must be sent over this path.
+    pub(crate) fn requeue_path_retransmits(&mut self, path_retransmits: &super::PathRetransmits) {
+        let super::PathRetransmits { observed_address } = path_retransmits;
+        self.pending_observed_addr |= observed_address;
     }
 
     pub(crate) fn remote_status(&self) -> Option<PathStatus> {

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -218,8 +218,9 @@ pub(super) struct PathData {
     ///
     /// Note that this is across all spaces on this path
     pub(super) in_flight: InFlight,
-    /// Whether this path has had it's remote address reported back to the peer. This only happens
-    /// if both peers agree to so based on their transport parameters.
+    /// Whether this path needs to report its remote address back to the peer.
+    ///
+    /// This only happens if both peers agree to do so based on their transport parameters.
     pub(super) pending_observed_addr: bool,
     /// Observed address frame with the largest sequence number received from the peer on this path.
     pub(super) last_observed_addr_report: Option<ObservedAddr>,

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -654,8 +654,8 @@ impl PathData {
     }
 
     /// Handles lost retransmittable data that must be sent over this path.
-    pub(crate) fn requeue_path_retransmits(&mut self, path_retransmits: &super::PathRetransmits) {
-        let super::PathRetransmits { observed_address } = path_retransmits;
+    pub(crate) fn requeue_path_retransmits(&mut self, path_retransmits: &PathRetransmits) {
+        let PathRetransmits { observed_address } = path_retransmits;
         self.pending_observed_addr |= observed_address;
     }
 
@@ -1171,6 +1171,12 @@ pub enum SetPathStatusError {
 #[error("closed path")]
 pub struct ClosedPath {
     pub(super) _private: (),
+}
+
+/// Path-specific retransmittable data lost in a packet.
+#[derive(Debug, Default, Clone)]
+pub(super) struct PathRetransmits {
+    pub(super) observed_address: bool,
 }
 
 #[cfg(test)]

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -218,11 +218,8 @@ pub(super) struct PathData {
     ///
     /// Note that this is across all spaces on this path
     pub(super) in_flight: InFlight,
-    /// Whether this path needs to report its remote address back to the peer.
-    ///
-    /// This only happens if both peers agree to do so based on their transport parameters.
-    // TODO(@divma): use PathRetransmits directly
-    pub(super) pending_observed_addr: bool,
+    /// Queue of data that must be sent over this specific [`PathData::generation`] path.
+    pub(super) pending: PathRetransmits,
     /// Observed address frame with the largest sequence number received from the peer on this path.
     pub(super) last_observed_addr_report: Option<ObservedAddr>,
     /// The QUIC-MULTIPATH path status
@@ -350,7 +347,7 @@ impl PathData {
                 ),
             first_packet_after_rtt_sample: None,
             in_flight: InFlight::new(),
-            pending_observed_addr: true,
+            pending: PathRetransmits::default(),
             last_observed_addr_report: None,
             status: Default::default(),
             first_packet: None,
@@ -400,7 +397,7 @@ impl PathData {
             mtud: prev.mtud.clone(),
             first_packet_after_rtt_sample: prev.first_packet_after_rtt_sample,
             in_flight: InFlight::new(),
-            pending_observed_addr: true,
+            pending: PathRetransmits::default(),
             last_observed_addr_report: None,
             status: prev.status.clone(),
             first_packet: None,
@@ -653,12 +650,6 @@ impl PathData {
                 Some(addr)
             }
         }
-    }
-
-    /// Handles lost retransmittable data that must be sent over this path.
-    pub(crate) fn requeue_path_retransmits(&mut self, path_retransmits: &PathRetransmits) {
-        let PathRetransmits { observed_address } = path_retransmits;
-        self.pending_observed_addr |= observed_address;
     }
 
     pub(crate) fn remote_status(&self) -> Option<PathStatus> {
@@ -1178,6 +1169,9 @@ pub struct ClosedPath {
 /// Path-specific retransmittable data lost in a packet.
 #[derive(Debug, Default, Clone)]
 pub(super) struct PathRetransmits {
+    /// Whether this path needs to report its remote address back to the peer.
+    ///
+    /// This only happens if both peers agree to do so based on their transport parameters.
     pub(super) observed_address: bool,
 }
 
@@ -1185,6 +1179,13 @@ impl PathRetransmits {
     pub(super) fn is_empty(&self) -> bool {
         let PathRetransmits { observed_address } = self;
         !observed_address
+    }
+}
+
+impl std::ops::BitOrAssign for PathRetransmits {
+    fn bitor_assign(&mut self, rhs: Self) {
+        let Self { observed_address } = rhs;
+        self.observed_address |= observed_address;
     }
 }
 

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1143,7 +1143,7 @@ pub struct ClosedPath {
     pub(super) _private: (),
 }
 
-/// Retransmittable data specific to a [`Path::generation`].
+/// Retransmittable data specific to a [`PathData::generation`].
 #[derive(Debug, Default, Clone)]
 pub(super) struct PathRetransmits {
     /// Whether this path needs to report its remote address back to the peer.

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -221,6 +221,7 @@ pub(super) struct PathData {
     /// Whether this path needs to report its remote address back to the peer.
     ///
     /// This only happens if both peers agree to do so based on their transport parameters.
+    // TODO(@divma): use PathRetransmits directly
     pub(super) pending_observed_addr: bool,
     /// Observed address frame with the largest sequence number received from the peer on this path.
     pub(super) last_observed_addr_report: Option<ObservedAddr>,
@@ -1178,6 +1179,13 @@ pub struct ClosedPath {
 #[derive(Debug, Default, Clone)]
 pub(super) struct PathRetransmits {
     pub(super) observed_address: bool,
+}
+
+impl PathRetransmits {
+    pub(super) fn is_empty(&self) -> bool {
+        let PathRetransmits { observed_address } = self;
+        !observed_address
+    }
 }
 
 #[cfg(test)]

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -1177,7 +1177,7 @@ pub(super) struct PathRetransmits {
 
 impl PathRetransmits {
     pub(super) fn is_empty(&self) -> bool {
-        let PathRetransmits { observed_address } = self;
+        let Self { observed_address } = self;
         !observed_address
     }
 }

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -509,7 +509,7 @@ pub(super) struct LostPacket {
 
 /// Retransmittable data queue.
 ///
-/// Data in this queue must be retransmittable over any path.
+/// Data in this queue must be retransmittable over any path in the same [`SpaceKind`].
 #[allow(unreachable_pub)] // fuzzing only
 #[derive(Debug, Default, Clone)]
 pub struct Retransmits {

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -489,13 +489,22 @@ pub(super) struct SentPacket {
     /// The largest packet number acknowledged by this packet
     pub(super) largest_acked: FxHashMap<PathId, u64>,
     /// Data which needs to be retransmitted in case the packet is lost.
-    /// The data is boxed to minimize `SentPacket` size for the typical case of
-    /// packets only containing ACKs and STREAM frames.
+    ///
+    /// These might be retransmitted over any available path.
     pub(super) retransmits: ThinRetransmits,
+    /// Path-specific data which needs to be retransmitted in case the packet is lost.
+    pub(super) path_retransmits: PathRetransmits,
     /// Metadata for stream frames in a packet
     ///
     /// The actual application data is stored with the stream state.
     pub(super) stream_frames: frame::StreamMetaVec,
+}
+
+/// Data that must be retransmitted over the same path.
+#[derive(Debug, Clone, Default)]
+pub(super) struct PathRetransmits {
+    /// OBSERVED_ADDR frames.
+    pub(super) observed_address: bool,
 }
 
 /// Represents one or more packets that are deemed lost.
@@ -505,7 +514,9 @@ pub(super) struct LostPacket {
     pub(super) time_sent: Instant,
 }
 
-/// Retransmittable data queue
+/// Retransmittable data queue.
+///
+/// Data in this queue must be retransmittable over any path.
 #[allow(unreachable_pub)] // fuzzing only
 #[derive(Debug, Default, Clone)]
 pub struct Retransmits {
@@ -520,7 +531,6 @@ pub struct Retransmits {
     pub(super) retire_cids: Vec<(PathId, u64)>,
     pub(super) ack_frequency: bool,
     pub(super) handshake_done: bool,
-    pub(super) observed_addr: bool,
     /// Whether we should inform the peer we will allow higher [`PathId`]s.
     pub(super) max_path_id: bool,
     /// Whether we should inform the peer that their max [`PathId`] is blocking our attempt to open
@@ -574,7 +584,6 @@ impl Retransmits {
             retire_cids,
             ack_frequency,
             handshake_done,
-            observed_addr,
             max_path_id,
             paths_blocked,
             new_tokens,
@@ -598,7 +607,6 @@ impl Retransmits {
             && retire_cids.is_empty()
             && !ack_frequency
             && !handshake_done
-            && !observed_addr
             && !max_path_id
             && !paths_blocked
             && new_tokens.is_empty()
@@ -625,7 +633,6 @@ impl ::std::ops::BitOrAssign for Retransmits {
             retire_cids,
             ack_frequency,
             handshake_done,
-            observed_addr,
             max_path_id,
             paths_blocked,
             new_tokens,
@@ -654,7 +661,6 @@ impl ::std::ops::BitOrAssign for Retransmits {
         self.retire_cids.extend(retire_cids);
         self.ack_frequency |= ack_frequency;
         self.handshake_done |= handshake_done;
-        self.observed_addr |= observed_addr;
         self.max_path_id |= max_path_id;
         self.paths_blocked |= paths_blocked;
         self.new_tokens.extend_from_slice(&new_tokens);

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -525,7 +525,7 @@ pub(super) struct SentPacket {
     ///
     /// These might be retransmitted over any available path in the same [`SpaceKind`].
     pub(super) retransmits: ThinRetransmits,
-    /// Retransmittable data specific to a [`Path::generation`].
+    /// Retransmittable data specific to a path generation.
     pub(super) path_retransmits: PathRetransmits,
     /// Metadata for stream frames in a packet
     ///

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use sorted_index_buffer::SortedIndexBuffer;
 use tracing::trace;
 
-use super::PathId;
+use super::{PathId, paths::PathRetransmits};
 use crate::{
     Dir, Duration, FourTuple, Instant, StreamId, TransportError, TransportErrorCode, VarInt,
     connection::StreamsState,
@@ -498,13 +498,6 @@ pub(super) struct SentPacket {
     ///
     /// The actual application data is stored with the stream state.
     pub(super) stream_frames: frame::StreamMetaVec,
-}
-
-/// Data that must be retransmitted over the same path.
-#[derive(Debug, Clone, Default)]
-pub(super) struct PathRetransmits {
-    /// OBSERVED_ADDR frames.
-    pub(super) observed_address: bool,
 }
 
 /// Represents one or more packets that are deemed lost.

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -490,7 +490,7 @@ pub(super) struct SentPacket {
     pub(super) largest_acked: FxHashMap<PathId, u64>,
     /// Data which needs to be retransmitted in case the packet is lost.
     ///
-    /// These might be retransmitted over any available path.
+    /// These might be retransmitted over any available path in the same [`SpaceKind`].
     pub(super) retransmits: ThinRetransmits,
     /// Path-specific data which needs to be retransmitted in case the packet is lost.
     pub(super) path_retransmits: PathRetransmits,

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -525,7 +525,7 @@ pub(super) struct SentPacket {
     ///
     /// These might be retransmitted over any available path in the same [`SpaceKind`].
     pub(super) retransmits: ThinRetransmits,
-    /// Path-specific data which needs to be retransmitted in case the packet is lost.
+    /// Retransmittable data specific to a [`Path::generation`].
     pub(super) path_retransmits: PathRetransmits,
     /// Metadata for stream frames in a packet
     ///

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3918,10 +3918,9 @@ fn address_discovery_retransmission() {
         .stats()
         .frame_tx
         .observed_addr;
-    assert_eq!(sent_frames, 1, "server should have sent OBSERVED_ADDR once");
+    assert_eq!(sent_frames, 1);
 
-    // Drop the in-flight datagram(s) carrying the OBSERVED_ADDR frame so the client never sees
-    // them, forcing the server to retransmit it.
+    // Drop in-flight datagrams to force retransmission
     pair.client.inbound.clear();
 
     pair.drive();
@@ -3931,50 +3930,29 @@ fn address_discovery_retransmission() {
         .stats()
         .frame_tx
         .observed_addr;
-    assert_eq!(
-        resent_frames, 2,
-        "server should have retransmitted OBSERVED_ADDR once"
-    );
+    assert_eq!(resent_frames, 2,);
+
     let received_frames = pair
         .client_conn_mut(server_ch)
         .stats()
         .frame_rx
         .observed_addr;
-
     assert_eq!(received_frames, 1);
 
-    let expected_addr = pair.routes.as_basic().client_addr;
-    let conn = pair.client_conn_mut(client_ch);
-    let mut extra = vec![];
-    conn.poll_until(
-        |e| matches!(e, Event::HandshakeDataReady),
-        "client HandshakeDataReady",
-        &mut extra,
-    );
-    conn.poll_until(
-        |e| matches!(e, Event::Connected),
-        "client Connected",
-        &mut extra,
-    );
-    conn.poll_until(
-        |e| matches!(e, Event::HandshakeConfirmed),
-        "client HandshakeConfirmed",
-        &mut extra,
-    );
-    while let Some(e) = conn.poll() {
-        extra.push(e);
-    }
+    let (mut client_events, _server_events) = pair.lax_finish_connect(client_ch, server_ch);
+    pair.client_conn_mut(client_ch)
+        .poll_until_none(|_| true, &mut client_events);
 
-    let mut extra = extra.iter().filter_map(|e| match e {
+    let mut reports = client_events.iter().filter_map(|e| match e {
         Event::Path(PathEvent::ObservedAddr { id, addr }) => Some((*id, *addr)),
         _ => None,
     });
+
     assert_eq!(
-        extra.next().unwrap(),
-        (PathId::ZERO, expected_addr),
-        "expected retransmitted ObservedAddr for {expected_addr}"
+        reports.next().unwrap(),
+        (PathId::ZERO, pair.routes.as_basic().client_addr),
     );
-    assert!(extra.next().is_none());
+    assert!(reports.next().is_none());
 }
 
 #[test]

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3950,34 +3950,38 @@ fn address_discovery_retransmission() {
 fn address_discovery_rebind_retransmission() {
     let _guard = subscribe();
 
-    let (mut pair, _client_events, _server_events) = ConnPair::builder()
+    let (mut pair, client_cfg) = ConnPair::builder()
         .with_transport_cfg(TransportConfig {
             address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
             ..TransportConfig::default()
         })
-        .disable_mtud_discovery()
-        .lax_connect();
+        .build_pair();
+    let client_ch = pair.begin_connect(client_cfg);
 
-    let sent_before = pair.stats(Server).frame_tx.observed_addr;
-    let received_before = pair.stats(Client).frame_rx.observed_addr;
-    assert!(
-        sent_before > 0,
-        "server should have sent OBSERVED_ADDR before the rebind"
-    );
+    pair.step();
+    let server_ch = pair.server.assert_accept();
 
-    // rebind: the server must observe the new address and send an updated OBSERVED_ADDR
-    // rather than retransmitting the stale one from before the rebind
-    let time = pair.time;
-    pair.conn_mut(Client).handle_network_change(None, time);
-    let client_addr = pair.routes.as_basic_mut().passive_migration(Client);
+    let mut pair = ConnPair::new(pair, client_ch, server_ch);
+
+    while pair.stats(Server).frame_tx.observed_addr == 0 {
+        pair.step();
+    }
+
+    // Drop in-flight datagrams to force retransmission, and migrate to check the report isn't stale
+    pair.client.inbound.clear();
+    // let stale_addr = pair.routes.as_basic().client_addr;
+    let fresh_addr = pair.routes.as_basic_mut().passive_migration(Client);
+    // let time = pair.time;
+    // pair.conn_mut(Client).handle_network_change(None, time);
+    // assert_ne!(stale_addr, fresh_addr);
 
     pair.drive();
 
-    // Exactly one fresh OBSERVED_ADDR for the new address, no stale retransmissions.
-    assert_eq!(pair.stats(Server).frame_tx.observed_addr, sent_before + 1);
-    assert_eq!(pair.stats(Client).frame_rx.observed_addr, received_before + 1);
+    // Sent twice but received once.
+    assert_eq!(pair.stats(Server).frame_tx.observed_addr, 2);
+    assert_eq!(pair.stats(Client).frame_rx.observed_addr, 1);
 
     let mut reports = Vec::default();
     pair.conn_mut(Client).poll_until_none(
@@ -3992,8 +3996,7 @@ fn address_discovery_rebind_retransmission() {
 
     assert_eq!(
         reports.next().unwrap(),
-        (PathId::ZERO, client_addr),
-        "expected updated ObservedAddr for new address {client_addr}"
+        (PathId::ZERO, pair.routes.as_basic().client_addr),
     );
     assert!(reports.next().is_none());
 }

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3948,40 +3948,50 @@ fn address_discovery_retransmission() {
 
 #[test]
 fn address_discovery_rebind_retransmission() {
+    // NOTE: unlike `address_discovery_retransmission`, in which we drop packets even if during the
+    // handshake, `address_discovery_rebind_retransmission` needs to also migrate. Migrating and
+    // dropping packets causes any incoming packets from the client to the server to be dicarded,
+    // which ultimately prevents the connection from being established.
+    //
+    // Instead, for this test, we drop in-flight data and migrate after the handshake has been
+    // confirmed.
+
     let _guard = subscribe();
 
-    let (mut pair, client_cfg) = ConnPair::builder()
+    // we don't care about extra events, just that the connection is established.
+    let (mut pair, _, _) = ConnPair::builder()
         .with_transport_cfg(TransportConfig {
             address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
             ..TransportConfig::default()
         })
-        .build_pair();
-    let client_ch = pair.begin_connect(client_cfg);
+        .lax_connect();
 
+    // Drain any remaining events
+    while pair.poll(Client).is_some() {}
+
+    let prev_sent = pair.stats(Server).frame_tx.observed_addr;
+    // This implementation sends address discovery reports with path challenges, so start a path
+    // validation attempt that will produce the frame we will later drop
+    pair.conn_mut(Server).trigger_path_validation();
     pair.step();
-    let server_ch = pair.server.assert_accept();
+    assert_eq!(pair.stats(Server).frame_tx.observed_addr, prev_sent + 1);
 
-    let mut pair = ConnPair::new(pair, client_ch, server_ch);
-
-    while pair.stats(Server).frame_tx.observed_addr == 0 {
-        pair.step();
-    }
-
-    // Drop in-flight datagrams to force retransmission, and migrate to check the report isn't stale
     pair.client.inbound.clear();
-    // let stale_addr = pair.routes.as_basic().client_addr;
+
+    let stale_addr = pair.routes.as_basic().client_addr;
     let fresh_addr = pair.routes.as_basic_mut().passive_migration(Client);
-    // let time = pair.time;
-    // pair.conn_mut(Client).handle_network_change(None, time);
-    // assert_ne!(stale_addr, fresh_addr);
+    pair.handle_network_change(Client, None);
+    assert_ne!(stale_addr, fresh_addr);
 
     pair.drive();
 
-    // Sent twice but received once.
-    assert_eq!(pair.stats(Server).frame_tx.observed_addr, 2);
-    assert_eq!(pair.stats(Client).frame_rx.observed_addr, 1);
+    assert!(pair.stats(Server).frame_tx.observed_addr >= prev_sent + 2);
+    assert_eq!(
+        pair.stats(Client).frame_rx.observed_addr + 1, // + 1 for the lost frame
+        pair.stats(Server).frame_tx.observed_addr
+    );
 
     let mut reports = Vec::default();
     pair.conn_mut(Client).poll_until_none(

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3927,21 +3927,40 @@ fn address_discovery_retransmission() {
     let client_ch = pair.begin_connect(client_config);
     pair.step();
 
-    // lose the last packet
-    pair.client.inbound.pop_back().unwrap();
-    pair.step();
-    let conn = pair.client_conn_mut(client_ch);
-    assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
-    assert_matches!(conn.poll(), Some(Event::Connected));
-    assert_matches!(conn.poll(), None);
-
+    // clear ALL server→client packets so OBSERVED_ADDR must arrive via retransmission,
+    // regardless of whether it was coalesced into the first or second datagram
+    pair.client.inbound.clear();
     pair.drive();
+
     let conn = pair.client_conn_mut(client_ch);
-    assert_matches!(conn.poll(), Some(Event::HandshakeConfirmed));
-    assert_matches!(
-        conn.poll(),
-        Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
-            if addr == pair.routes.as_basic().client_addr
+    let mut extra = vec![];
+    conn.poll_until(
+        |e| matches!(e, Event::HandshakeDataReady),
+        "client HandshakeDataReady",
+        &mut extra,
+    );
+    conn.poll_until(
+        |e| matches!(e, Event::Connected),
+        "client Connected",
+        &mut extra,
+    );
+    conn.poll_until(
+        |e| matches!(e, Event::HandshakeConfirmed),
+        "client HandshakeConfirmed",
+        &mut extra,
+    );
+    while let Some(e) = conn.poll() {
+        extra.push(e);
+    }
+
+    let expected_addr = pair.routes.as_basic().client_addr;
+    assert!(
+        extra.iter().any(|e| matches!(
+            e,
+            Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, addr })
+                if *addr == expected_addr
+        )),
+        "expected retransmitted ObservedAddr for {expected_addr}"
     );
 }
 
@@ -3970,30 +3989,29 @@ fn address_discovery_rebind_retransmission() {
         }),
         ..client_config()
     };
-    let client_ch = pair.begin_connect(client_config);
-    pair.step();
+    let (client_ch, _, _, _) = pair.lax_connect_with(client_config);
 
-    // lose the last packet
-    pair.client.inbound.pop_back().unwrap();
-    pair.step();
-    let conn = pair.client_conn_mut(client_ch);
-    assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
-    assert_matches!(conn.poll(), Some(Event::Connected));
-    assert_matches!(conn.poll(), None);
-
-    // simulate a rebind to ensure we will get an updated address instead of retransmitting
-    // outdated info
+    // rebind: the server must observe the new address and send an updated OBSERVED_ADDR
+    // rather than retransmitting the stale one from before the rebind
     let time = pair.time;
     pair.client_conn_mut(client_ch)
         .handle_network_change(None, time);
     let client_addr = pair.routes.as_basic_mut().passive_migration(Client);
 
     pair.drive();
+
     let conn = pair.client_conn_mut(client_ch);
-    assert_matches!(conn.poll(), Some(Event::HandshakeConfirmed));
+    let mut extra = vec![];
+    while let Some(e) = conn.poll() {
+        extra.push(e);
+    }
+
+    let obs = extra
+        .into_iter()
+        .find(|e| matches!(e, Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, .. })));
     assert_matches!(
-        conn.poll(),
-        Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
+        obs,
+        Some(Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, addr }))
             if addr == client_addr
     );
 }

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3950,7 +3950,7 @@ fn address_discovery_retransmission() {
 fn address_discovery_rebind_retransmission() {
     // NOTE: unlike `address_discovery_retransmission`, in which we drop packets even if during the
     // handshake, `address_discovery_rebind_retransmission` needs to also migrate. Migrating and
-    // dropping packets causes any incoming packets from the client to the server to be dicarded,
+    // dropping packets causes any incoming packets from the client to the server to be discarded,
     // which ultimately prevents the connection from being established.
     //
     // Instead, for this test, we drop in-flight data and migrate after the handshake has been

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3900,33 +3900,50 @@ fn address_discovery_zero_rtt_rejection() {
 fn address_discovery_retransmission() {
     let _guard = subscribe();
 
-    let server = ServerConfig {
-        transport: Arc::new(TransportConfig {
+    let (mut pair, client_cfg) = ConnPair::builder()
+        .with_transport_cfg(TransportConfig {
             address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
             ..TransportConfig::default()
-        }),
-        ..server_config()
-    };
-    let mut pair = Pair::new(Default::default(), server);
-    let client_config = ClientConfig {
-        transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::both(),
-            // Assume a low-latency connection so pacing doesn't interfere with the test
-            initial_rtt: Duration::from_millis(10),
-            ..TransportConfig::default()
-        }),
-        ..client_config()
-    };
-    let client_ch = pair.begin_connect(client_config);
-    pair.step();
+        })
+        .build_pair();
+    let client_ch = pair.begin_connect(client_cfg);
 
-    // clear ALL server→client packets so OBSERVED_ADDR must arrive via retransmission,
-    // regardless of whether it was coalesced into the first or second datagram
+    pair.step();
+    let server_ch = pair.server.assert_accept();
+
+    let sent_frames = pair
+        .server_conn_mut(server_ch)
+        .stats()
+        .frame_tx
+        .observed_addr;
+    assert_eq!(sent_frames, 1, "server should have sent OBSERVED_ADDR once");
+
+    // Drop the in-flight datagram(s) carrying the OBSERVED_ADDR frame so the client never sees
+    // them, forcing the server to retransmit it.
     pair.client.inbound.clear();
+
     pair.drive();
 
+    let resent_frames = pair
+        .server_conn_mut(server_ch)
+        .stats()
+        .frame_tx
+        .observed_addr;
+    assert_eq!(
+        resent_frames, 2,
+        "server should have retransmitted OBSERVED_ADDR once"
+    );
+    let received_frames = pair
+        .client_conn_mut(server_ch)
+        .stats()
+        .frame_rx
+        .observed_addr;
+
+    assert_eq!(received_frames, 1);
+
+    let expected_addr = pair.routes.as_basic().client_addr;
     let conn = pair.client_conn_mut(client_ch);
     let mut extra = vec![];
     conn.poll_until(
@@ -3948,15 +3965,16 @@ fn address_discovery_retransmission() {
         extra.push(e);
     }
 
-    let expected_addr = pair.routes.as_basic().client_addr;
-    assert!(
-        extra.iter().any(|e| matches!(
-            e,
-            Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, addr })
-                if *addr == expected_addr
-        )),
+    let mut extra = extra.iter().filter_map(|e| match e {
+        Event::Path(PathEvent::ObservedAddr { id, addr }) => Some((*id, *addr)),
+        _ => None,
+    });
+    assert_eq!(
+        extra.next().unwrap(),
+        (PathId::ZERO, expected_addr),
         "expected retransmitted ObservedAddr for {expected_addr}"
     );
+    assert!(extra.next().is_none());
 }
 
 #[test]
@@ -4001,9 +4019,15 @@ fn address_discovery_rebind_retransmission() {
         extra.push(e);
     }
 
-    let obs = extra
-        .into_iter()
-        .find(|e| matches!(e, Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, .. })));
+    let obs = extra.into_iter().find(|e| {
+        matches!(
+            e,
+            Event::Path(PathEvent::ObservedAddr {
+                id: PathId::ZERO,
+                ..
+            })
+        )
+    });
     assert_matches!(
         obs,
         Some(Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, addr }))

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3950,58 +3950,52 @@ fn address_discovery_retransmission() {
 fn address_discovery_rebind_retransmission() {
     let _guard = subscribe();
 
-    let server = ServerConfig {
-        transport: Arc::new(TransportConfig {
+    let (mut pair, _client_events, _server_events) = ConnPair::builder()
+        .with_transport_cfg(TransportConfig {
             address_discovery_role: crate::address_discovery::Role::both(),
             // Assume a low-latency connection so pacing doesn't interfere with the test
             initial_rtt: Duration::from_millis(10),
-            mtu_discovery_config: None,
             ..TransportConfig::default()
-        }),
-        ..server_config()
-    };
-    let mut pair = Pair::new(Default::default(), server);
-    let client_config = ClientConfig {
-        transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::both(),
-            // Assume a low-latency connection so pacing doesn't interfere with the test
-            initial_rtt: Duration::from_millis(10),
-            mtu_discovery_config: None,
-            ..TransportConfig::default()
-        }),
-        ..client_config()
-    };
-    let (client_ch, _, _, _) = pair.lax_connect_with(client_config);
+        })
+        .disable_mtud_discovery()
+        .lax_connect();
+
+    let sent_before = pair.stats(Server).frame_tx.observed_addr;
+    let received_before = pair.stats(Client).frame_rx.observed_addr;
+    assert!(
+        sent_before > 0,
+        "server should have sent OBSERVED_ADDR before the rebind"
+    );
 
     // rebind: the server must observe the new address and send an updated OBSERVED_ADDR
     // rather than retransmitting the stale one from before the rebind
     let time = pair.time;
-    pair.client_conn_mut(client_ch)
-        .handle_network_change(None, time);
+    pair.conn_mut(Client).handle_network_change(None, time);
     let client_addr = pair.routes.as_basic_mut().passive_migration(Client);
 
     pair.drive();
 
-    let conn = pair.client_conn_mut(client_ch);
-    let mut extra = vec![];
-    while let Some(e) = conn.poll() {
-        extra.push(e);
-    }
+    // Exactly one fresh OBSERVED_ADDR for the new address, no stale retransmissions.
+    assert_eq!(pair.stats(Server).frame_tx.observed_addr, sent_before + 1);
+    assert_eq!(pair.stats(Client).frame_rx.observed_addr, received_before + 1);
 
-    let obs = extra.into_iter().find(|e| {
-        matches!(
-            e,
-            Event::Path(PathEvent::ObservedAddr {
-                id: PathId::ZERO,
-                ..
-            })
-        )
-    });
-    assert_matches!(
-        obs,
-        Some(Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, addr }))
-            if addr == client_addr
+    let mut reports = Vec::default();
+    pair.conn_mut(Client).poll_until_none(
+        |e| matches!(e, Event::Path(PathEvent::ObservedAddr { .. })),
+        &mut reports,
     );
+
+    let mut reports = reports.iter().filter_map(|e| match e {
+        Event::Path(PathEvent::ObservedAddr { id, addr }) => Some((*id, *addr)),
+        _ => None,
+    });
+
+    assert_eq!(
+        reports.next().unwrap(),
+        (PathId::ZERO, client_addr),
+        "expected updated ObservedAddr for new address {client_addr}"
+    );
+    assert!(reports.next().is_none());
 }
 
 /// Non-multipath: handle_network_change pings for liveness and rotates the CID

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3707,44 +3707,39 @@ fn voluntary_ack_with_large_datagrams() {
 fn address_discovery() {
     let _guard = subscribe();
 
-    let server = ServerConfig {
-        transport: Arc::new(TransportConfig {
+    // Create the connections accumulating events not related to connection establishment.
+    let (mut pair, mut c_events, mut s_events) = ConnPair::builder()
+        .with_transport_cfg(TransportConfig {
             address_discovery_role: crate::address_discovery::Role::both(),
             ..TransportConfig::default()
-        }),
-        ..server_config()
-    };
-    let mut pair = Pair::new(Default::default(), server);
-    let client_config = ClientConfig {
-        transport: Arc::new(TransportConfig {
-            address_discovery_role: crate::address_discovery::Role::both(),
-            ..TransportConfig::default()
-        }),
-        ..client_config()
-    };
-    let conn_handle = pair.begin_connect(client_config);
+        })
+        .lax_connect();
 
     // wait for idle connections
     pair.drive();
 
-    // check that the client received the correct address
-    let expected_addr = pair.routes.as_basic().client_addr;
-    let conn = pair.client_conn_mut(conn_handle);
-    assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
-    assert_matches!(conn.poll(), Some(Event::Connected));
-    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
-    assert_matches!(conn.poll(), Some(Event::HandshakeConfirmed));
-    assert_matches!(conn.poll(), None);
+    // Depending on handshake size, ObservedAddr reports might arrive before or after the handshake
+    // is confirmed. Gather all events to account for that.
+    let keep = |e: &Event| matches!(e, &Event::Path(PathEvent::ObservedAddr { .. }));
+    pair.conn_mut(Client).poll_until_none(keep, &mut c_events);
+    pair.conn_mut(Server).poll_until_none(keep, &mut s_events);
 
-    // check that the server received the correct address
-    let conn_handle = pair.server.assert_accept();
-    let expected_addr = pair.routes.as_basic().server_addr;
-    let conn = pair.server_conn_mut(conn_handle);
-    assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
-    assert_matches!(conn.poll(), Some(Event::HandshakeConfirmed));
-    assert_matches!(conn.poll(), Some(Event::Connected));
-    assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
-    assert_matches!(conn.poll(), None);
+    // Extract the report info from relevant events.
+    let get_report_info = |e: &Event| match e {
+        Event::Path(PathEvent::ObservedAddr { id, addr }) => Some((*id, *addr)),
+        _ => None,
+    };
+    let mut c_events = c_events.iter().filter_map(get_report_info);
+    let mut s_events = s_events.iter().filter_map(get_report_info);
+
+    let c_report = c_events.next().expect("client should have received report");
+    let s_report = s_events.next().expect("server should have received report");
+
+    assert_eq!(c_report, (PathId::ZERO, pair.routes.as_basic().client_addr));
+    assert_eq!(s_report, (PathId::ZERO, pair.routes.as_basic().server_addr));
+
+    assert!(c_events.next().is_none());
+    assert!(s_events.next().is_none());
 }
 
 /// Test that a different address discovery configuration on 0rtt used by the client is accepted by

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3732,8 +3732,8 @@ fn address_discovery() {
     let conn = pair.client_conn_mut(conn_handle);
     assert_matches!(conn.poll(), Some(Event::HandshakeDataReady));
     assert_matches!(conn.poll(), Some(Event::Connected));
-    assert_matches!(conn.poll(), Some(Event::HandshakeConfirmed));
     assert_matches!(conn.poll(), Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr})) if addr == expected_addr);
+    assert_matches!(conn.poll(), Some(Event::HandshakeConfirmed));
     assert_matches!(conn.poll(), None);
 
     // check that the server received the correct address

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3913,37 +3913,28 @@ fn address_discovery_retransmission() {
     pair.step();
     let server_ch = pair.server.assert_accept();
 
-    let sent_frames = pair
-        .server_conn_mut(server_ch)
-        .stats()
-        .frame_tx
-        .observed_addr;
-    assert_eq!(sent_frames, 1);
+    let mut pair = ConnPair::new(pair, client_ch, server_ch);
+
+    while pair.stats(Server).frame_tx.observed_addr == 0 {
+        pair.step();
+    }
 
     // Drop in-flight datagrams to force retransmission
     pair.client.inbound.clear();
 
     pair.drive();
 
-    let resent_frames = pair
-        .server_conn_mut(server_ch)
-        .stats()
-        .frame_tx
-        .observed_addr;
-    assert_eq!(resent_frames, 2,);
+    // Sent twice but received once.
+    assert_eq!(pair.stats(Server).frame_tx.observed_addr, 2);
+    assert_eq!(pair.stats(Client).frame_rx.observed_addr, 1);
 
-    let received_frames = pair
-        .client_conn_mut(server_ch)
-        .stats()
-        .frame_rx
-        .observed_addr;
-    assert_eq!(received_frames, 1);
+    let mut reports = Vec::default();
+    pair.conn_mut(Client).poll_until_none(
+        |e| matches!(e, Event::Path(PathEvent::ObservedAddr { .. })),
+        &mut reports,
+    );
 
-    let (mut client_events, _server_events) = pair.lax_finish_connect(client_ch, server_ch);
-    pair.client_conn_mut(client_ch)
-        .poll_until_none(|_| true, &mut client_events);
-
-    let mut reports = client_events.iter().filter_map(|e| match e {
+    let mut reports = reports.iter().filter_map(|e| match e {
         Event::Path(PathEvent::ObservedAddr { id, addr }) => Some((*id, *addr)),
         _ => None,
     });

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -725,59 +725,46 @@ fn per_path_observed_address() -> TestResult {
         address_discovery_role: crate::address_discovery::Role::both(),
         ..TransportConfig::default()
     };
-    let (mut pair, client_events, server_events) = ConnPair::builder()
+    let (mut pair, client_events, _server_events) = ConnPair::builder()
         .with_transport_cfg(transport_cfg)
         .lax_connect();
 
     info!("connected");
     pair.drive();
 
-    // ObservedAddr may be emitted during connection; check events from connection and post-drive
-    let expected_addr = pair.routes.as_basic().client_addr;
-    let client_obs = client_events
-        .into_iter()
-        .find(|e| matches!(e, Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, .. })))
-        .or_else(|| pair.poll(Client));
-    assert_matches!(
-        client_obs,
-        Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
-            if addr == expected_addr
-    );
-    assert_matches!(pair.poll(Client), None);
+    let first_addr = pair.routes.as_basic().client_addr;
+    let first_server_addr = pair.routes.as_basic().server_addr;
+    let mut second_client_addr = first_addr;
+    let mut second_server_addr = first_server_addr;
+    second_client_addr.set_port(second_client_addr.port() + 1);
+    second_server_addr.set_port(second_server_addr.port() + 1);
+    pair.routes = ManyToManyRouting::simple_symmetric(
+        [first_addr, second_client_addr],
+        [first_server_addr, second_server_addr],
+    )
+    .into();
 
-    let expected_addr = pair.routes.as_basic().server_addr;
-    let server_obs = server_events
-        .into_iter()
-        .find(|e| matches!(e, Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, .. })))
-        .or_else(|| pair.poll(Server));
-    assert_matches!(
-        server_obs,
-        Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
-            if addr == expected_addr
-    );
-    assert_matches!(pair.poll(Server), None);
-
-    // simulate a rebind on the client, this will close the current path and open a new one
-    let our_addr = pair.routes.as_basic_mut().passive_migration(Client);
-    pair.handle_network_change(Client, None);
-
+    let second_path = FourTuple {
+        local_ip: Some(second_client_addr.ip()),
+        remote: second_server_addr,
+    };
+    let path_id = pair.open_path(Client, second_path, PathStatus::Available)?;
     pair.drive();
 
-    assert_matches!(
-        pair.poll(Client),
-        Some(Event::Path(PathEvent::Abandoned {
-            id: PathId(0),
-            reason: PathAbandonReason::UnusableAfterNetworkChange
-        }))
-    );
-    assert_matches!(
-        pair.poll(Client),
-        Some(Event::Path(PathEvent::Established { id: PathId(1) }))
-    );
-    assert_matches!(
-        pair.poll(Client),
-        Some(Event::Path(PathEvent::ObservedAddr{ id: PathId(1), addr })) if addr == our_addr
-    );
+    let mut found_first = false;
+    let mut found_second = false;
+    let post_connect_events = std::iter::from_fn(|| pair.poll(Client));
+    for event in client_events.into_iter().chain(post_connect_events) {
+        if let Event::Path(PathEvent::ObservedAddr { id, addr }) = event {
+            if id == PathId::ZERO && addr == first_addr {
+                found_first = true;
+            } else if id == path_id && addr == second_client_addr {
+                found_second = true;
+            }
+        }
+    }
+    assert!(found_first);
+    assert!(found_second);
 
     Ok(())
 }

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -725,26 +725,33 @@ fn per_path_observed_address() -> TestResult {
         address_discovery_role: crate::address_discovery::Role::both(),
         ..TransportConfig::default()
     };
-    let mut pair = ConnPair::builder()
+    let (mut pair, client_events, server_events) = ConnPair::builder()
         .with_transport_cfg(transport_cfg)
-        .connect();
+        .lax_connect();
 
     info!("connected");
     pair.drive();
 
-    // check that the client received the correct address
+    // ObservedAddr may be emitted during connection; check events from connection and post-drive
     let expected_addr = pair.routes.as_basic().client_addr;
+    let client_obs = client_events
+        .into_iter()
+        .find(|e| matches!(e, Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, .. })))
+        .or_else(|| pair.poll(Client));
     assert_matches!(
-        pair.poll(Client),
+        client_obs,
         Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
             if addr == expected_addr
     );
     assert_matches!(pair.poll(Client), None);
 
-    // check that the server received the correct address
     let expected_addr = pair.routes.as_basic().server_addr;
+    let server_obs = server_events
+        .into_iter()
+        .find(|e| matches!(e, Event::Path(PathEvent::ObservedAddr { id: PathId::ZERO, .. })))
+        .or_else(|| pair.poll(Server));
     assert_matches!(
-        pair.poll(Server),
+        server_obs,
         Some(Event::Path(PathEvent::ObservedAddr{id: PathId::ZERO, addr}))
             if addr == expected_addr
     );

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -339,7 +339,7 @@ impl Pair {
     ///
     /// The return type contains the client events and server events that were not related to
     /// connection establishment.
-    fn lax_finish_connect(
+    pub(super) fn lax_finish_connect(
         &mut self,
         client_ch: ConnectionHandle,
         server_ch: ConnectionHandle,

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -355,12 +355,6 @@ impl Pair {
             "client HandshakeDataReady",
             &mut client_events,
         );
-
-        client.poll_until(
-            |e| matches!(e, Event::HandshakeDataReady),
-            "client Event::HandshakeDataReady",
-            &mut client_events,
-        );
         client.poll_until(
             |e| matches!(e, Event::Connected),
             "client Event::Connected",
@@ -464,7 +458,7 @@ impl Connection {
     /// Polls events until the pattern is matched.
     ///
     /// Returns all events found before a match is found. If no event matches `pattern` it panics.
-    fn poll_until(
+    pub(super) fn poll_until(
         &mut self,
         pattern: impl Fn(&Event) -> bool,
         label: &'static str,
@@ -637,9 +631,9 @@ impl ConnPairBuilder {
         ConnPair::connect_with(pair, client_cfg)
     }
 
-    /// Builds the [`connpair`] and connects the two endpoints, accumulating events emitted by both
-    /// enpoints that are not related to connection establishment.
-    pub(super) fn lax_connect(self) -> ConnPair {
+    /// Builds the [`ConnPair`] and connects the two endpoints, accumulating events emitted by both
+    /// endpoints that are not related to connection establishment.
+    pub(super) fn lax_connect(self) -> (ConnPair, Vec<Event>, Vec<Event>) {
         let (pair, client_cfg) = self.build_pair();
         ConnPair::lax_connect_with(pair, client_cfg)
     }

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -1326,7 +1326,7 @@ pub(crate) fn subscribe() -> tracing::subscriber::DefaultGuard {
                 .with_default_directive(tracing::Level::TRACE.into())
                 .from_env_lossy(),
         )
-        // .without_time()
+        .without_time()
         .with_line_number(true)
         .with_writer(|| TestWriter);
     tracing::subscriber::set_default(builder.finish())

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -284,12 +284,6 @@ impl Pair {
         self.connect_with(client_config())
     }
 
-    pub(super) fn lax_connect(
-        &mut self,
-    ) -> (ConnectionHandle, Vec<Event>, ConnectionHandle, Vec<Event>) {
-        self.lax_connect_with(client_config())
-    }
-
     pub(super) fn connect_with(
         &mut self,
         config: ClientConfig,

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -284,6 +284,12 @@ impl Pair {
         self.connect_with(client_config())
     }
 
+    pub(super) fn lax_connect(
+        &mut self,
+    ) -> (ConnectionHandle, Vec<Event>, ConnectionHandle, Vec<Event>) {
+        self.lax_connect_with(client_config())
+    }
+
     pub(super) fn connect_with(
         &mut self,
         config: ClientConfig,
@@ -294,6 +300,21 @@ impl Pair {
         let server_ch = self.server.assert_accept();
         self.finish_connect(client_ch, server_ch);
         (client_ch, server_ch)
+    }
+
+    /// Like [`Self::connect_with`], but allows events not related to connection establishment.
+    ///
+    /// Extra events are accumulated and returned.
+    pub(super) fn lax_connect_with(
+        &mut self,
+        config: ClientConfig,
+    ) -> (ConnectionHandle, Vec<Event>, ConnectionHandle, Vec<Event>) {
+        info!("connecting");
+        let client_ch = self.begin_connect(config);
+        self.drive();
+        let server_ch = self.server.assert_accept();
+        let (client_events, server_events) = self.lax_finish_connect(client_ch, server_ch);
+        (client_ch, client_events, server_ch, server_events)
     }
 
     /// Just start connecting the client
@@ -311,6 +332,63 @@ impl Pair {
             .unwrap();
         self.client.connections.insert(client_ch, client_conn);
         client_ch
+    }
+
+    /// Asserts that client and server events lead to connection, allowing and accumulating
+    /// unrelated events.
+    ///
+    /// The return type contains the client events and server events that were not related to
+    /// connection establishment.
+    fn lax_finish_connect(
+        &mut self,
+        client_ch: ConnectionHandle,
+        server_ch: ConnectionHandle,
+    ) -> (Vec<Event>, Vec<Event>) {
+        let client = self.client.connections.get_mut(&client_ch).unwrap();
+        let server = self.server.connections.get_mut(&server_ch).unwrap();
+
+        let mut client_events = Vec::default();
+        let mut server_events = Vec::default();
+
+        client.poll_until(
+            |e| matches!(e, Event::HandshakeDataReady),
+            "client HandshakeDataReady",
+            &mut client_events,
+        );
+
+        client.poll_until(
+            |e| matches!(e, Event::HandshakeDataReady),
+            "client Event::HandshakeDataReady",
+            &mut client_events,
+        );
+        client.poll_until(
+            |e| matches!(e, Event::Connected),
+            "client Event::Connected",
+            &mut client_events,
+        );
+        server.poll_until(
+            |e| matches!(e, Event::HandshakeDataReady),
+            "server Event::HandshakeDataReady",
+            &mut server_events,
+        );
+        server.poll_until(
+            |e| matches!(e, Event::HandshakeConfirmed),
+            "server Event::HandshakeConfirmed",
+            &mut server_events,
+        );
+        server.poll_until(
+            |e| matches!(e, Event::Connected),
+            "server Event::Connected",
+            &mut server_events,
+        );
+        client.poll_until(
+            |e| matches!(e, Event::HandshakeConfirmed),
+            "client Event::HandshakeConfirmed",
+            &mut client_events,
+        );
+        info!("connected");
+
+        (client_events, server_events)
     }
 
     fn finish_connect(&mut self, client_ch: ConnectionHandle, server_ch: ConnectionHandle) {
@@ -379,6 +457,28 @@ impl Pair {
 
     pub(super) fn server_datagrams(&mut self, ch: ConnectionHandle) -> Datagrams<'_> {
         self.server_conn_mut(ch).datagrams()
+    }
+}
+
+impl Connection {
+    /// Polls events until the pattern is matched.
+    ///
+    /// Returns all events found before a match is found. If no event matches `pattern` it panics.
+    fn poll_until(
+        &mut self,
+        pattern: impl Fn(&Event) -> bool,
+        label: &'static str,
+        non_matching: &mut Vec<Event>,
+    ) {
+        while let Some(event) = self.poll() {
+            if pattern(&event) {
+                return;
+            } else {
+                non_matching.push(event);
+            }
+        }
+
+        panic!("{label} not found");
     }
 }
 
@@ -536,6 +636,13 @@ impl ConnPairBuilder {
         let (pair, client_cfg) = self.build_pair();
         ConnPair::connect_with(pair, client_cfg)
     }
+
+    /// Builds the [`connpair`] and connects the two endpoints, accumulating events emitted by both
+    /// enpoints that are not related to connection establishment.
+    pub(super) fn lax_connect(self) -> ConnPair {
+        let (pair, client_cfg) = self.build_pair();
+        ConnPair::lax_connect_with(pair, client_cfg)
+    }
 }
 
 /// Wrapper to a [`Pair`] which keeps handles to the client and server connections.
@@ -571,6 +678,26 @@ impl ConnPair {
             client_ch,
             server_ch,
         }
+    }
+
+    /// Creates the [`ConnPair`] allowing events not related to connection establishment.
+    ///
+    /// These events are returned along the [`ConnPair`].
+    fn lax_connect_with(
+        mut pair: Pair,
+        client_cfg: ClientConfig,
+    ) -> (Self, Vec<Event>, Vec<Event>) {
+        let (client_ch, client_events, server_ch, server_events) =
+            pair.lax_connect_with(client_cfg);
+        (
+            Self {
+                pair,
+                client_ch,
+                server_ch,
+            },
+            client_events,
+            server_events,
+        )
     }
 
     pub(super) fn conn(&self, side: Side) -> &Connection {

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -479,6 +479,19 @@ impl Connection {
 
         panic!("{label} not found");
     }
+
+    /// Polls events until None, accumulating those that match `pattern`.
+    pub(super) fn poll_until_none(
+        &mut self,
+        pattern: impl Fn(&Event) -> bool,
+        matching: &mut Vec<Event>,
+    ) {
+        while let Some(event) = self.poll() {
+            if pattern(&event) {
+                matching.push(event);
+            }
+        }
+    }
 }
 
 /// A builder for [`ConnPair`], because there are too many with_* methods.
@@ -1319,7 +1332,7 @@ pub(crate) fn subscribe() -> tracing::subscriber::DefaultGuard {
                 .with_default_directive(tracing::Level::TRACE.into())
                 .from_env_lossy(),
         )
-        .without_time()
+        // .without_time()
         .with_line_number(true)
         .with_writer(|| TestWriter);
     tracing::subscriber::set_default(builder.finish())


### PR DESCRIPTION
## Description

- Adds `PathRetransmits` to track data that must be sent over a specific path.
- Fixes re-transmission of `OBSERVED_ADDR` frames. This was not done correctly
  because the loss of a packet containing these frames would set a global
  variable to be re-sent, that was then picked up by the first path. Think a
  path "stealing" re-transmission of the frame from another path.
- Naming standards: Replaces `observed_addr_sent` for `pending_observed_addr` to
  use the naming convention in the codebase.

Partially replaces #674

## Breaking Changes



## Notes & open questions

Much simpler and elegant this way.
As I mentioned in #674 a test is not really possible because of the multiple
"safeguards" that prevents this from happening

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.

