### PR TITLE
chore: improve semver checks for stable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,20 +410,8 @@ jobs:
         with:
           go-version: "stable"
 
-      - name: Setup Environment (PR)
-        if: ${{ github.event_name == 'pull_request' }}
-        shell: bash
-        run: |
-          echo "HEAD_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})" >> ${GITHUB_ENV}
-      - name: Setup Environment (Push)
-        if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
-        shell: bash
-        run: |
-          echo "HEAD_COMMIT_SHA=$(git rev-parse origin/main)" >> ${GITHUB_ENV}
       - name: Check semver
         # uses: obi1kenobi/cargo-semver-checks-action@v2
         uses: n0-computer/cargo-semver-checks-action@feat-baseline
         with:
           package: noq, noq-proto, noq-udp
-          baseline-rev: ${{ env.HEAD_COMMIT_SHA }}
-          use-cache: false

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -79,14 +79,12 @@ jobs:
           echo noq-udp version: $NOQ_UDP_VERSION
 
           sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh/Cargo.toml
-          sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh/bench/Cargo.toml
           sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh/Cargo.toml
-          sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh/bench/Cargo.toml
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/Cargo.toml
-          sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/bench/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh-relay/Cargo.toml
+          sed -i -E "/^noq = \"[0-9.]+\"/s/\"[0-9.]+\"/\"\1\" $NOQ_VERSION/" iroh/bench/Cargo.toml
 
 
       - name: Build patchbay tests

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -67,14 +67,16 @@ jobs:
           noq-udp = { path = "../noq/noq-udp" }
           EOF
 
-          # Patch the version numbers
+          # Patch the version numbers. Note because the output of
+          # cargo-metadata is JSON, these variables will include the
+          # quotes around the version numbers.
           NOQ_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq") | .version')
           NOQ_PROTO_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-proto") | .version')
           NOQ_UDP_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-udp") | .version')
 
-          sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_VERSION\"/" iroh/Cargo.toml
-          sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_PROTO_VERSION\"/" iroh/Cargo.toml
-          sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_UDP_VERSION\"/" iroh/Cargo.toml
+          sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/Cargo.toml
 
 
       - name: Build patchbay tests

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -68,9 +68,9 @@ jobs:
           EOF
 
           # Patch the version numbers
-          NOQ_VERSION=#(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq") | .version')
-          NOQ_PROTO_VERSION=#(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-proto") | .version')
-          NOQ_UDP_VERSION=#(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-udp") | .version')
+          NOQ_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq") | .version')
+          NOQ_PROTO_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-proto") | .version')
+          NOQ_UDP_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-udp") | .version')
 
           sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_VERSION\"/" iroh/Cargo.toml
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_PROTO_VERSION\"/" iroh/Cargo.toml

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -67,6 +67,16 @@ jobs:
           noq-udp = { path = "../noq/noq-udp" }
           EOF
 
+          # Patch the version numbers
+          NOQ_VERSION=#(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq") | .version')
+          NOQ_PROTO_VERSION=#(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-proto") | .version')
+          NOQ_UDP_VERSION=#(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-udp") | .version')
+
+          sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_VERSION\"/" iroh/Cargo.toml
+          sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_PROTO_VERSION\"/" iroh/Cargo.toml
+          sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1\"$NOQ_UDP_VERSION\"/" iroh/Cargo.toml
+
+
       - name: Build patchbay tests
         working-directory: iroh
         run: cargo make patchbay --no-run

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -79,10 +79,13 @@ jobs:
           echo noq-udp version: $NOQ_UDP_VERSION
 
           sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh/bench/Cargo.toml
           sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh/bench/Cargo.toml
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/bench/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh-relay/Cargo.toml
 
 

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -70,9 +70,9 @@ jobs:
           # Patch the version numbers. Note because the output of
           # cargo-metadata is JSON, these variables will include the
           # quotes around the version numbers.
