### PR TITLE
refactor(qnt): higher priority for add and remove address frames

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -6247,6 +6247,32 @@ impl Connection {
             }
         }
 
+        // ADD_ADDRESS
+        while space_id == SpaceId::Data
+            && !scheduling_info.is_abandoned
+            && scheduling_info.may_send_data
+            && frame::AddAddress::SIZE_BOUND <= builder.frame_space_remaining()
+        {
+            if let Some(added_address) = space.pending.add_address.pop_last() {
+                builder.write_frame(added_address, stats);
+            } else {
+                break;
+            }
+        }
+
+        // REMOVE_ADDRESS
+        while space_id == SpaceId::Data
+            && !scheduling_info.is_abandoned
+            && scheduling_info.may_send_data
+            && frame::RemoveAddress::SIZE_BOUND <= builder.frame_space_remaining()
+        {
+            if let Some(removed_address) = space.pending.remove_address.pop_last() {
+                builder.write_frame(removed_address, stats);
+            } else {
+                break;
+            }
+        }
+
         // REACH_OUT
         while !scheduling_info.is_abandoned
             && scheduling_info.may_send_data
@@ -6545,32 +6571,6 @@ impl Connection {
 
                 builder.write_frame(new_token, stats);
                 builder.retransmits_mut().new_tokens.push(network_path);
-            }
-        }
-
-        // ADD_ADDRESS
-        while space_id == SpaceId::Data
-            && !scheduling_info.is_abandoned
-            && scheduling_info.may_send_data
-            && frame::AddAddress::SIZE_BOUND <= builder.frame_space_remaining()
-        {
-            if let Some(added_address) = space.pending.add_address.pop_last() {
-                builder.write_frame(added_address, stats);
-            } else {
-                break;
-            }
-        }
-
-        // REMOVE_ADDRESS
-        while space_id == SpaceId::Data
-            && !scheduling_info.is_abandoned
-            && scheduling_info.may_send_data
-            && frame::RemoveAddress::SIZE_BOUND <= builder.frame_space_remaining()
-        {
-            if let Some(removed_address) = space.pending.remove_address.pop_last() {
-                builder.write_frame(removed_address, stats);
-            } else {
-                break;
             }
         }
 


### PR DESCRIPTION
## Description

This moves the ADD_ADDRESS and REMOVE_ADDRESS frames to be the same
priority as REACH_OUT (they are only sent by the server while only the
client sends REACH_OUT frames). In particular they need to be sent
before any user data and before new connection IDs. Otherwise
PATH_NEW_CONNECTION_ID frames being issued for other paths are
delaying the ADD_ADDRESS frames which can already be used by QNT.

## Breaking Changes

n/a

## Notes & open questions

This is part of my notes from investigating #4247.

## Change checklist

- [x] Self-review.