### PR TITLE
refactor(multipath): Track OpenStatus on PacketNumberSpace

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -87,7 +87,7 @@ pub use spaces::Retransmits;
 #[cfg(not(fuzzing))]
 use spaces::Retransmits;
 pub(crate) use spaces::SpaceKind;
-use spaces::{PacketSpace, SendableFrames, SentPacket, ThinRetransmits};
+use spaces::{OpenStatus, PacketSpace, SendableFrames, SentPacket, ThinRetransmits};
 
 mod stats;
 pub use stats::{ConnectionStats, FrameStats, PathStats, UdpStats};
@@ -334,15 +334,21 @@ impl Connection {
         let connection_side = ConnectionSide::from(side_args);
         let side = connection_side.side();
         let mut rng = StdRng::from_seed(rng_seed);
-        let initial_space = PacketSpace::new(now, SpaceId::Initial, &mut rng);
-        let handshake_space = PacketSpace::new(now, SpaceId::Handshake, &mut rng);
+        let mut initial_space = PacketSpace::new(now, SpaceId::Initial, &mut rng);
+        let mut handshake_space = PacketSpace::new(now, SpaceId::Handshake, &mut rng);
         #[cfg(test)]
-        let data_space = match config.deterministic_packet_numbers {
+        let mut data_space = match config.deterministic_packet_numbers {
             true => PacketSpace::new_deterministic(now, SpaceId::Data),
             false => PacketSpace::new(now, SpaceId::Data, &mut rng),
         };
         #[cfg(not(test))]
-        let data_space = PacketSpace::new(now, SpaceId::Data, &mut rng);
+        let mut data_space = PacketSpace::new(now, SpaceId::Data, &mut rng);
+
+        // The spaces for PathId::ZERO do not need the PathEvent::Established event.
+        initial_space.for_path(PathId::ZERO).open_status = OpenStatus::Informed;
+        handshake_space.for_path(PathId::ZERO).open_status = OpenStatus::Informed;
+        data_space.for_path(PathId::ZERO).open_status = OpenStatus::Informed;
+
         let state = State::handshake(state::Handshake {
             remote_cid_set: side.is_server(),
             expected_token: Bytes::new(),
@@ -359,8 +365,6 @@ impl Connection {
             ),
         )]);
 
-        let mut path = PathData::new(network_path, allow_mtud, None, 0, now, &config);
-        path.open_status = paths::OpenStatus::Informed;
         let mut this = Self {
             endpoint_config,
             crypto_state: CryptoState::new(crypto, init_cid, side, &mut rng),
@@ -370,7 +374,7 @@ impl Connection {
             paths: BTreeMap::from_iter([(
                 PathId::ZERO,
                 PathState {
-                    data: path,
+                    data: PathData::new(network_path, allow_mtud, None, 0, now, &config),
                     prev: None,
                 },
             )]),
@@ -4880,7 +4884,6 @@ impl Connection {
         packet: Packet,
         #[allow(unused)] qlog: &mut QlogRecvPacket,
     ) -> Result<(), TransportError> {
-        let is_multipath_negotiated = self.is_multipath_negotiated();
         let payload = packet.payload.freeze();
         let mut is_probing_packet = true;
         let mut close = None;
@@ -5007,79 +5010,7 @@ impl Connection {
                         self.open_nat_traversed_paths(now);
                     } else {
                         // Try to see if this is a response to an on-path PATH_CHALLENGE.
-
-                        let path = self
-                            .paths
-                            .get_mut(&path_id)
-                            .expect("payload is processed only after the path becomes known");
-
-                        use PathTimer::*;
-                        use paths::OnPathResponseReceived::*;
-                        match path
-                            .data
-                            .on_path_response_received(now, response.0, network_path)
-                        {
-                            OnPath { was_open } if !self.abandoned_paths.contains(&path_id) => {
-                                let qlog = self.qlog.with_time(now);
-
-                                self.timers.stop(
-                                    Timer::PerPath(path_id, PathValidationFailed),
-                                    qlog.clone(),
-                                );
-                                self.timers.stop(
-                                    Timer::PerPath(path_id, AbandonFromValidation),
-                                    qlog.clone(),
-                                );
-
-                                let next_challenge = path
-                                    .data
-                                    .earliest_on_path_expiring_challenge()
-                                    .map(|time| time + self.ack_frequency.max_ack_delay_for_pto());
-                                self.timers.set_or_stop(
-                                    Timer::PerPath(path_id, PathChallengeLost),
-                                    next_challenge,
-                                    qlog,
-                                );
-
-                                if !was_open {
-                                    if is_multipath_negotiated {
-                                        self.events.push_back(Event::Path(
-                                            PathEvent::Established { id: path_id },
-                                        ));
-                                    }
-                                    if let Some(observed) =
-                                        path.data.last_observed_addr_report.as_ref()
-                                    {
-                                        self.events.push_back(Event::Path(
-                                            PathEvent::ObservedAddr {
-                                                id: path_id,
-                                                addr: observed.socket_addr(),
-                                            },
-                                        ));
-                                    }
-                                }
-                                if let Some((_, ref mut prev)) = path.prev {
-                                    // If an on-path response was received while there is a
-                                    // previous path from a migration, then the new path is
-                                    // validated and we can stop sending challenges that try to
-                                    // re-validate the previous path.
-                                    prev.reset_on_path_challenges();
-                                }
-                            }
-                            OnPath { .. } => {
-                                trace!(
-                                    %response,
-                                    "ignoring PATH_RESPONSE received after path is abandoned"
-                                );
-                            }
-                            Ignored {
-                                sent_on,
-                                current_path,
-                            } => {
-                                debug!(%sent_on, %current_path, %response, "ignoring valid PATH_RESPONSE")
-                            }
-                            Unknown => debug!(%response, "ignoring invalid PATH_RESPONSE"),
-                        }
+                        self.handle_path_response_on_path(now, response, path_id, network_path);
                     }
                 }
                 Frame::MaxData(frame::MaxData(bytes)) => {
@@ -5348,10 +5279,12 @@ impl Connection {
                         ));
                     }
 
+                    let space_open_status =
+                        self.spaces[SpaceKind::Data].for_path(path_id).open_status;
                     let path = self.path_data_mut(path_id);
                     if path.network_path.remote == network_path.remote {
                         if let Some(updated) = path.update_observed_addr_report(observed)
-                            && path.open_status == paths::OpenStatus::Informed
+                            && space_open_status == OpenStatus::Informed
                         {
                             self.events.push_back(Event::Path(PathEvent::ObservedAddr {
                                 id: path_id,
@@ -5657,6 +5590,84 @@ impl Connection {
         }
 
         Ok(())
+    }
+
+    /// Handles any on-path PATH_RESPONSE frames.
+    ///
+    /// *path_id* and *network_path* are those on which the PATH_RESPONSE was received.
+    fn handle_path_response_on_path(
+        &mut self,
+        now: Instant,
+        response: frame::PathResponse,
+        path_id: PathId,
+        network_path: FourTuple,
+    ) {
+        let is_multipath_negotiated = self.is_multipath_negotiated();
+        let path = self
+            .paths
+            .get_mut(&path_id)
+            .expect("payload is processed only after the path becomes known");
+        match path
+            .data
+            .on_path_response_received(now, response.0, network_path)
+        {
+            paths::OnPathResponseReceived::OnPath if !self.abandoned_paths.contains(&path_id) => {
+                let qlog = self.qlog.with_time(now);
+                self.timers.stop(
+                    Timer::PerPath(path_id, PathTimer::PathValidationFailed),
+                    qlog.clone(),
+                );
+                self.timers.stop(
+                    Timer::PerPath(path_id, PathTimer::AbandonFromValidation),
+                    qlog.clone(),
+                );
+                let next_challenge = path
+                    .data
+                    .earliest_on_path_expiring_challenge()
+                    .map(|time| time + self.ack_frequency.max_ack_delay_for_pto());
+                self.timers.set_or_stop(
+                    Timer::PerPath(path_id, PathTimer::PathChallengeLost),
+                    next_challenge,
+                    qlog,
+                );
+                let pns = self.spaces[SpaceKind::Data].for_path(path_id);
+                if !matches!(pns.open_status, OpenStatus::Informed) {
+                    if is_multipath_negotiated {
+                        self.events
+                            .push_back(Event::Path(PathEvent::Established { id: path_id }));
+                    }
+                    pns.open_status = OpenStatus::Informed;
+                    if let Some(observed) = path.data.last_observed_addr_report.as_ref() {
+                        self.events.push_back(Event::Path(PathEvent::ObservedAddr {
+                            id: path_id,
+                            addr: observed.socket_addr(),
+                        }));
+                    }
+                }
+                if let Some((_, ref mut prev)) = path.prev {
+                    // If an on-path response was received while there is a
+                    // previous path from a migration, then the new path is
+                    // validated and we can stop sending challenges that try to
+                    // re-validate the previous path.
+                    prev.reset_on_path_challenges();
+                }
+            }
+            paths::OnPathResponseReceived::OnPath => {
+                trace!(
+                    %response,
+                    "ignoring PATH_RESPONSE received after path is abandoned"
+                );
+            }
+            paths::OnPathResponseReceived::Unknown => {
+                debug!(%response, "ignoring invalid PATH_RESPONSE");
+            }
+            paths::OnPathResponseReceived::Ignored {
+                sent_on,
+                current_path,
+            } => {
+                debug!(%sent_on, %current_path, %response, "ignoring valid PATH_RESPONSE");
+            }
+        }
     }
 
     /// Opens any paths that have been successfully NAT traversed.
@@ -6161,10 +6172,11 @@ impl Connection {
             builder.write_frame(challenge, stats);
             builder.require_padding();
             let pto = self.ack_frequency.max_ack_delay_for_pto() + path.rtt.pto_base();
-            match path.open_status {
-                paths::OpenStatus::Sent | paths::OpenStatus::Informed => {}
-                paths::OpenStatus::Pending => {
-                    path.open_status = paths::OpenStatus::Sent;
+            let pns = space.for_path(path_id);
+            match pns.open_status {
+                OpenStatus::Sent | OpenStatus::Informed => {}
+                OpenStatus::Pending => {
+                    pns.open_status = OpenStatus::Sent;
                     self.timers.set(
                         Timer::PerPath(path_id, PathTimer::AbandonFromValidation),
                         now + 3 * pto,

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -266,18 +266,6 @@ pub(super) struct PathData {
     /// <https://www.rfc-editor.org/rfc/rfc9000.html#section-10.1>.
     pub(super) permit_idle_reset: bool,
 
-    /// Whether the path has already been considered opened from an application perspective.
-    ///
-    /// This means, for paths other than the original [`PathId::ZERO`], a first path challenge has
-    /// been responded to, regardless of the initial validation status of the path. This state is
-    /// irreversible, since it's not affected by the path being closed.
-    ///
-    /// Sending a PATH_CHALLENGE and receiving a valid response before the application is informed
-    /// of the path, is a way to ensure the path is usable before it is reported. This is not
-    /// required by the spec, and in the future might be changed for simply requiring a first ack'd
-    /// packet.
-    pub(super) open_status: OpenStatus,
-
     /// Whether we're currently draining the path after having abandoned it.
     ///
     /// This should only be true when a path discard timer is armed, and after the path was
@@ -356,7 +344,6 @@ impl PathData {
             idle_timeout: config.default_path_max_idle_timeout,
             keep_alive: config.default_path_keep_alive_interval,
             permit_idle_reset: true,
-            open_status: OpenStatus::default(),
             draining: false,
             #[cfg(feature = "qlog")]
             recovery_metrics: RecoveryMetrics::default(),
@@ -406,7 +393,6 @@ impl PathData {
             idle_timeout: prev.idle_timeout,
             keep_alive: prev.keep_alive,
             permit_idle_reset: true,
-            open_status: OpenStatus::default(),
             draining: false,
             #[cfg(feature = "qlog")]
             recovery_metrics: prev.recovery_metrics.clone(),
@@ -544,10 +530,7 @@ impl PathData {
                 let rtt = now.saturating_duration_since(sent_instant);
                 self.rtt.reset_initial_rtt(rtt);
 
-                let prev_status = std::mem::replace(&mut self.open_status, OpenStatus::Informed);
-                OnPathResponseReceived::OnPath {
-                    was_open: matches!(prev_status, OpenStatus::Informed),
-                }
+                OnPathResponseReceived::OnPath
             }
             // Response to an on-path PathChallenge that does not validate this path.
             Some(info) => {
@@ -673,7 +656,7 @@ impl PathData {
 
 pub(super) enum OnPathResponseReceived {
     /// This response validates the path on its current remote address.
-    OnPath { was_open: bool },
+    OnPath,
     /// The received token is unknown.
     Unknown,
     /// The response is valid but it's not usable for path validation.
@@ -681,18 +664,6 @@ pub(super) enum OnPathResponseReceived {
         sent_on: FourTuple,
         current_path: FourTuple,
     },
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub(super) enum OpenStatus {
-    /// A first packet has not been sent using this [`PathId`].
-    #[default]
-    Pending,
-    /// The first packet has been sent using this [`PathId`]. However, it is not yet deemed good
-    /// enough to be reported to the application.
-    Sent,
-    /// The application has been informed of this path.
-    Informed,
 }
 
 /// Congestion metrics as described in [`recovery_metrics_updated`].

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -228,6 +228,18 @@ impl IndexMut<SpaceKind> for [PacketSpace; 3] {
 ///
 /// [`PathData`]: super::paths::PathData
 pub(super) struct PacketNumberSpace {
+    /// Whether the path has already been considered opened from an application perspective.
+    ///
+    /// This means, for paths other than the original [`PathId::ZERO`], a first path
+    /// challenge has been responded to, regardless of the initial validation status of the
+    /// path. This state is irreversible, since it's not affected by the path being closed.
+    ///
+    /// Sending a PATH_CHALLENGE and receiving a valid response before the application is
+    /// informed of the path, is a way to ensure the path is usable before it is
+    /// reported. This is not required by the spec, and in the future might be changed for
+    /// simply requiring a first ack'd packet.
+    pub(super) open_status: OpenStatus,
+
     /// Highest received packet number, if any
     pub(super) largest_received_packet_number: Option<u64>,
     /// The packet number of the next packet that will be sent, if any. In the Data space, the
@@ -289,6 +301,7 @@ impl PacketNumberSpace {
             SpaceId::Data => Some(PacketNumberFilter::new(rng)),
         };
         Self {
+            open_status: OpenStatus::default(),
             largest_received_packet_number: None,
             next_packet_number: 0,
             largest_acked_packet_pn: None,
@@ -317,6 +330,7 @@ impl PacketNumberSpace {
             SpaceId::Data => Some(PacketNumberFilter::disabled()),
         };
         Self {
+            open_status: OpenStatus::default(),
             largest_received_packet_number: None,
             next_packet_number: 0,
             largest_acked_packet_pn: None,
@@ -471,6 +485,18 @@ impl PacketNumberSpace {
         // this shouldn't need to visit many packets before finishing one way or another.
         self.sent_packets.values().any(|x| x.size != 0)
     }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OpenStatus {
+    /// A first packet has not been sent using this [`PathId`].
+    #[default]
+    Pending,
+    /// The first packet has been sent using this [`PathId`]. However, it is not yet deemed good
+    /// enough to be reported to the application.
+    Sent,
+    /// The application has been informed of this path.
+    Informed,
 }
 
 /// Represents one or more packets subject to retransmission


### PR DESCRIPTION
## Description

A path's open status, whether the application has been informed of the
path being usable, does not belong to the 4-tuple state of the path
generation. It is something that is specific to the PacketNumberSpace
as it stay stable regardless of the 4-tuple the path migrates to.

Contributes to #591.

## Breaking Changes

none

## Notes & open questions

none

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.