-          NOQ_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq") | .version')
-          NOQ_PROTO_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-proto") | .version')
-          NOQ_UDP_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-udp") | .version')
+          NOQ_VERSION=$(cargo metadata --manifest-path=../noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq") | .version')
+          NOQ_PROTO_VERSION=$(cargo metadata --manifest-path=../noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-proto") | .version')
+          NOQ_UDP_VERSION=$(cargo metadata --manifest-path=../noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-udp") | .version')
 
           echo noq version: $NOQ_VERSION
           echo noq-proto version: $NOQ_PROTO_VERSION

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -84,7 +84,7 @@ jobs:
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh-relay/Cargo.toml
-          sed -i -E "/^noq = \"[0-9.]+\"/s/\"[0-9.]+\"/\"$NOQ_VERSION\"/" iroh/bench/Cargo.toml
+          sed -i -E "/^noq = \"[0-9.]+\"/s/\"[0-9.]+\"/$NOQ_VERSION/" iroh/bench/Cargo.toml
 
 
       - name: Build patchbay tests

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -79,8 +79,11 @@ jobs:
           echo noq-udp version: $NOQ_UDP_VERSION
 
           sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/Cargo.toml
+          sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh-relay/Cargo.toml
 
 
       - name: Build patchbay tests

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -84,7 +84,7 @@ jobs:
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh-relay/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh-relay/Cargo.toml
-          sed -i -E "/^noq = \"[0-9.]+\"/s/\"[0-9.]+\"/\"\1\" $NOQ_VERSION/" iroh/bench/Cargo.toml
+          sed -i -E "/^noq = \"[0-9.]+\"/s/\"[0-9.]+\"/\"$NOQ_VERSION\"/" iroh/bench/Cargo.toml
 
 
       - name: Build patchbay tests

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -74,6 +74,10 @@ jobs:
           NOQ_PROTO_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-proto") | .version')
           NOQ_UDP_VERSION=$(cargo metadata --manifest-path=noq/Cargo.toml --format-version=1 --no-deps | jq '.packages[] | select(.name == "noq-udp") | .version')
 
+          echo noq version: $NOQ_VERSION
+          echo noq-proto version: $NOQ_PROTO_VERSION
+          echo noq-udp version: $NOQ_UDP_VERSION
+
           sed -i -E "/^noq .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_VERSION/" iroh/Cargo.toml
           sed -i -E "/^noq-proto .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_PROTO_VERSION/" iroh/Cargo.toml
           sed -i -E "/^noq-udp .*version/s/(version += +)\"[0-9.]+\"/\1 $NOQ_UDP_VERSION/" iroh/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.1.0"
+version = "1.1.0-alpha.0"
 dependencies = [
  "aes-gcm",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "arbitrary",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.1"
+version = "1.1.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-executor",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.1"
+version = "1.1.0-alpha.0"
 dependencies = [
  "cfg_aliases",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.1.0-alpha.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-executor",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.1.0-alpha.0"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "arbitrary",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.1.0-alpha.0"
+version = "1.1.0"
 dependencies = [
  "cfg_aliases",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["noq", "noq-proto", "noq-udp", "bench", "perf"]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.0-alpha.0"
+version = "1.1.0"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ default-members = ["noq", "noq-proto", "noq-udp", "bench", "perf"]
 resolver = "2"
 
 [workspace.package]
+version = "1.1.0-alpha.0"
 rust-version = "1.88"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,21 @@ unreachable_pub = "warn"
 manual_let_else = "warn"
 or_fun_call = "warn"
 use_self = "warn"
+
+[workspace.metadata.cargo-semver-checks.lints]
+enum_struct_variant_field_marked_deprecated = { required-update = "minor" }
+enum_tuple_variant_field_marked_deprecated = { required-update = "minor" }
+enum_variant_marked_deprecated = { required-update = "minor" }
+function_marked_deprecated = { required-update = "minor" }
+global_value_marked_deprecated = { required-update = "minor" }
+macro_marked_deprecated = { required-update = "minor" }
+proc_macro_marked_deprecated = { required-update = "minor" }
+struct_field_marked_deprecated = { required-update = "minor" }
+trait_associated_const_marked_deprecated = { required-update = "minor" }
+trait_associated_type_marked_deprecated = { required-update = "minor" }
+trait_marked_deprecated = { required-update = "minor" }
+trait_method_marked_deprecated = { required-update = "minor" }
+type_associated_const_marked_deprecated = { required-update = "minor" }
+type_marked_deprecated = { required-update = "minor" }
+type_method_marked_deprecated = { required-update = "minor" }
+union_field_marked_deprecated = { required-update = "minor" }

--- a/docs/book/Cargo.toml
+++ b/docs/book/Cargo.toml
@@ -11,6 +11,6 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 bytes = { workspace = true }
-noq = { version = "1.0.1", path = "../../noq" }
+noq = { version = "1.1.0-alpha.0", path = "../../noq" }
 rcgen.workspace = true
 rustls.workspace = true

--- a/noq-proto/Cargo.toml
+++ b/noq-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noq-proto"
-version = "1.1.0-alpha.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/noq-proto/Cargo.toml
+++ b/noq-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noq-proto"
-version = "1.0.1"
+version = "1.1.0-alpha.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/noq-udp/Cargo.toml
+++ b/noq-udp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noq-udp"
-version = "1.0.1"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/noq/Cargo.toml
+++ b/noq/Cargo.toml
@@ -67,7 +67,7 @@ derive_more = { workspace = true }
 futures-io = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 pin-project-lite = { workspace = true }
-proto = { package = "noq-proto", path = "../noq-proto", version = "1.0.1", default-features = false }
+proto = { package = "noq-proto", path = "../noq-proto", version = "1.1.0-alpha.0", default-features = false }
 rustls = { workspace = true, optional = true }
 smol = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/noq/Cargo.toml
+++ b/noq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noq"
-version = "1.0.1"
+version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "General purpose QUIC transport protocol implementation"
@@ -73,7 +73,7 @@ smol = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing =  { workspace = true }
 tokio = { workspace = true }
-udp = { package = "noq-udp", path = "../noq-udp", version = "1.0.1", default-features = false, features = ["tracing"] }
+udp = { package = "noq-udp", path = "../noq-udp", version = "1.1.0-alpha.0", default-features = false, features = ["tracing"] }
 
 # Fix minimal dependencies for indirect deps
 async-global-executor = { workspace = true, optional = true }


### PR DESCRIPTION
## Description

This updates semver checks with the following behaviour:

- The baseline for the check is now the latest published release on
  crates.io

- If you make a semver-breaking change you must also bump the package
  version number so that the semver check will pass. Because we like
  to bump the versions of all crates at the same time you can not use
  pre-releases since cargo does not allow mixing those and the iroh
  patchbay tests has 2nd-level dependencies on noq-udp (via netwatch).

- Adding deprecated items is allowed in minor version bumps, matching
  https://semver.org/#how-should-i-handle-deprecating-functionality

- Bump noq-proto version because we previously added deprecations.

- Now the baseline is somewhat stable, enable caching.


## Breaking Changes

none

## Notes & open questions

I tested this first by not bumping the noq-proto version number and it fails in that case. Which is due to #725.

Once this is merged I will make the semver check required in noq.

The version bumping required to make semver-checks pass could be a bit annoying. It will also make patching iroh for noq a little bit harder. As shown by what the patchbay check has to do now. I'm tempted to think for now that this is worth it, but happy to think about how to tweak this as we gain experience.

OTOH having to bump to the right version means that come to a release we do know what the next version should be. Which is probably good.

## Change checklist

- [x] Self-review.

