### PR TITLE
fix(migration): Do not update local_ip for probing packets

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5021,7 +5021,7 @@ impl Connection {
                         self.open_nat_traversed_paths(now);
                     } else {
                         // Try to see if this is a response to an on-path PATH_CHALLENGE.
-                        self.handle_path_response_on_path(now, response, path_id, network_path);
+                        self.handle_path_response_on_path(now, response, path_id);
                     }
                 }
                 Frame::MaxData(frame::MaxData(bytes)) => {
@@ -5611,17 +5611,13 @@ impl Connection {
         now: Instant,
         response: frame::PathResponse,
         path_id: PathId,
-        network_path: FourTuple,
     ) {
         let is_multipath_negotiated = self.is_multipath_negotiated();
         let path = self
             .paths
             .get_mut(&path_id)
             .expect("payload is processed only after the path becomes known");
-        match path
-            .data
-            .on_path_response_received(now, response.0, network_path)
-        {
+        match path.data.on_path_response_received(now, response.0) {
             paths::OnPathResponseReceived::OnPath if !self.abandoned_paths.contains(&path_id) => {
                 let qlog = self.qlog.with_time(now);
                 self.timers.stop(

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -496,7 +496,6 @@ impl PathData {
         &mut self,
         now: Instant,
         token: u64,
-        network_path: FourTuple,
     ) -> OnPathResponseReceived {
         // > § 8.2.3
         // > Path validation succeeds when a PATH_RESPONSE frame is received that contains the
@@ -507,15 +506,20 @@ impl PathData {
         // At this point we have three potentially different network paths:
         // - current network path (`Self::network_path`)
         // - network path used to send the path challenge (`SentChallengeInfo::network_path`)
-        // - network path over which the response arrived (`network_path`)
+        // - network path over which the response arrived (not needed)
         //
-        // As per the spec, this only validates the network path on which this was *sent*.
+        // As per the spec, this only validates the network path on which this was *sent*,
+        // regardless of the path on which it was received in order to protect against
+        // off-path packet forwarding attacks.
         match self.unconfirmed_challenges.remove(&token) {
             // Response to an on-path PathChallenge that validates this path.
             // The sent path should match the current path. However, it's possible that the
             // challenge was sent when no local_ip was known. This case is allowed as well.
             Some(info) if info.network_path.is_probably_same_path(&self.network_path) => {
-                self.network_path.update_local_if_same_remote(&network_path);
+                // Do not update or set the self.network_path.local_ip:
+                // Connection::process_payload does this the correct way for non-probing
+                // packets. We can mark the path as validated though, because for a change
+                // in local_ip only we do not need to re-validate the path.
                 let sent_instant = info.sent_instant;
                 if !std::mem::replace(&mut self.validated, true) {
                     trace!("new path validated");

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -508,22 +508,18 @@ impl PathData {
         // - network path used to send the path challenge (`SentChallengeInfo::network_path`)
         // - network path over which the response arrived (not needed)
         //
-        // As per https://www.rfc-editor.org/rfc/rfc9000.html#section-8.2.3-1, this only
-        // validates the network path on which this was *sent*, regardless of the path on
-        // which it was received in order to protect against off-path packet forwarding
-        // attacks:
-        //
-        // > A PATH_RESPONSE frame received on any network path validates the path on which
-        // > the PATH_CHALLENGE was sent.
+        // As per above spec quote, this only validates the network path on which this was
+        // *sent*, regardless of the path on which it was received in order to protect
+        // against off-path packet forwarding attacks.
         match self.unconfirmed_challenges.remove(&token) {
             // Response to an on-path PathChallenge that validates this path.
             // The sent path should match the current path. However, it's possible that the
             // challenge was sent when no local_ip was known. This case is allowed as well.
             Some(info) if info.network_path.is_probably_same_path(&self.network_path) => {
                 // Do not update or set the self.network_path.local_ip:
-                // Connection::process_payload does this the correct way for non-probing
-                // packets. We can mark the path as validated though, because for a change
-                // in local_ip only we do not need to re-validate the path.
+                // Connection::process_payload handles this later when required. We can mark
+                // the path as validated though, because for a change in local_ip only we do
+                // not need to re-validate the path.
                 let sent_instant = info.sent_instant;
                 if !std::mem::replace(&mut self.validated, true) {
                     trace!("new path validated");

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -508,9 +508,13 @@ impl PathData {
         // - network path used to send the path challenge (`SentChallengeInfo::network_path`)
         // - network path over which the response arrived (not needed)
         //
-        // As per the spec, this only validates the network path on which this was *sent*,
-        // regardless of the path on which it was received in order to protect against
-        // off-path packet forwarding attacks.
+        // As per https://www.rfc-editor.org/rfc/rfc9000.html#section-8.2.3-1, this only
+        // validates the network path on which this was *sent*, regardless of the path on
+        // which it was received in order to protect against off-path packet forwarding
+        // attacks:
+        //
+        // > A PATH_RESPONSE frame received on any network path validates the path on which
+        // > the PATH_CHALLENGE was sent.
         match self.unconfirmed_challenges.remove(&token) {
             // Response to an on-path PathChallenge that validates this path.
             // The sent path should match the current path. However, it's possible that the

--- a/noq-proto/src/lib.rs
+++ b/noq-proto/src/lib.rs
@@ -435,23 +435,6 @@ impl FourTuple {
     pub(crate) fn is_probably_same_path(&self, other: &Self) -> bool {
         self.remote == other.remote && (self.local_ip.is_none() || self.local_ip == other.local_ip)
     }
-
-    /// Updates this tuple's local address iff
-    /// - it was unset before,
-    /// - the other tuple has the same remote, and
-    /// - the other tuple has a local address set.
-    ///
-    /// Returns whether this and the other remote are now fully equal.
-    pub(crate) fn update_local_if_same_remote(&mut self, other: &Self) -> bool {
-        if self.remote != other.remote {
-            return false;
-        }
-        if self.local_ip.is_some() && self.local_ip != other.local_ip {
-            return false;
-        }
-        self.local_ip = other.local_ip;
-        true
-    }
 }
 
 impl fmt::Display for FourTuple {


### PR DESCRIPTION
## Description

When receiving a PATH_RESPONSE for which the 4-tuple of the challenge
matches the local network path the path should be marked as
validated. But it should not itself update the PathData::network_path
of that path generation. This is already being correctly handled,
taking packet numbers and probing packets into account, at the end of
Connection::process_payload.

If the local IP *did* somehow change after the challenge was sent but
before the response was received, the PathData::network_path will no
longer match the path the challenge was sent on and the response will
be ignored. This means the timers would remain set and a new challenge
would be sent.

## Breaking Changes

none

## Notes & open questions

none

## Change checklist

- [x] Self-review.