### PR TITLE
fix!(proto): Deprecate UdpStats::ios as io-operations can't be measured from this crate

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2209,6 +2209,7 @@ impl Connection {
                 let rx = &mut self.path_stats.for_path(path_id).udp_rx;
                 rx.datagrams += 1;
                 rx.bytes += first_decode.len() as u64;
+                rx.ios += 1;
                 let data_len = first_decode.len();
 
                 self.handle_decode(now, network_path, path_id, ecn, first_decode);
@@ -4227,8 +4228,6 @@ impl Connection {
         stateless_reset: bool,
         mut qlog: QlogRecvPacket,
     ) {
-        self.path_stats.for_path(path_id).udp_rx.ios += 1;
-
         if let Some(ref packet) = packet {
             trace!(
                 "got {:?} packet ({} bytes) from {} using id {}",

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2209,7 +2209,6 @@ impl Connection {
                 let rx = &mut self.path_stats.for_path(path_id).udp_rx;
                 rx.datagrams += 1;
                 rx.bytes += first_decode.len() as u64;
-                rx.ios += 1;
                 let data_len = first_decode.len();
 
                 self.handle_decode(now, network_path, path_id, ecn, first_decode);

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1074,7 +1074,7 @@ impl Connection {
             {
                 #[cfg(test)]
                 {
-                    self.partial_stats.transmit_count += 1;
+                    self.partial_stats.transmit_tx += 1;
                 }
                 return Some(transmit);
             }
@@ -1090,7 +1090,7 @@ impl Connection {
             ) {
                 #[cfg(test)]
                 {
-                    self.partial_stats.transmit_count += 1;
+                    self.partial_stats.transmit_tx += 1;
                 }
                 return Some(transmit);
             }
@@ -1118,7 +1118,7 @@ impl Connection {
                 if let Some(transmit) = self.poll_transmit_mtu_probe(now, buf, path_id) {
                     #[cfg(test)]
                     {
-                        self.partial_stats.transmit_count += 1;
+                        self.partial_stats.transmit_tx += 1;
                     }
                     return Some(transmit);
                 }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1072,6 +1072,10 @@ impl Connection {
             if !connection_close_pending
                 && let Some(transmit) = self.poll_transmit_off_path(now, buf, path_id)
             {
+                #[cfg(test)]
+                {
+                    self.partial_stats.gso_batches += 1;
+                }
                 return Some(transmit);
             }
 
@@ -1084,6 +1088,10 @@ impl Connection {
                 &info,
                 connection_close_pending,
             ) {
+                #[cfg(test)]
+                {
+                    self.partial_stats.gso_batches += 1;
+                }
                 return Some(transmit);
             }
 
@@ -1108,6 +1116,10 @@ impl Connection {
             let mut next_path_id = self.paths.first_entry().map(|e| *e.key());
             while let Some(path_id) = next_path_id {
                 if let Some(transmit) = self.poll_transmit_mtu_probe(now, buf, path_id) {
+                    #[cfg(test)]
+                    {
+                        self.partial_stats.gso_batches += 1;
+                    }
                     return Some(transmit);
                 }
                 next_path_id = self.paths.keys().find(|i| **i > path_id).copied();

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1074,7 +1074,7 @@ impl Connection {
             {
                 #[cfg(test)]
                 {
-                    self.partial_stats.gso_batches += 1;
+                    self.partial_stats.transmit_count += 1;
                 }
                 return Some(transmit);
             }
@@ -1090,7 +1090,7 @@ impl Connection {
             ) {
                 #[cfg(test)]
                 {
-                    self.partial_stats.gso_batches += 1;
+                    self.partial_stats.transmit_count += 1;
                 }
                 return Some(transmit);
             }
@@ -1118,7 +1118,7 @@ impl Connection {
                 if let Some(transmit) = self.poll_transmit_mtu_probe(now, buf, path_id) {
                     #[cfg(test)]
                     {
-                        self.partial_stats.gso_batches += 1;
+                        self.partial_stats.transmit_count += 1;
                     }
                     return Some(transmit);
                 }

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1074,7 +1074,7 @@ impl Connection {
             {
                 #[cfg(test)]
                 {
-                    self.partial_stats.transmit_tx += 1;
+                    self.partial_stats.transmits_tx += 1;
                 }
                 return Some(transmit);
             }
@@ -1090,7 +1090,7 @@ impl Connection {
             ) {
                 #[cfg(test)]
                 {
-                    self.partial_stats.transmit_tx += 1;
+                    self.partial_stats.transmits_tx += 1;
                 }
                 return Some(transmit);
             }
@@ -1118,7 +1118,7 @@ impl Connection {
                 if let Some(transmit) = self.poll_transmit_mtu_probe(now, buf, path_id) {
                     #[cfg(test)]
                     {
-                        self.partial_stats.transmit_tx += 1;
+                        self.partial_stats.transmits_tx += 1;
                     }
                     return Some(transmit);
                 }

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -272,7 +272,7 @@ pub struct ConnectionStats {
 
     /// Number of [`super::Transmit`] produced by this connection.
     #[cfg(test)]
-    pub(crate) transmit_count: u64,
+    pub(crate) transmit_tx: u64,
 }
 
 impl std::ops::Add<PathStats> for ConnectionStats {
@@ -305,7 +305,7 @@ impl std::ops::Add<PathStats> for ConnectionStats {
             lost_packets: self.lost_packets + lost_packets,
             lost_bytes: self.lost_bytes + lost_bytes,
             #[cfg(test)]
-            transmit_count: self.transmit_count,
+            transmit_tx: self.transmit_tx,
         }
     }
 }
@@ -338,7 +338,7 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
             lost_packets,
             lost_bytes,
             #[cfg(test)]
-                transmit_count: _,
+                transmit_tx: _,
         } = self;
         *udp_tx += path_udp_tx;
         *udp_rx += path_udp_rx;

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -20,9 +20,9 @@ pub struct UdpStats {
     pub bytes: u64,
     /// The number of I/O operations executed.
     ///
-    /// Can be less than `datagrams` when GSO, GRO, and/or batched system calls are in use.
+    /// This can't be measured from this crate and will always be 0
     #[deprecated(
-        since = "1.0.1",
+        since = "1.0.2",
         note = "IO counting can't be meaningfully measured from this crate. See <https://github.com/n0-computer/noq/issues/727>"
     )]
     pub ios: u64,
@@ -270,9 +270,9 @@ pub struct ConnectionStats {
     /// The number of bytes lost on the connection.
     pub lost_bytes: u64,
 
-    /// Batches produced by this connection.
+    /// Number of [`super::Transmit`] produced by this connection.
     #[cfg(test)]
-    pub(crate) gso_batches: u64,
+    pub(crate) transmit_count: u64,
 }
 
 impl std::ops::Add<PathStats> for ConnectionStats {
@@ -305,7 +305,7 @@ impl std::ops::Add<PathStats> for ConnectionStats {
             lost_packets: self.lost_packets + lost_packets,
             lost_bytes: self.lost_bytes + lost_bytes,
             #[cfg(test)]
-            gso_batches: self.gso_batches,
+            transmit_count: self.transmit_count,
         }
     }
 }
@@ -338,7 +338,7 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
             lost_packets,
             lost_bytes,
             #[cfg(test)]
-                gso_batches: _,
+                transmit_count: _,
         } = self;
         *udp_tx += path_udp_tx;
         *udp_rx += path_udp_rx;

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -22,6 +22,7 @@ pub struct UdpStats {
     ///
     /// Can be less than `datagrams` when GSO, GRO, and/or batched system calls are in use.
     #[deprecated(
+        since = "1.0.1",
         note = "IO counting can't be meaningfully measured from this crate. See <https://github.com/n0-computer/noq/issues/727>"
     )]
     pub ios: u64,
@@ -269,7 +270,7 @@ pub struct ConnectionStats {
     /// The number of bytes lost on the connection.
     pub lost_bytes: u64,
 
-    /// Batches produced by this connetion.
+    /// Batches produced by this connection.
     #[cfg(test)]
     pub(crate) gso_batches: u64,
 }

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -272,7 +272,7 @@ pub struct ConnectionStats {
 
     /// Number of [`super::Transmit`] produced by this connection.
     #[cfg(test)]
-    pub(crate) transmit_tx: u64,
+    pub(crate) transmits_tx: u64,
 }
 
 impl std::ops::Add<PathStats> for ConnectionStats {
@@ -305,7 +305,7 @@ impl std::ops::Add<PathStats> for ConnectionStats {
             lost_packets: self.lost_packets + lost_packets,
             lost_bytes: self.lost_bytes + lost_bytes,
             #[cfg(test)]
-            transmit_tx: self.transmit_tx,
+            transmits_tx: self.transmits_tx,
         }
     }
 }
@@ -338,7 +338,7 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
             lost_packets,
             lost_bytes,
             #[cfg(test)]
-                transmit_tx: _,
+                transmits_tx: _,
         } = self;
         *udp_tx += path_udp_tx;
         *udp_rx += path_udp_rx;

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -21,6 +21,9 @@ pub struct UdpStats {
     /// The number of I/O operations executed.
     ///
     /// Can be less than `datagrams` when GSO, GRO, and/or batched system calls are in use.
+    #[deprecated(
+        note = "IO counting can't be meaningfully measured from this crate. See <https://github.com/n0-computer/noq/issues/727>"
+    )]
     pub ios: u64,
 }
 
@@ -28,7 +31,6 @@ impl UdpStats {
     pub(crate) fn on_sent(&mut self, datagrams: u64, bytes: usize) {
         self.datagrams += datagrams;
         self.bytes += bytes as u64;
-        self.ios += 1;
     }
 }
 
@@ -266,6 +268,10 @@ pub struct ConnectionStats {
     pub lost_packets: u64,
     /// The number of bytes lost on the connection.
     pub lost_bytes: u64,
+
+    /// Batches produced by this connetion.
+    #[cfg(test)]
+    pub(crate) gso_batches: u64,
 }
 
 impl std::ops::Add<PathStats> for ConnectionStats {
@@ -297,6 +303,8 @@ impl std::ops::Add<PathStats> for ConnectionStats {
             frame_rx: self.frame_rx + frame_rx,
             lost_packets: self.lost_packets + lost_packets,
             lost_bytes: self.lost_bytes + lost_bytes,
+            #[cfg(test)]
+            gso_batches: self.gso_batches,
         }
     }
 }
@@ -328,6 +336,8 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
             frame_rx,
             lost_packets,
             lost_bytes,
+            #[cfg(test)]
+                gso_batches: _,
         } = self;
         *udp_tx += path_udp_tx;
         *udp_rx += path_udp_rx;

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2198,7 +2198,7 @@ fn tail_loss_respect_max_datagrams() {
 
     // Finally checking the number of sent udp datagrams match the number of iops
     let client_stats = pair.client_conn_mut(client_ch).stats();
-    assert_eq!(client_stats.transmit_count, client_stats.udp_tx.datagrams);
+    assert_eq!(client_stats.transmit_tx, client_stats.udp_tx.datagrams);
 }
 
 #[test]
@@ -3501,7 +3501,7 @@ fn stream_gso() {
 
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
 
     // Send 20KiB of stream data, which comfortably fits inside two `tests::util::MAX_DATAGRAMS`
     // datagram batches
@@ -3511,7 +3511,7 @@ fn stream_gso() {
     }
     pair.client_send(client_ch, s).finish().unwrap();
     pair.drive();
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
     assert_eq!(final_transmit_count - initial_transmit_count, 2);
 }
 
@@ -3521,7 +3521,7 @@ fn datagram_gso() {
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
     let initial_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
 
     // Send 10 datagrams above half the MTU, which fits inside a `tests::util::MAX_DATAGRAMS`
@@ -3535,7 +3535,7 @@ fn datagram_gso() {
             .unwrap();
     }
     pair.drive();
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
     let final_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
     assert_eq!(final_transmit_count - initial_transmit_count, 1);
     // Expected overhead: flags + CID + PN + tag + frame type + frame length = 1 + 8 + 1 + 16 + 1 + 2 = 29
@@ -3551,7 +3551,7 @@ fn gso_truncation() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
 
     // Send three application datagrams such that each is large to be combined with another in a
     // single MTU, and the second datagram would require an unreasonably large amount of padding to
@@ -3564,7 +3564,7 @@ fn gso_truncation() {
             .unwrap();
     }
     pair.drive();
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
     assert_eq!(final_transmit_count - initial_transmit_count, 2);
     for len in SIZES {
         assert_eq!(
@@ -3596,7 +3596,7 @@ fn pad_to_mtu() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect_with(client_config);
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
     pair.server.capture_inbound_packets = true;
 
     info!("sending");
@@ -3624,7 +3624,7 @@ fn pad_to_mtu() {
     pair.drive();
 
     // Check that both datagrams ended up in the same GSO batch
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
     assert_eq!(final_transmit_count - initial_transmit_count, 1);
 
     assert_eq!(

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2198,7 +2198,7 @@ fn tail_loss_respect_max_datagrams() {
 
     // Finally checking the number of sent udp datagrams match the number of iops
     let client_stats = pair.client_conn_mut(client_ch).stats();
-    assert_eq!(client_stats.gso_batches, client_stats.udp_tx.datagrams);
+    assert_eq!(client_stats.transmit_count, client_stats.udp_tx.datagrams);
 }
 
 #[test]
@@ -3501,7 +3501,7 @@ fn stream_gso() {
 
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
 
-    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
 
     // Send 20KiB of stream data, which comfortably fits inside two `tests::util::MAX_DATAGRAMS`
     // datagram batches
@@ -3511,8 +3511,8 @@ fn stream_gso() {
     }
     pair.client_send(client_ch, s).finish().unwrap();
     pair.drive();
-    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
-    assert_eq!(final_gso_batches - initial_gso_batches, 2);
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    assert_eq!(final_transmit_count - initial_transmit_count, 2);
 }
 
 #[test]
@@ -3521,7 +3521,7 @@ fn datagram_gso() {
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
-    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
     let initial_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
 
     // Send 10 datagrams above half the MTU, which fits inside a `tests::util::MAX_DATAGRAMS`
@@ -3535,9 +3535,9 @@ fn datagram_gso() {
             .unwrap();
     }
     pair.drive();
-    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
     let final_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
-    assert_eq!(final_gso_batches - initial_gso_batches, 1);
+    assert_eq!(final_transmit_count - initial_transmit_count, 1);
     // Expected overhead: flags + CID + PN + tag + frame type + frame length = 1 + 8 + 1 + 16 + 1 + 2 = 29
     assert_eq!(
         final_bytes - initial_bytes,
@@ -3551,7 +3551,7 @@ fn gso_truncation() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
 
     // Send three application datagrams such that each is large to be combined with another in a
     // single MTU, and the second datagram would require an unreasonably large amount of padding to
@@ -3564,8 +3564,8 @@ fn gso_truncation() {
             .unwrap();
     }
     pair.drive();
-    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
-    assert_eq!(final_gso_batches - initial_gso_batches, 2);
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    assert_eq!(final_transmit_count - initial_transmit_count, 2);
     for len in SIZES {
         assert_eq!(
             pair.server_datagrams(server_ch)
@@ -3596,7 +3596,7 @@ fn pad_to_mtu() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect_with(client_config);
 
-    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
     pair.server.capture_inbound_packets = true;
 
     info!("sending");
@@ -3624,8 +3624,8 @@ fn pad_to_mtu() {
     pair.drive();
 
     // Check that both datagrams ended up in the same GSO batch
-    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
-    assert_eq!(final_gso_batches - initial_gso_batches, 1);
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_count;
+    assert_eq!(final_transmit_count - initial_transmit_count, 1);
 
     assert_eq!(
         pair.server_datagrams(server_ch)

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2202,7 +2202,7 @@ fn tail_loss_respect_max_datagrams() {
 }
 
 #[test]
-fn udp_rx_ios_overcounts_coalesced_packets() {
+fn udp_rx_ios_overcounts_batches_udp_datagrams() {
     // this is a regression test
     let _guard = subscribe();
     let mut pair = ConnPair::default();

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2198,18 +2198,7 @@ fn tail_loss_respect_max_datagrams() {
 
     // Finally checking the number of sent udp datagrams match the number of iops
     let client_stats = pair.client_conn_mut(client_ch).stats();
-    assert_eq!(client_stats.udp_tx.ios, client_stats.udp_tx.datagrams);
-}
-
-#[test]
-fn udp_rx_ios_overcounts_batched_udp_datagrams() {
-    // this is a regression test
-    let _guard = subscribe();
-    let mut pair = ConnPair::default();
-
-    let client_stats = pair.conn_mut(Client).stats();
-
-    assert!(client_stats.udp_rx.ios <= client_stats.udp_rx.datagrams);
+    assert_eq!(client_stats.gso_batches, client_stats.udp_tx.datagrams);
 }
 
 #[test]
@@ -3512,7 +3501,7 @@ fn stream_gso() {
 
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
 
     // Send 20KiB of stream data, which comfortably fits inside two `tests::util::MAX_DATAGRAMS`
     // datagram batches
@@ -3522,7 +3511,7 @@ fn stream_gso() {
     }
     pair.client_send(client_ch, s).finish().unwrap();
     pair.drive();
-    let final_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
     assert_eq!(final_ios - initial_ios, 2);
 }
 
@@ -3532,7 +3521,7 @@ fn datagram_gso() {
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
     let initial_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
 
     // Send 10 datagrams above half the MTU, which fits inside a `tests::util::MAX_DATAGRAMS`
@@ -3546,7 +3535,7 @@ fn datagram_gso() {
             .unwrap();
     }
     pair.drive();
-    let final_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
     let final_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
     assert_eq!(final_ios - initial_ios, 1);
     // Expected overhead: flags + CID + PN + tag + frame type + frame length = 1 + 8 + 1 + 16 + 1 + 2 = 29
@@ -3562,7 +3551,7 @@ fn gso_truncation() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
 
     // Send three application datagrams such that each is large to be combined with another in a
     // single MTU, and the second datagram would require an unreasonably large amount of padding to
@@ -3575,7 +3564,7 @@ fn gso_truncation() {
             .unwrap();
     }
     pair.drive();
-    let final_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
     assert_eq!(final_ios - initial_ios, 2);
     for len in SIZES {
         assert_eq!(
@@ -3607,7 +3596,7 @@ fn pad_to_mtu() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect_with(client_config);
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
     pair.server.capture_inbound_packets = true;
 
     info!("sending");
@@ -3635,7 +3624,7 @@ fn pad_to_mtu() {
     pair.drive();
 
     // Check that both datagrams ended up in the same GSO batch
-    let final_ios = pair.client_conn_mut(client_ch).stats().udp_tx.ios;
+    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
     assert_eq!(final_ios - initial_ios, 1);
 
     assert_eq!(

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2198,7 +2198,7 @@ fn tail_loss_respect_max_datagrams() {
 
     // Finally checking the number of sent udp datagrams match the number of iops
     let client_stats = pair.client_conn_mut(client_ch).stats();
-    assert_eq!(client_stats.transmit_tx, client_stats.udp_tx.datagrams);
+    assert_eq!(client_stats.transmits_tx, client_stats.udp_tx.datagrams);
 }
 
 #[test]
@@ -3501,7 +3501,7 @@ fn stream_gso() {
 
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
 
     // Send 20KiB of stream data, which comfortably fits inside two `tests::util::MAX_DATAGRAMS`
     // datagram batches
@@ -3511,7 +3511,7 @@ fn stream_gso() {
     }
     pair.client_send(client_ch, s).finish().unwrap();
     pair.drive();
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
     assert_eq!(final_transmit_count - initial_transmit_count, 2);
 }
 
@@ -3521,7 +3521,7 @@ fn datagram_gso() {
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
     let initial_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
 
     // Send 10 datagrams above half the MTU, which fits inside a `tests::util::MAX_DATAGRAMS`
@@ -3535,7 +3535,7 @@ fn datagram_gso() {
             .unwrap();
     }
     pair.drive();
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
     let final_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
     assert_eq!(final_transmit_count - initial_transmit_count, 1);
     // Expected overhead: flags + CID + PN + tag + frame type + frame length = 1 + 8 + 1 + 16 + 1 + 2 = 29
@@ -3551,7 +3551,7 @@ fn gso_truncation() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
 
     // Send three application datagrams such that each is large to be combined with another in a
     // single MTU, and the second datagram would require an unreasonably large amount of padding to
@@ -3564,7 +3564,7 @@ fn gso_truncation() {
             .unwrap();
     }
     pair.drive();
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
     assert_eq!(final_transmit_count - initial_transmit_count, 2);
     for len in SIZES {
         assert_eq!(
@@ -3596,7 +3596,7 @@ fn pad_to_mtu() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect_with(client_config);
 
-    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let initial_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
     pair.server.capture_inbound_packets = true;
 
     info!("sending");
@@ -3624,7 +3624,7 @@ fn pad_to_mtu() {
     pair.drive();
 
     // Check that both datagrams ended up in the same GSO batch
-    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmit_tx;
+    let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
     assert_eq!(final_transmit_count - initial_transmit_count, 1);
 
     assert_eq!(

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2202,6 +2202,17 @@ fn tail_loss_respect_max_datagrams() {
 }
 
 #[test]
+fn udp_rx_ios_overcounts_coalesced_packets() {
+    // this is a regression test
+    let _guard = subscribe();
+    let mut pair = ConnPair::default();
+
+    let client_stats = pair.conn_mut(Client).stats();
+
+    assert!(client_stats.udp_rx.ios <= client_stats.udp_rx.datagrams);
+}
+
+#[test]
 fn datagram_send_recv() {
     let _guard = subscribe();
     let mut pair = Pair::default();

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -3501,7 +3501,7 @@ fn stream_gso() {
 
     let s = pair.client_streams(client_ch).open(Dir::Uni).unwrap();
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
 
     // Send 20KiB of stream data, which comfortably fits inside two `tests::util::MAX_DATAGRAMS`
     // datagram batches
@@ -3511,8 +3511,8 @@ fn stream_gso() {
     }
     pair.client_send(client_ch, s).finish().unwrap();
     pair.drive();
-    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
-    assert_eq!(final_ios - initial_ios, 2);
+    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    assert_eq!(final_gso_batches - initial_gso_batches, 2);
 }
 
 #[test]
@@ -3521,7 +3521,7 @@ fn datagram_gso() {
     let mut pair = Pair::default();
     let (client_ch, _) = pair.connect();
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
     let initial_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
 
     // Send 10 datagrams above half the MTU, which fits inside a `tests::util::MAX_DATAGRAMS`
@@ -3535,9 +3535,9 @@ fn datagram_gso() {
             .unwrap();
     }
     pair.drive();
-    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
     let final_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
-    assert_eq!(final_ios - initial_ios, 1);
+    assert_eq!(final_gso_batches - initial_gso_batches, 1);
     // Expected overhead: flags + CID + PN + tag + frame type + frame length = 1 + 8 + 1 + 16 + 1 + 2 = 29
     assert_eq!(
         final_bytes - initial_bytes,
@@ -3551,7 +3551,7 @@ fn gso_truncation() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect();
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
 
     // Send three application datagrams such that each is large to be combined with another in a
     // single MTU, and the second datagram would require an unreasonably large amount of padding to
@@ -3564,8 +3564,8 @@ fn gso_truncation() {
             .unwrap();
     }
     pair.drive();
-    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
-    assert_eq!(final_ios - initial_ios, 2);
+    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    assert_eq!(final_gso_batches - initial_gso_batches, 2);
     for len in SIZES {
         assert_eq!(
             pair.server_datagrams(server_ch)
@@ -3596,7 +3596,7 @@ fn pad_to_mtu() {
     let mut pair = Pair::default();
     let (client_ch, server_ch) = pair.connect_with(client_config);
 
-    let initial_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
+    let initial_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
     pair.server.capture_inbound_packets = true;
 
     info!("sending");
@@ -3624,8 +3624,8 @@ fn pad_to_mtu() {
     pair.drive();
 
     // Check that both datagrams ended up in the same GSO batch
-    let final_ios = pair.client_conn_mut(client_ch).stats().gso_batches;
-    assert_eq!(final_ios - initial_ios, 1);
+    let final_gso_batches = pair.client_conn_mut(client_ch).stats().gso_batches;
+    assert_eq!(final_gso_batches - initial_gso_batches, 1);
 
     assert_eq!(
         pair.server_datagrams(server_ch)

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -2202,7 +2202,7 @@ fn tail_loss_respect_max_datagrams() {
 }
 
 #[test]
-fn udp_rx_ios_overcounts_batches_udp_datagrams() {
+fn udp_rx_ios_overcounts_batched_udp_datagrams() {
     // this is a regression test
     let _guard = subscribe();
     let mut pair = ConnPair::default();


### PR DESCRIPTION
## Description

Closes #727 
Deprecates `ios` in `UdpStats`. It's a bit of a shame that `UdpStats` is shared by so many places, path's sending stats, receiving stats, connection-wide send and recv stats. There is no field that captures something like this and makes sense across all of them, so adding it would make for a structural change.

This field was clearly added to test gso batching: a connection-wide sending stat. This is the only place where this is meaningful, so to be able to continue testing this, a test only field is added to the connection stats.

## Breaking Changes

- Deprecates `UdpStats::ios` without replacement. See #727 If you do need to count io operations, please do so by incorporating counting operations in your `AsyncUdpSocket` implementation

## Notes & open questions

If anyone seriously cares about this, we should know thanks to the deprecation warning, and would prompt us to add something that better fits with the rest of the stats. 

Whatever we do won't just be a undo of this PR as counting doesn't make sense in the rest of places, and the name is misleading. Basically, the deprecation warning should allow us to decide whether a larger change is required to get the `gso_batches` (what the field actually tried to measure, as noted by the tests) or if it can be cleanly removed. I'm tempted to say the latter, as I don't think users care too much about this. 

Now, if they _do_ want a count of `io` operations, that's an entirely different approach that requires interaction with the `AsyncUdpSocket`.

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Breaking changes documented.

<!--
tip:
   Run `cargo make` in the workspace root to check many light-weight CI steps locally.
-->
