### PR TITLE
fix(noq-udp): Set Windows ioctls to suppress ICMP errors on recv

### DIFF
--- a/noq-udp/src/windows.rs
+++ b/noq-udp/src/windows.rs
@@ -51,15 +51,26 @@ impl UdpSocketState {
 
         socket.0.set_nonblocking(true)?;
 
-        // Suppress the Windows behavior of failing the next recv with WSAECONNRESET when a
-        // prior send drew an ICMP port-unreachable. See [`disable_conn_reset`].
-        if let Err(e) = disable_conn_reset(&*socket.0) {
-            if is_unsupported_error(&e) {
-                crate::log::debug!(
-                    "SIO_UDP_CONNRESET not supported, recv may emit errors after sending to a closed port"
-                );
-            } else {
-                return Err(e);
+        // Stop Windows from failing the next recv with WSAECONNRESET or WSAENETRESET when a
+        // prior send drew an ICMP error. WSAECONNRESET follows a port-unreachable (a send to a
+        // closed port) and WSAENETRESET follows a TTL-expired / net-unreachable; both are
+        // reported against the next recv on the same socket. We never want to fail the recv
+        // path due to a failed send. The SIO_UDP_CONNRESET and SIO_UDP_NETRESET ioctls with
+        // a FALSE argument switch these error reportings off completely.
+        for (control_code, name) in [
+            (WinSock::SIO_UDP_CONNRESET, "SIO_UDP_CONNRESET"),
+            (WinSock::SIO_UDP_NETRESET, "SIO_UDP_NETRESET"),
+        ] {
+            if let Err(e) = disable_udp_ioctl(&*socket.0, control_code) {
+                if is_unsupported_error(&e) {
+                    // SIO_UDP_NETRESET requires Windows 8+, and neither ioctl is implemented
+                    // under Wine.
+                    crate::log::debug!(
+                        "{name} not supported, recv may emit errors after a prior send drew an ICMP error"
+                    );
+                } else {
+                    return Err(e);
+                }
             }
         }
 
@@ -540,26 +551,22 @@ fn send(state: &UdpSocketState, socket: UdpSockRef<'_>, transmit: &Transmit<'_>)
     }
 }
 
-/// Disables the Windows behavior of reporting ICMP port-unreachable errors against recv.
+/// Disables a boolean UDP `WSAIoctl` notification flag on `socket` by passing `FALSE`.
 ///
-/// On Windows a UDP datagram sent to a port with no listener draws an ICMP
-/// port-unreachable, and the OS surfaces that error (WSAECONNRESET) against the *next*
-/// recv on the same socket. For an unconnected QUIC socket the offending peer is one we
-/// may never hear from again, so failing an otherwise-healthy recv (and dropping any
-/// datagram queued behind the error) is never what we want. The `SIO_UDP_CONNRESET`
-/// ioctl with a `FALSE` argument turns the reporting off.
+/// Used to turn off the ICMP-error notifications (`SIO_UDP_CONNRESET`,
+/// `SIO_UDP_NETRESET`) that Windows otherwise reports against the next recv. See
+/// [`UdpSocketState::new`] for why we suppress them.
 ///
 /// See <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsaioctl>.
-fn disable_conn_reset(socket: &impl AsRawSocket) -> io::Result<()> {
-    // FALSE: do not report connection resets (ICMP port-unreachable) on recv.
-    let enabled: u32 = 0;
+fn disable_udp_ioctl(socket: &impl AsRawSocket, control_code: u32) -> io::Result<()> {
+    let disabled: u32 = 0; // FALSE
     let mut bytes_returned: u32 = 0;
     let rc = unsafe {
         WinSock::WSAIoctl(
             socket.as_raw_socket() as usize,
-            WinSock::SIO_UDP_CONNRESET,
-            &enabled as *const _ as *const _,
-            mem::size_of_val(&enabled) as u32,
+            control_code,
+            &disabled as *const _ as *const _,
+            mem::size_of_val(&disabled) as u32,
             ptr::null_mut(),
             0,
             &mut bytes_returned,

--- a/noq-udp/src/windows.rs
+++ b/noq-udp/src/windows.rs
@@ -61,15 +61,17 @@ impl UdpSocketState {
             (WinSock::SIO_UDP_CONNRESET, "SIO_UDP_CONNRESET"),
             (WinSock::SIO_UDP_NETRESET, "SIO_UDP_NETRESET"),
         ] {
-            if let Err(e) = disable_udp_ioctl(&*socket.0, control_code) {
-                if is_unsupported_error(&e) {
+            if let Err(error) = disable_udp_ioctl(&*socket.0, control_code) {
+                if is_unsupported_error(&error) {
                     // SIO_UDP_NETRESET requires Windows 8+, and neither ioctl is implemented
                     // under Wine.
                     crate::log::debug!(
                         "{name} not supported, recv may emit errors after a prior send drew an ICMP error"
                     );
                 } else {
-                    return Err(e);
+                    crate::log::debug!(
+                        "disabling {name} failed: {error}, recv may emit errors after a prior send drew an ICMP error"
+                    );
                 }
             }
         }

--- a/noq-udp/src/windows.rs
+++ b/noq-udp/src/windows.rs
@@ -50,6 +50,19 @@ impl UdpSocketState {
         );
 
         socket.0.set_nonblocking(true)?;
+
+        // Suppress the Windows behavior of failing the next recv with WSAECONNRESET when a
+        // prior send drew an ICMP port-unreachable. See [`disable_conn_reset`].
+        if let Err(e) = disable_conn_reset(&*socket.0) {
+            if is_unsupported_error(&e) {
+                crate::log::debug!(
+                    "SIO_UDP_CONNRESET not supported, recv may emit errors after sending to a closed port"
+                );
+            } else {
+                return Err(e);
+            }
+        }
+
         let addr = socket.0.local_addr()?;
         let is_ipv6 = addr.as_socket_ipv6().is_some();
         let is_ipv4 = if is_ipv6 {
@@ -524,6 +537,40 @@ fn send(state: &UdpSocketState, socket: UdpSockRef<'_>, transmit: &Transmit<'_>)
             }
             Err(err)
         }
+    }
+}
+
+/// Disables the Windows behavior of reporting ICMP port-unreachable errors against recv.
+///
+/// On Windows a UDP datagram sent to a port with no listener draws an ICMP
+/// port-unreachable, and the OS surfaces that error (WSAECONNRESET) against the *next*
+/// recv on the same socket. For an unconnected QUIC socket the offending peer is one we
+/// may never hear from again, so failing an otherwise-healthy recv (and dropping any
+/// datagram queued behind the error) is never what we want. The `SIO_UDP_CONNRESET`
+/// ioctl with a `FALSE` argument turns the reporting off.
+///
+/// See <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsaioctl>.
+fn disable_conn_reset(socket: &impl AsRawSocket) -> io::Result<()> {
+    // FALSE: do not report connection resets (ICMP port-unreachable) on recv.
+    let enabled: u32 = 0;
+    let mut bytes_returned: u32 = 0;
+    let rc = unsafe {
+        WinSock::WSAIoctl(
+            socket.as_raw_socket() as usize,
+            WinSock::SIO_UDP_CONNRESET,
+            &enabled as *const _ as *const _,
+            mem::size_of_val(&enabled) as u32,
+            ptr::null_mut(),
+            0,
+            &mut bytes_returned,
+            ptr::null_mut(),
+            None,
+        )
+    };
+
+    match rc == 0 {
+        true => Ok(()),
+        false => Err(io::Error::last_os_error()),
     }
 }
 

--- a/noq-udp/tests/tests.rs
+++ b/noq-udp/tests/tests.rs
@@ -317,6 +317,72 @@ fn socket_buffers() {
     );
 }
 
+/// Regression test for the Windows behavior suppressed via `SIO_UDP_CONNRESET`.
+///
+/// A recv must survive an ICMP error caused by an earlier send on the same socket.
+///
+/// On Windows, sending a UDP datagram to a port with no listener draws an ICMP
+/// port-unreachable, and the OS reports it against the *next* recv on that socket as
+/// WSAECONNRESET. Without `SIO_UDP_CONNRESET` disabled our recv surfaces that error, so
+/// a perfectly good datagram waiting behind it is lost and the recv fails. With the
+/// option set in `UdpSocketState::new` the error is suppressed and the real datagram is
+/// delivered.
+///
+/// This only exercises the bug on Windows. Other platforms do not deliver the ICMP
+/// error to an unconnected recv, so the recv just returns the datagram and the test
+/// passes whether or not the fix is present.
+#[test]
+fn recv_survives_icmp_unreachable_from_prior_send() {
+    use std::{thread, time::Duration};
+
+    // The socket under test, plus a legitimate peer to deliver a real datagram.
+    let receiver = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let receiver_addr = receiver.local_addr().unwrap();
+    let sender = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let sender_addr = sender.local_addr().unwrap();
+
+    // A definitely-closed port: bind a socket, take its address, then drop it.
+    let closed_addr = {
+        let tmp = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        tmp.local_addr().unwrap()
+    };
+
+    let receiver_state = UdpSocketState::new((&receiver).into()).unwrap();
+    // Reverse the non-blocking flag set by `UdpSocketState` so the recv below blocks
+    // until a datagram is ready, keeping the test non-racy. The read timeout is a
+    // safety net so a regression surfaces as a failure rather than a hang.
+    receiver.set_nonblocking(false).unwrap();
+    receiver
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+
+    // The receiver pokes the closed port. On Windows the ICMP port-unreachable that
+    // comes back arms WSAECONNRESET against the receiver's next recv.
+    receiver.send_to(b"void", closed_addr).unwrap();
+
+    // Give the ICMP reply time to arrive, so the error is pending before the real
+    // datagram and the recv.
+    thread::sleep(Duration::from_millis(100));
+
+    // The peer sends a real datagram that the receiver must deliver.
+    sender.send_to(b"hello", receiver_addr).unwrap();
+
+    // Without the fix this recv returns WSAECONNRESET on Windows instead of "hello".
+    let mut buf = [0u8; 16];
+    let mut meta = RecvMeta::default();
+    let n = receiver_state
+        .recv(
+            (&receiver).into(),
+            &mut [IoSliceMut::new(&mut buf)],
+            slice::from_mut(&mut meta),
+        )
+        .expect("recv must not surface the ICMP error");
+
+    assert_eq!(n, 1);
+    assert_eq!(&buf[..meta.len], b"hello");
+    assert_eq!(meta.addr.port(), sender_addr.port());
+}
+
 fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
     let send_state = UdpSocketState::new(send.into()).unwrap();
     let recv_state = UdpSocketState::new(recv.into()).unwrap();


### PR DESCRIPTION
Description

On Windows, the OS reports the fate of a previously sent UDP datagram against the **next `recv`** on that socket. A send to a port with no listener draws an ICMP port-unreachable, reported as `WSAECONNRESET`; a send whose datagram has its TTL expire in transit draws an ICMP time-exceeded, reported as `WSAENETRESET`. We already ignore `WSAECONNRESET` on the recv path (the Rust standard library maps `WSAECONNRESET` to `io::ErrorKind::ConnectionReset  which we ignore in the `EndpointDriver`).

Windows provides ioctls to suppress these notifications altogether, which saves a syscall and has no downsides for us, as we never handle recv errors related to a previous send anyway. This disables both `SIO_UDP_CONNRESET` (port-unreachable / `WSAECONNRESET`) and `SIO_UDP_NETRESET` (TTL-expired / `WSAENETRESET`) in `UdpSocketState::new`.


## Notes & open questions

Comes with a regression test that I confirmed to fail on Windows without the fix. It deterministically reproduces the port-unreachable (`WSAECONNRESET`) path.

`SIO_UDP_CONNRESET` and `SIO_UDP_NETRESET` are ioctls, not socket options, so they go through `WSAIoctl` rather than the existing `set_socket_option`/`setsockopt` helper. `SIO_UDP_NETRESET` requires Windows 8+, and neither is implemented under Wine; a missing ioctl is logged and tolerated rather than treated as fatal.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.