### PR TITLE
deps: bump anyhow version to avoid unsoundness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"


### PR DESCRIPTION
## Description

Today's cargo-deny gift

## Breaking Changes

none

## Notes & open questions

Not updating Cargo.toml because there's no API issue with those
versions for us. It's not our job to make sure users use sound
versions I guess.

## Change checklist

- [x] Self-review.