### PR TITLE
fix(proto): Move pending path responses to PacketNumberSpace

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2011,9 +2011,13 @@ impl Connection {
         buf: &mut Vec<u8>,
         path_id: PathId,
     ) -> Option<Transmit> {
-        let path = self.paths.get_mut(&path_id).map(|state| &mut state.data)?;
+        let network_path = self
+            .paths
+            .get_mut(&path_id)
+            .map(|state| state.data.network_path)?;
         let cid_queue = self.remote_cids.get_mut(&path_id)?;
-        let (token, network_path) = path.pending_response.pop_off_path(path.network_path)?;
+        let pns = self.spaces[SpaceKind::Data].for_path(path_id);
+        let (token, network_path) = pns.pending_path_responses.pop_off_path(network_path)?;
 
         // TODO: make off-path probes unlinkable.
         let cid = cid_queue.active();
@@ -4979,14 +4983,16 @@ impl Connection {
                     close = Some(reason);
                 }
                 Frame::PathChallenge(challenge) => {
-                    let path = &mut self
-                        .path_mut(path_id)
-                        .expect("payload is processed only after the path becomes known");
-                    path.pending_response
+                    self.spaces[SpaceKind::Data]
+                        .for_path(path_id)
+                        .pending_path_responses
                         .push(number, challenge.0, network_path);
                     // If we were passively migrated (e.g. NAT rebinding), our local_ip will
                     // not match. Once we processed a non-probing packet the local_ip will
                     // finally be updated.
+                    let path = &mut self
+                        .path_mut(path_id)
+                        .expect("payload is processed only after the path becomes known");
                     if network_path.remote == path.network_path.remote {
                         // PATH_CHALLENGE on active path, possible off-path packet
                         // forwarding attack. Send a non-probing packet to recover the
@@ -6212,15 +6218,14 @@ impl Connection {
             }
         }
 
-        // PATH_RESPONSE
+        // PATH_RESPONSE (on-path)
         if !scheduling_info.is_abandoned
             && space_id == SpaceId::Data
             && builder.frame_space_remaining() > frame::PathResponse::SIZE_BOUND
-            && let Some(token) = path.pending_response.pop_on_path(path.network_path)
-            // PATH_RESPONSE must be part of datagrams expanded to the MIN_INITIAL_SIZE (1200
-            // bytes). A datagram can be expanded to this size if it's the first, as it defines the
-            // GSO segment size, or if the first datagram is larger than this.
-            && !(builder.buf.num_datagrams() > 1 && builder.buf.segment_size() < usize::from(MIN_INITIAL_SIZE))
+            // An on-path PATH_RESPONSE must be part of datagrams expanded to the
+            // MIN_INITIAL_SIZE (1200 bytes).
+            && builder.buf.segment_size() >= usize::from(MIN_INITIAL_SIZE)
+            && let Some(token) = space.for_path(path_id).pending_path_responses.pop_on_path(path.network_path)
         {
             let response = frame::PathResponse(token);
             builder.write_frame(response, stats);
@@ -6950,7 +6955,7 @@ impl Connection {
         }
     }
 
-    /// Whether we have on-path 1-RTT data to send.
+    /// Whether we have **on-path** 1-RTT data to send.
     ///
     /// This checks for frames that can only be sent in the data space (1-RTT):
     /// - Pending PATH_CHALLENGE frames on the active and previous path if just migrated.
@@ -6961,9 +6966,15 @@ impl Connection {
     /// See also [`PacketSpace::can_send`] which keeps track of all other frame types that
     /// may need to be sent.
     fn can_send_1rtt(&self, path_id: PathId, max_size: usize) -> SendableFrames {
-        let space_specific = self.paths.get(&path_id).is_some_and(|path| {
-            path.data.pending_challenge || !path.data.pending_response.is_empty()
-        });
+        let network_path = self.path_data(path_id).network_path;
+        let space_specific = self
+            .paths
+            .get(&path_id)
+            .is_some_and(|path| path.data.pending_challenge)
+            || self.spaces[SpaceKind::Data]
+                .number_spaces
+                .get(&path_id)
+                .is_some_and(|pns| pns.pending_path_responses.has_pending_on_path(network_path));
 
         // Stream control frames are checked in PacketSpace::can_send, only check data here.
         let other = self.streams.can_send_stream_data()

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2654,7 +2654,7 @@ impl Connection {
         // TODO(flub): This is very brute-force: it pings *all* the paths.  Instead it would
         //    be nice if we could only send a single packet for this.
         for path_data in self.spaces[self.highest_space].number_spaces.values_mut() {
-            path_data.ping_pending = true;
+            path_data.pending_ping = true;
         }
     }
 
@@ -2666,7 +2666,7 @@ impl Connection {
             .number_spaces
             .get_mut(&path)
             .ok_or(ClosedPath { _private: () })?;
-        path_data.ping_pending = true;
+        path_data.pending_ping = true;
         Ok(())
     }
 
@@ -5919,10 +5919,10 @@ impl Connection {
         for (path_id, remote) in recoverable_paths.into_iter() {
             // Schedule a Ping for a liveness check.
             if let Some(path_space) = self.spaces[SpaceId::Data].number_spaces.get_mut(&path_id) {
-                path_space.ping_pending = true;
+                path_space.pending_ping = true;
 
                 if immediate_ack_allowed {
-                    path_space.immediate_ack_pending = true;
+                    path_space.pending_immediate_ack = true;
                 }
             }
 
@@ -6076,14 +6076,14 @@ impl Connection {
 
         // PING
         if !scheduling_info.is_abandoned
-            && mem::replace(&mut space.for_path(path_id).ping_pending, false)
+            && mem::replace(&mut space.for_path(path_id).pending_ping, false)
         {
             builder.write_frame(frame::Ping, stats);
         }
 
         // IMMEDIATE_ACK
         if !scheduling_info.is_abandoned
-            && mem::replace(&mut space.for_path(path_id).immediate_ack_pending, false)
+            && mem::replace(&mut space.for_path(path_id).pending_immediate_ack, false)
         {
             debug_assert_eq!(
                 space_id,
@@ -6800,7 +6800,7 @@ impl Connection {
         );
         self.spaces[SpaceId::Data]
             .for_path(path_id)
-            .immediate_ack_pending = true;
+            .pending_immediate_ack = true;
     }
 
     /// Decodes a packet, returning its decrypted payload, so it can be inspected in tests

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2018,6 +2018,7 @@ impl Connection {
         // TODO: make off-path probes unlinkable.
         let cid = cid_queue.active();
 
+        // PATH_RESPONSE (off-path)
         let frame = frame::PathResponse(token);
 
         let buf = &mut TransmitBuf::new(buf, NonZeroUsize::MIN, MIN_INITIAL_SIZE.into());
@@ -2027,6 +2028,8 @@ impl Connection {
         let stats = &mut self.path_stats.for_path(path_id).frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(off-path)"));
 
+        // PATH_CHALLENGE (off-path)
+        //
         // If we are a client doing NAT traversal, always include a PATH_CHALLENGE with any
         // off-path PATH_RESPONSE. No need to schedule any retries for this, if NAT
         // traversal is taking place then this remote already is being probed with
@@ -2094,6 +2097,7 @@ impl Connection {
         };
         let token = self.rng.random();
 
+        // PATH_CHALLENGE (NAT probe)
         let frame = frame::PathChallenge(token);
 
         let mut buf = TransmitBuf::new(buf, NonZeroUsize::MIN, MIN_INITIAL_SIZE.into());
@@ -6141,17 +6145,16 @@ impl Connection {
                 .ack_frequency_sent(path_id, builder.packet_number, max_ack_delay);
         }
 
-        // PATH_CHALLENGE
+        // PATH_CHALLENGE (on-path)
         if !scheduling_info.is_abandoned
             && space_id == SpaceId::Data
             && path.pending_challenge
             // we don't want to send new challenges if we are already closing
             && !self.state.is_closed()
             && builder.frame_space_remaining() > frame::PathChallenge::SIZE_BOUND
-            // PATH_CHALLENGE must be part of datagrams expanded to the MIN_INITIAL_SIZE (1200
-            // bytes). A datagram can be expanded to this size if it's the first, as it defines the
-            // GSO segment size, or if the first datagram is larger than this.
-            && !(builder.buf.num_datagrams() > 1 && builder.buf.segment_size() < usize::from(MIN_INITIAL_SIZE))
+            // An on-path PATH_CHALLENGE must be part of datagrams expanded to the
+            // MIN_INITIAL_SIZE (1200 bytes).
+            && builder.buf.segment_size() >= usize::from(MIN_INITIAL_SIZE)
         {
             path.pending_challenge = false;
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -977,7 +977,7 @@ impl Connection {
 
         // To open a path locally we need to send a packet on the path. Sending a challenge
         // guarantees this.
-        data.pending_on_path_challenge = true;
+        data.pending_challenge = true;
 
         let path = vacant_entry.insert(PathState { data, prev: None });
 
@@ -1952,10 +1952,10 @@ impl Connection {
         path_id: PathId,
     ) -> Option<Transmit> {
         let (prev_cid, prev_path) = self.paths.get_mut(&path_id)?.prev.as_mut()?;
-        if !prev_path.pending_on_path_challenge {
+        if !prev_path.pending_challenge {
             return None;
         };
-        prev_path.pending_on_path_challenge = false;
+        prev_path.pending_challenge = false;
         let token = self.rng.random();
         let network_path = prev_path.network_path;
         prev_path.record_path_challenge_sent(now, token, network_path);
@@ -2013,7 +2013,7 @@ impl Connection {
     ) -> Option<Transmit> {
         let path = self.paths.get_mut(&path_id).map(|state| &mut state.data)?;
         let cid_queue = self.remote_cids.get_mut(&path_id)?;
-        let (token, network_path) = path.path_responses.pop_off_path(path.network_path)?;
+        let (token, network_path) = path.pending_response.pop_off_path(path.network_path)?;
 
         // TODO: make off-path probes unlinkable.
         let cid = cid_queue.active();
@@ -2517,9 +2517,9 @@ impl Connection {
                             let Some(path) = self.paths.get_mut(&path_id) else {
                                 continue;
                             };
-                            trace!(?path.data.on_path_challenges_lost, "path challenge deemed lost");
-                            path.data.pending_on_path_challenge = true;
-                            path.data.on_path_challenges_lost += 1;
+                            trace!(?path.data.lost_challenge_count, "path challenge deemed lost");
+                            path.data.pending_challenge = true;
+                            path.data.lost_challenge_count += 1;
                         }
                         PathTimer::AbandonFromValidation => {
                             let Some(path) = self.paths.get_mut(&path_id) else {
@@ -4978,7 +4978,8 @@ impl Connection {
                     let path = &mut self
                         .path_mut(path_id)
                         .expect("payload is processed only after the path becomes known");
-                    path.path_responses.push(number, challenge.0, network_path);
+                    path.pending_response
+                        .push(number, challenge.0, network_path);
                     // If we were passively migrated (e.g. NAT rebinding), our local_ip will
                     // not match. Once we processed a non-probing packet the local_ip will
                     // finally be updated.
@@ -5758,7 +5759,7 @@ impl Connection {
                 addr: updated,
             }));
         }
-        new_path_data.pending_on_path_challenge = true;
+        new_path_data.pending_challenge = true;
 
         let mut prev_path_data = mem::replace(&mut path.data, new_path_data);
 
@@ -5773,7 +5774,7 @@ impl Connection {
         if !prev_path_data.validated
             && let Some(cid) = self.remote_cids.get(&path_id).map(CidQueue::active)
         {
-            prev_path_data.pending_on_path_challenge = true;
+            prev_path_data.pending_challenge = true;
             // We haven't updated the remote CID yet, this captures the remote CID we were using on
             // the previous path.
             path.prev = Some((cid, prev_path_data));
@@ -6143,7 +6144,7 @@ impl Connection {
         // PATH_CHALLENGE
         if !scheduling_info.is_abandoned
             && space_id == SpaceId::Data
-            && path.pending_on_path_challenge
+            && path.pending_challenge
             // we don't want to send new challenges if we are already closing
             && !self.state.is_closed()
             && builder.frame_space_remaining() > frame::PathChallenge::SIZE_BOUND
@@ -6152,7 +6153,7 @@ impl Connection {
             // GSO segment size, or if the first datagram is larger than this.
             && !(builder.buf.num_datagrams() > 1 && builder.buf.segment_size() < usize::from(MIN_INITIAL_SIZE))
         {
-            path.pending_on_path_challenge = false;
+            path.pending_challenge = false;
 
             let token = self.rng.random();
             path.record_path_challenge_sent(now, token, path.network_path);
@@ -6179,7 +6180,7 @@ impl Connection {
                 self.qlog.with_time(now),
             );
 
-            if is_multipath_negotiated && !path.validated && path.pending_on_path_challenge {
+            if is_multipath_negotiated && !path.validated && path.pending_challenge {
                 // queue informing the path status along with the challenge
                 space.pending.path_status.insert(path_id);
             }
@@ -6212,7 +6213,7 @@ impl Connection {
         if !scheduling_info.is_abandoned
             && space_id == SpaceId::Data
             && builder.frame_space_remaining() > frame::PathResponse::SIZE_BOUND
-            && let Some(token) = path.path_responses.pop_on_path(path.network_path)
+            && let Some(token) = path.pending_response.pop_on_path(path.network_path)
             // PATH_RESPONSE must be part of datagrams expanded to the MIN_INITIAL_SIZE (1200
             // bytes). A datagram can be expanded to this size if it's the first, as it defines the
             // GSO segment size, or if the first datagram is larger than this.
@@ -6928,7 +6929,7 @@ impl Connection {
     #[cfg(test)]
     pub(crate) fn trigger_path_validation(&mut self) {
         for path in self.paths.values_mut() {
-            path.data.pending_on_path_challenge = true;
+            path.data.pending_challenge = true;
         }
     }
 
@@ -6958,7 +6959,7 @@ impl Connection {
     /// may need to be sent.
     fn can_send_1rtt(&self, path_id: PathId, max_size: usize) -> SendableFrames {
         let space_specific = self.paths.get(&path_id).is_some_and(|path| {
-            path.data.pending_on_path_challenge || !path.data.path_responses.is_empty()
+            path.data.pending_challenge || !path.data.pending_response.is_empty()
         });
 
         // Stream control frames are checked in PacketSpace::can_send, only check data here.

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -182,23 +182,30 @@ pub(super) struct PathData {
     /// I.e. when app_limited is true, the congestion controller doesn't increase the congestion window.
     pub(super) app_limited: bool,
 
-    /// Path challenges sent (on the wire, on-path) that we didn't receive a path response for yet
-    on_path_challenges_unconfirmed: IntMap<u64, SentChallengeInfo>,
     /// Whether to trigger sending another PATH_CHALLENGE in the next poll_transmit.
     ///
-    /// This is picked up by [`super::Connection::space_can_send`].
+    /// This is picked up by [`super::Connection::space_can_send`]. These are **not**
+    /// retransmittable, which is why they are not part of the `PathRetransmits`.
     ///
-    /// Only used for RFC9000-style path migration and multipath path validation (for opening).
+    /// Only used for **on-path** challenges, like RFC9000-style path migration and
+    /// multipath path validation (for opening).
     ///
-    /// This is **not used** for n0 nat traversal challenge sending.
-    pub(super) pending_on_path_challenge: bool,
+    /// This is **not used** for n0 nat traversal challenge sending, which is off-path.
+    pub(super) pending_challenge: bool,
+    /// Pending **on-path** response to a PATH_CHALLENGE frame.
+    ///
+    /// Only the challenge with the highest packet number needs to be responded to, so this
+    /// only ever contains one response. Likewise the 4-tuple of the response will always
+    /// match the 4-tuple of this path generation. The struct is re-used for off-path
+    /// responses however, where these vary.
+    pub(super) pending_response: PathResponses,
+    /// On-path path challenges sent that we didn't receive a path response for yet.
+    unconfirmed_challenges: IntMap<u64, SentChallengeInfo>,
     /// How often we've deemed a path challenge to be lost.
     ///
     /// Similar to [`Self::pto_count`], but for on-path path challenges.
     /// Used to calculate exponential backoff for retrying path challenges.
-    pub(super) on_path_challenges_lost: u32,
-    /// Pending responses to PATH_CHALLENGE frames
-    pub(super) path_responses: PathResponses,
+    pub(super) lost_challenge_count: u32,
     /// Whether we're certain the peer can both send and receive on this address
     ///
     /// Initially equal to `use_stateless_retry` for servers, and becomes false again on every
@@ -324,10 +331,10 @@ impl PathData {
             ),
             congestion,
             app_limited: false,
-            on_path_challenges_unconfirmed: Default::default(),
-            on_path_challenges_lost: 0,
-            pending_on_path_challenge: false,
-            path_responses: PathResponses::default(),
+            unconfirmed_challenges: Default::default(),
+            lost_challenge_count: 0,
+            pending_challenge: false,
+            pending_response: PathResponses::default(),
             validated: false,
             total_sent: 0,
             total_recvd: 0,
@@ -388,10 +395,10 @@ impl PathData {
             sending_ecn: true,
             congestion,
             app_limited: false,
-            on_path_challenges_unconfirmed: Default::default(),
-            on_path_challenges_lost: 0,
-            pending_on_path_challenge: false,
-            path_responses: PathResponses::default(),
+            unconfirmed_challenges: Default::default(),
+            lost_challenge_count: 0,
+            pending_challenge: false,
+            pending_response: PathResponses::default(),
             validated: false,
             total_sent: 0,
             total_recvd: 0,
@@ -416,7 +423,7 @@ impl PathData {
 
     /// Whether we're in the process of validating this path with PATH_CHALLENGEs
     pub(super) fn is_validating_path(&self) -> bool {
-        !self.on_path_challenges_unconfirmed.is_empty() || self.pending_on_path_challenge
+        !self.unconfirmed_challenges.is_empty() || self.pending_challenge
     }
 
     /// Indicates whether we're a server that hasn't validated the peer's address and hasn't
@@ -452,7 +459,7 @@ impl PathData {
             network_path,
         };
         debug_assert_eq!(network_path, self.network_path);
-        self.on_path_challenges_unconfirmed.insert(token, info);
+        self.unconfirmed_challenges.insert(token, info);
     }
 
     /// Remove `packet` with number `pn` from this path's congestion control counters, or return
@@ -491,18 +498,18 @@ impl PathData {
 
     /// The earliest time at which an on-path challenge we sent is considered lost.
     pub(super) fn earliest_on_path_expiring_challenge(&self) -> Option<Instant> {
-        if self.on_path_challenges_unconfirmed.is_empty() {
+        if self.unconfirmed_challenges.is_empty() {
             return None;
         }
         let duration = self.on_path_challenge_expiry();
-        self.on_path_challenges_unconfirmed
+        self.unconfirmed_challenges
             .values()
             .map(|info| info.sent_instant + duration)
             .min()
     }
 
     pub(super) fn on_path_challenge_expiry(&self) -> Duration {
-        let backoff = 2u32.pow(self.on_path_challenges_lost.min(MAX_BACKOFF_EXPONENT));
+        let backoff = 2u32.pow(self.lost_challenge_count.min(MAX_BACKOFF_EXPONENT));
         let duration = self.rtt.pto_base() * backoff;
         duration.min(MAX_PTO_INTERVAL)
     }
@@ -526,7 +533,7 @@ impl PathData {
         // - network path over which the response arrived (`network_path`)
         //
         // As per the spec, this only validates the network path on which this was *sent*.
-        match self.on_path_challenges_unconfirmed.remove(&token) {
+        match self.unconfirmed_challenges.remove(&token) {
             // Response to an on-path PathChallenge that validates this path.
             // The sent path should match the current path. However, it's possible that the
             // challenge was sent when no local_ip was known. This case is allowed as well.
@@ -553,12 +560,12 @@ impl PathData {
             Some(info) => {
                 // This is a valid path response, but this validates a 4-tuple we no longer
                 // have in use. Keep only sent challenges for the current path.
-                self.on_path_challenges_unconfirmed
+                self.unconfirmed_challenges
                     .retain(|_token, i| i.network_path == self.network_path);
 
                 // If there are no challenges for the current path, schedule one
-                if !self.on_path_challenges_unconfirmed.is_empty() {
-                    self.pending_on_path_challenge = true;
+                if !self.unconfirmed_challenges.is_empty() {
+                    self.pending_challenge = true;
                 }
                 OnPathResponseReceived::Ignored {
                     sent_on: info.network_path,
@@ -574,9 +581,9 @@ impl PathData {
 
     /// Removes all on-path challenges we remember and cancels sending new on-path challenges.
     pub(super) fn reset_on_path_challenges(&mut self) {
-        self.on_path_challenges_unconfirmed.clear();
-        self.pending_on_path_challenge = false;
-        self.on_path_challenges_lost = 0;
+        self.unconfirmed_challenges.clear();
+        self.pending_challenge = false;
+        self.lost_challenge_count = 0;
     }
 
     #[cfg(feature = "qlog")]

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -192,13 +192,6 @@ pub(super) struct PathData {
     ///
     /// This is **not used** for n0 nat traversal challenge sending, which is off-path.
     pub(super) pending_challenge: bool,
-    /// Pending **on-path** response to a PATH_CHALLENGE frame.
-    ///
-    /// Only the challenge with the highest packet number needs to be responded to, so this
-    /// only ever contains one response. Likewise the 4-tuple of the response will always
-    /// match the 4-tuple of this path generation. The struct is re-used for off-path
-    /// responses however, where these vary.
-    pub(super) pending_response: PathResponses,
     /// On-path path challenges sent that we didn't receive a path response for yet.
     unconfirmed_challenges: IntMap<u64, SentChallengeInfo>,
     /// How often we've deemed a path challenge to be lost.
@@ -334,7 +327,6 @@ impl PathData {
             unconfirmed_challenges: Default::default(),
             lost_challenge_count: 0,
             pending_challenge: false,
-            pending_response: PathResponses::default(),
             validated: false,
             total_sent: 0,
             total_recvd: 0,
@@ -398,7 +390,6 @@ impl PathData {
             unconfirmed_challenges: Default::default(),
             lost_challenge_count: 0,
             pending_challenge: false,
-            pending_response: PathResponses::default(),
             validated: false,
             total_sent: 0,
             total_recvd: 0,
@@ -922,7 +913,8 @@ impl PathResponses {
         let response = *self.pending.last()?;
         // We use an exact comparison here, because once we've received for the first time,
         // we really should either already have a local_ip, or we will never get one
-        // (because our OS doesn't support it).
+        // (because our OS doesn't support it). And even if we get it wrong we are only
+        // slightly less efficient and would not include other on-path data in the packet.
         if response.network_path == network_path {
             // We don't bother searching further because we expect that the on-path response will
             // get drained in the immediate future by a call to `pop_on_path`
@@ -942,6 +934,13 @@ impl PathResponses {
         }
         self.pending.pop();
         Some(response.token)
+    }
+
+    /// Whether the next [`Self::pop_on_path`] will return something to send.
+    pub(crate) fn has_pending_on_path(&self, network_path: FourTuple) -> bool {
+        self.pending
+            .last()
+            .is_some_and(|response| response.network_path == network_path)
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -103,7 +103,7 @@ impl PacketSpace {
         if request_immediate_ack {
             // The probe should be ACKed without delay (should only be used in the Data space and
             // when the peer supports the acknowledgement frequency extension)
-            self.for_path(path_id).immediate_ack_pending = true;
+            self.for_path(path_id).pending_immediate_ack = true;
         }
 
         // We prefer to send new data to make most efficient use of bandwidth.
@@ -129,8 +129,8 @@ impl PacketSpace {
         // Nothing new to send and nothing to retransmit, so fall back on a ping. This should only
         // happen in rare cases during the handshake when the server becomes blocked by
         // anti-amplification.
-        if !self.for_path(path_id).immediate_ack_pending {
-            self.for_path(path_id).ping_pending = true;
+        if !self.for_path(path_id).pending_immediate_ack {
+            self.for_path(path_id).pending_ping = true;
         }
     }
 
@@ -149,7 +149,7 @@ impl PacketSpace {
         let space_specific = self
             .number_spaces
             .get(&path_id)
-            .is_some_and(|s| s.ping_pending || s.immediate_ack_pending);
+            .is_some_and(|s| s.pending_ping || s.pending_immediate_ack);
         let other = !self.pending.is_empty(streams);
         SendableFrames {
             acks,
@@ -255,14 +255,14 @@ pub(super) struct PacketNumberSpace {
     /// distinguishing between ECN bleaching and counts having been updated by a near-simultaneous
     /// ACK already processed in another space.
     pub(super) ecn_feedback: frame::EcnCounts,
-    /// A PING frame needs to be sent on this path
-    pub(super) ping_pending: bool,
-    /// An IMMEDIATE_ACK (draft-ietf-quic-ack-frequency) frame needs to be sent on this path
-    pub(super) immediate_ack_pending: bool,
+    /// A PING frame needs to be sent on this path.
+    pub(super) pending_ping: bool,
+    /// Packet numbers to acknowledge.
+    pub(super) pending_acks: PendingAcks,
+    /// An IMMEDIATE_ACK (draft-ietf-quic-ack-frequency) frame needs to be sent on this path.
+    pub(super) pending_immediate_ack: bool,
     /// Packet deduplicator
     pub(super) dedup: Dedup,
-    /// Packet numbers to acknowledge
-    pub(super) pending_acks: PendingAcks,
 
     //
     // Loss Detection
@@ -299,8 +299,8 @@ impl PacketNumberSpace {
             lost_packets: SortedIndexBuffer::new(),
             ecn_counters: frame::EcnCounts::ZERO,
             ecn_feedback: frame::EcnCounts::ZERO,
-            ping_pending: false,
-            immediate_ack_pending: false,
+            pending_ping: false,
+            pending_immediate_ack: false,
             dedup: Default::default(),
             pending_acks: PendingAcks::new(),
             time_of_last_ack_eliciting_packet: None,
@@ -327,8 +327,8 @@ impl PacketNumberSpace {
             lost_packets: SortedIndexBuffer::new(),
             ecn_counters: frame::EcnCounts::ZERO,
             ecn_feedback: frame::EcnCounts::ZERO,
-            ping_pending: false,
-            immediate_ack_pending: false,
+            pending_ping: false,
+            pending_immediate_ack: false,
             dedup: Default::default(),
             pending_acks: PendingAcks::new(),
             time_of_last_ack_eliciting_packet: None,

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -10,7 +10,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use sorted_index_buffer::SortedIndexBuffer;
 use tracing::trace;
 
-use super::PathId;
+use super::{PathId, paths::PathResponses};
 use crate::{
     Dir, Duration, FourTuple, Instant, StreamId, TransportError, TransportErrorCode, VarInt,
     connection::StreamsState,
@@ -146,10 +146,9 @@ impl PacketSpace {
             .number_spaces
             .values()
             .any(|pns| pns.pending_acks.can_send());
-        let space_specific = self
-            .number_spaces
-            .get(&path_id)
-            .is_some_and(|s| s.pending_ping || s.pending_immediate_ack);
+        let space_specific = self.number_spaces.get(&path_id).is_some_and(|s| {
+            s.pending_ping || s.pending_immediate_ack || !s.pending_path_responses.is_empty()
+        });
         let other = !self.pending.is_empty(streams);
         SendableFrames {
             acks,
@@ -261,6 +260,12 @@ pub(super) struct PacketNumberSpace {
     pub(super) pending_acks: PendingAcks,
     /// An IMMEDIATE_ACK (draft-ietf-quic-ack-frequency) frame needs to be sent on this path.
     pub(super) pending_immediate_ack: bool,
+    /// Responses to path challenges that need to be sent, on and off-path.
+    ///
+    /// Responses are only tied to the 4-tuple they were received on, not to a specific path
+    /// generation. Whether the response is on or off-path only depends on the path's
+    /// 4-tuple at sending time.
+    pub(super) pending_path_responses: PathResponses,
     /// Packet deduplicator
     pub(super) dedup: Dedup,
 
@@ -300,9 +305,10 @@ impl PacketNumberSpace {
             ecn_counters: frame::EcnCounts::ZERO,
             ecn_feedback: frame::EcnCounts::ZERO,
             pending_ping: false,
-            pending_immediate_ack: false,
-            dedup: Default::default(),
             pending_acks: PendingAcks::new(),
+            pending_immediate_ack: false,
+            pending_path_responses: PathResponses::default(),
+            dedup: Default::default(),
             time_of_last_ack_eliciting_packet: None,
             loss_time: None,
             loss_probes: 0,
@@ -328,9 +334,10 @@ impl PacketNumberSpace {
             ecn_counters: frame::EcnCounts::ZERO,
             ecn_feedback: frame::EcnCounts::ZERO,
             pending_ping: false,
-            pending_immediate_ack: false,
-            dedup: Default::default(),
             pending_acks: PendingAcks::new(),
+            pending_immediate_ack: false,
+            pending_path_responses: PathResponses::default(),
+            dedup: Default::default(),
             time_of_last_ack_eliciting_packet: None,
             loss_time: None,
             loss_probes: 0,


### PR DESCRIPTION
## Description

This primarily moves pending path responses to the PacketNumberSpace
they should be sent on. There is nothing in a path response that
signals it is on- or off-path, every response must be sent on the
4-tuple it was received on. The only difference is at sending time: an
on-path PATH_RESPONSE could be combined with other on-path data ready
to send.

## Breaking Changes

none

## Notes & open questions

This PR does a bunch of renames in independent commits. Best to review
commit-by-commit and also to merge without squashing.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.