### PR TITLE
refactor(multipath): challenges on a path generation are on path

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5670,13 +5670,7 @@ impl Connection {
                 );
             }
             paths::OnPathResponseReceived::Unknown => {
-                debug!(%response, "ignoring invalid PATH_RESPONSE");
-            }
-            paths::OnPathResponseReceived::Ignored {
-                sent_on,
-                current_path,
-            } => {
-                debug!(%sent_on, %current_path, %response, "ignoring valid PATH_RESPONSE");
+                debug!(%response, "ignoring unknown PATH_RESPONSE");
             }
         }
     }

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -514,7 +514,13 @@ impl PathData {
             // Response to an on-path PathChallenge that validates this path.
             // The sent path should match the current path. However, it's possible that the
             // challenge was sent when no local_ip was known. This case is allowed as well.
-            Some(info) if info.network_path.is_probably_same_path(&self.network_path) => {
+            Some(info) => {
+                // An on-path challenge that was sent on a different 4-tuple would be stored
+                // in a different path generation.
+                debug_assert!(
+                    info.network_path.is_probably_same_path(&self.network_path),
+                    "response can only be for same network path"
+                );
                 self.network_path.update_local_if_same_remote(&network_path);
                 let sent_instant = info.sent_instant;
                 if !std::mem::replace(&mut self.validated, true) {
@@ -529,22 +535,6 @@ impl PathData {
                 self.rtt.reset_initial_rtt(rtt);
 
                 OnPathResponseReceived::OnPath
-            }
-            // Response to an on-path PathChallenge that does not validate this path.
-            Some(info) => {
-                // This is a valid path response, but this validates a 4-tuple we no longer
-                // have in use. Keep only sent challenges for the current path.
-                self.unconfirmed_challenges
-                    .retain(|_token, i| i.network_path == self.network_path);
-
-                // If there are no challenges for the current path, schedule one
-                if !self.unconfirmed_challenges.is_empty() {
-                    self.pending_challenge = true;
-                }
-                OnPathResponseReceived::Ignored {
-                    sent_on: info.network_path,
-                    current_path: self.network_path,
-                }
             }
             None => {
                 // Response to an unknown PathChallenge. Does not indicate failure.
@@ -657,11 +647,6 @@ pub(super) enum OnPathResponseReceived {
     OnPath,
     /// The received token is unknown.
     Unknown,
-    /// The response is valid but it's not usable for path validation.
-    Ignored {
-        sent_on: FourTuple,
-        current_path: FourTuple,
-    },
 }
 
 /// Congestion metrics as described in [`recovery_metrics_updated`].


### PR DESCRIPTION
## Description

The token of any PATH_CHALLENGE sent as a on-path challenge is stored
on the path generation state (PathData). Thus any response that
matches the token is always on path. The PathData::network_path of a
path generation can not change, only the local_ip can be filled in if
initially missing.

This may not have been the case when this was originally introduced.

## Breaking Changes

none

## Notes & open questions

This is the more controversial part of #711, so targets that PR. This
state was originally introduced in #443.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.