### PR TITLE
fix(proto): Send CONNECTION_CLOSE also during the handshake

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -216,7 +216,7 @@ pub struct Connection {
     // Queued non-retransmittable 1-RTT data
     //
     /// If the CONNECTION_CLOSE frame needs to be sent
-    connection_close_pending: bool,
+    pending_connection_close: bool,
 
     //
     // ACK frequency
@@ -398,7 +398,7 @@ impl Connection {
             },
             timers: TimerTable::default(),
             authentication_failures: 0,
-            connection_close_pending: false,
+            pending_connection_close: false,
 
             ack_frequency: AckFrequencyState::new(get_max_ack_delay(
                 &TransportParameters::default(),
@@ -1046,7 +1046,7 @@ impl Connection {
             StateType::Draining | StateType::Closed => {
                 // self.connection_close_pending is only reset once the associated packet
                 // had been encoded successfully
-                if !self.connection_close_pending {
+                if !self.pending_connection_close {
                     for path in self.paths.values_mut() {
                         path.data.app_limited = true;
                     }
@@ -1668,7 +1668,7 @@ impl Connection {
                 if space_id.kind() == self.highest_space {
                     // Don't send another close packet. Even with multipath we only send
                     // CONNECTION_CLOSE on a single path since we expect our paths to work.
-                    self.connection_close_pending = false;
+                    self.pending_connection_close = false;
                 }
                 // Send a close frame in every possible space for robustness, per
                 // RFC9000 "Immediate Close during the Handshake". Don't bother trying
@@ -2469,7 +2469,7 @@ impl Connection {
                             );
                             self.close_common();
                             self.set_close_timer(now);
-                            self.connection_close_pending = true;
+                            self.pending_connection_close = true;
                             self.state.move_to_closed(err);
                         }
                     }
@@ -2620,7 +2620,7 @@ impl Connection {
         if !was_closed {
             self.close_common();
             self.set_close_timer(now);
-            self.connection_close_pending = true;
+            self.pending_connection_close = true;
             self.state.move_to_closed_local(reason);
         }
     }
@@ -4463,7 +4463,7 @@ impl Connection {
                 .map(|p| p.data.validated && p.data.network_path == network_path)
                 .unwrap_or(false)
             {
-                self.connection_close_pending = true;
+                self.pending_connection_close = true;
             }
         }
     }
@@ -4859,7 +4859,7 @@ impl Connection {
                 Frame::Close(reason) => {
                     self.state.move_to_draining(Some(reason.into()));
                     self.endpoint_events.push_back(EndpointEventInner::Draining);
-                    self.connection_close_pending = true;
+                    self.pending_connection_close = true;
                     return Ok(());
                 }
                 _ => {
@@ -5550,7 +5550,7 @@ impl Connection {
         if let Some(reason) = close {
             self.state.move_to_draining(Some(reason.into()));
             self.endpoint_events.push_back(EndpointEventInner::Draining);
-            self.connection_close_pending = true;
+            self.pending_connection_close = true;
         }
 
         // For Multipath any packet triggers migration. For RFC9000 or QNT (+ Multipath)
@@ -6964,7 +6964,7 @@ impl Connection {
             if !self.state.is_drained() {
                 self.set_close_timer(now);
             }
-            self.connection_close_pending = true;
+            self.pending_connection_close = true;
         }
     }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4859,6 +4859,7 @@ impl Connection {
                 Frame::Close(reason) => {
                     self.state.move_to_draining(Some(reason.into()));
                     self.endpoint_events.push_back(EndpointEventInner::Draining);
+                    self.connection_close_pending = true;
                     return Ok(());
                 }
                 _ => {

--- a/noq/src/tests.rs
+++ b/noq/src/tests.rs
@@ -1711,6 +1711,63 @@ async fn recv_stream_cancel_stop_drop() {
     );
 }
 
+/// Smoke test for normal behaviour of `Incoming::accept` after `Endpoint::close`.
+#[tokio::test(start_paused = true)]
+async fn smoke_wait_all_draining_after_incoming_accept_on_closed() -> TestResult {
+    let _guard = subscribe();
+
+    /// Draining should happen really fast. This ensures it doesn't hang.
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+
+    let factory = EndpointFactory::new();
+    let client = factory.endpoint("client");
+    let server = factory.endpoint("server");
+    let addr = server.local_addr()?;
+
+    let conn = client.connect(addr, "localhost")?;
+    let incoming = server.accept().await.unwrap();
+
+    server.close(0u32.into(), b"");
+
+    tokio::time::timeout(WAIT_TIMEOUT, server.wait_all_draining()).await?;
+
+    // This gives the endpoint another connection, but it should immediately be closed.
+    drop(incoming.accept()?);
+    conn.await.expect_err("closed during handshake");
+
+    tokio::time::timeout(WAIT_TIMEOUT, server.wait_all_draining()).await?;
+
+    Ok(())
+}
+
+/// Tests connection graceful connection close during handshaking.
+#[tokio::test(start_paused = true)]
+async fn graceful_close_during_handshake() -> TestResult {
+    let _guard = subscribe();
+
+    // Well above the expected fast draining time, but well below 3 * PTO ~ 3s.
+    const WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+
+    let factory = EndpointFactory::new();
+    let client = factory.endpoint("client");
+    let server = factory.endpoint("server");
+    let addr = server.local_addr()?;
+
+    let conn = client.connect(addr, "localhost")?;
+    let _server_conn = server.accept().await.unwrap().accept()?;
+
+    // Let the server send a connection close on the handshaking `Connecting`
+    server.close(0u32.into(), b"");
+
+    // The client should respond with a CONNECTION_CLOSE, allowing
+    // the server to transition to draining immediately.
+    tokio::time::timeout(WAIT_TIMEOUT, server.wait_all_draining()).await?;
+
+    conn.await.expect_err("should be closed");
+
+    Ok(())
+}
+
 #[derive(Default)]
 struct WakeCounter {
     wakes: AtomicUsize,


### PR DESCRIPTION
## Description

There are places handling CONNECTION_CLOSE frames in noq-proto. One is in `process_early_packet`, which processes frames during the handshake, and `process_packet`, handling frames any other time.
When we received a CONNECTION_CLOSE frame over the wire, the latter would move the state to draining and set `connection_close_pending = true`. The former would do almost the same, except it wouldn't set the close frame to pending.
This meant that connections that were closed by the server during the handshake would close on the client side without it sending a CONNECTION_CLOSE frame itself. The server side was thus left hanging and wouldn't close "gracefully".

This PR just aligns the behavior between these two places.

## Breaking Changes

None

## Notes & open questions

Disclosure: Heavily assisted by GLM 5.2.

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
- [x] All breaking changes documented.
