### PR TITLE
fix(proto): make path_stats not require self mutably - api unchanged

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1245,7 +1245,7 @@ impl Connection {
             .inc_total_sent(transmit.len() as u64);
 
         self.path_stats
-            .for_path(path_id)
+            .get_mut(path_id)
             .udp_tx
             .on_sent(transmit.num_datagrams() as u64, transmit.len());
 
@@ -1634,7 +1634,7 @@ impl Connection {
                         &mut self.spaces[space_id],
                         is_multipath_negotiated,
                         &mut builder,
-                        &mut self.path_stats.for_path(path_id).frame_tx,
+                        &mut self.path_stats.get_mut(path_id).frame_tx,
                         self.crypto_state.has_keys(space_id.encryption_level()),
                     );
                 }
@@ -1650,7 +1650,7 @@ impl Connection {
                     builder.frame_space_remaining() > frame::ConnectionClose::SIZE_BOUND,
                     "ACKs should leave space for ConnectionClose"
                 );
-                let stats = &mut self.path_stats.for_path(path_id).frame_tx;
+                let stats = &mut self.path_stats.get_mut(path_id).frame_tx;
                 if frame::ConnectionClose::SIZE_BOUND < builder.frame_space_remaining() {
                     let max_frame_size = builder.frame_space_remaining();
                     let close: Close = match self.state.as_type() {
@@ -1808,19 +1808,19 @@ impl Connection {
 
         // We implement MTU probes as ping packets padded up to the probe size
         trace!(?probe_size, "writing MTUD probe");
-        builder.write_frame(frame::Ping, &mut self.path_stats.for_path(path_id).frame_tx);
+        builder.write_frame(frame::Ping, &mut self.path_stats.get_mut(path_id).frame_tx);
 
         // If supported by the peer, we want no delays to the probe's ACK
         if self.peer_supports_ack_frequency() {
             builder.write_frame(
                 frame::ImmediateAck,
-                &mut self.path_stats.for_path(path_id).frame_tx,
+                &mut self.path_stats.get_mut(path_id).frame_tx,
             );
         }
 
         builder.finish_and_track(now, self, path_id, PadDatagram::ToSize(probe_size));
 
-        self.path_stats.for_path(path_id).sent_plpmtud_probes += 1;
+        self.path_stats.get_mut(path_id).sent_plpmtud_probes += 1;
 
         Some(self.build_transmit(path_id, transmit))
     }
@@ -1986,7 +1986,7 @@ impl Connection {
         // this is sent first.
         let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, *prev_cid, buf, self)?;
         let challenge = frame::PathChallenge(token);
-        let stats = &mut self.path_stats.for_path(path_id).frame_tx;
+        let stats = &mut self.path_stats.get_mut(path_id).frame_tx;
         builder.write_frame_with_log_msg(challenge, stats, Some("validating previous path"));
 
         // An endpoint MUST expand datagrams that contain a PATH_CHALLENGE frame
@@ -1997,7 +1997,7 @@ impl Connection {
 
         builder.finish(self, now);
         self.path_stats
-            .for_path(path_id)
+            .get_mut(path_id)
             .udp_tx
             .on_sent(1, buf.len());
 
@@ -2040,7 +2040,7 @@ impl Connection {
         buf.start_new_datagram();
 
         let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, cid, buf, self)?;
-        let stats = &mut self.path_stats.for_path(path_id).frame_tx;
+        let stats = &mut self.path_stats.get_mut(path_id).frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(off-path)"));
 
         // PATH_CHALLENGE (off-path)
@@ -2055,7 +2055,7 @@ impl Connection {
             && self.n0_nat_traversal.client_side().is_ok()
         {
             let token = self.rng.random();
-            let stats = &mut self.path_stats.for_path(path_id).frame_tx;
+            let stats = &mut self.path_stats.get_mut(path_id).frame_tx;
             builder.write_frame(frame::PathChallenge(token), stats);
             let ip_port = (network_path.remote.ip(), network_path.remote.port());
             self.n0_nat_traversal.mark_probe_sent(ip_port, token);
@@ -2067,7 +2067,7 @@ impl Connection {
         builder.finish(self, now);
 
         let size = buf.len();
-        self.path_stats.for_path(path_id).udp_tx.on_sent(1, size);
+        self.path_stats.get_mut(path_id).udp_tx.on_sent(1, size);
 
         trace!(
             dst = ?network_path.remote,
@@ -2119,7 +2119,7 @@ impl Connection {
         buf.start_new_datagram();
 
         let mut builder = PacketBuilder::new(now, SpaceId::Data, path_id, cid, &mut buf, self)?;
-        let stats = &mut self.path_stats.for_path(path_id).frame_tx;
+        let stats = &mut self.path_stats.get_mut(path_id).frame_tx;
         builder.write_frame_with_log_msg(frame, stats, Some("(nat-traversal)"));
         // Off-path: not tracked in congestion control. The packet is sent to a
         // different destination than path_id's network path.
@@ -2129,7 +2129,7 @@ impl Connection {
         self.n0_nat_traversal.mark_probe_sent(remote, token);
 
         let size = buf.len();
-        self.path_stats.for_path(path_id).udp_tx.on_sent(1, size);
+        self.path_stats.get_mut(path_id).udp_tx.on_sent(1, size);
 
         trace!(dst = ?remote, len = buf.len(), "sending off-path NAT probe");
         Some(Transmit {
@@ -2218,7 +2218,7 @@ impl Connection {
                     // anti-amplification blocked for it previously.
                     .unwrap_or(false);
 
-                let rx = &mut self.path_stats.for_path(path_id).udp_rx;
+                let rx = &mut self.path_stats.get_mut(path_id).udp_rx;
                 rx.datagrams += 1;
                 rx.bytes += first_decode.len() as u64;
                 let data_len = first_decode.len();
@@ -2233,7 +2233,7 @@ impl Connection {
                 }
 
                 if let Some(data) = remaining {
-                    self.path_stats.for_path(path_id).udp_rx.bytes += data.len() as u64;
+                    self.path_stats.get_mut(path_id).udp_rx.bytes += data.len() as u64;
                     self.handle_coalesced(now, network_path, path_id, ecn, data);
                 }
 
@@ -2655,11 +2655,11 @@ impl Connection {
     /// Returns path statistics
     pub fn path_stats(&mut self, path_id: PathId) -> Option<PathStats> {
         let path = self.paths.get(&path_id)?;
-        let stats = self.path_stats.for_path(path_id);
+        let mut stats = self.path_stats.get(path_id).unwrap_or_default();
         stats.rtt = path.data.rtt.get();
         stats.cwnd = path.data.congestion.window();
         stats.current_mtu = path.data.mtud.current_mtu();
-        Some(*stats)
+        Some(stats)
     }
 
     /// Ping the remote endpoint
@@ -2941,7 +2941,7 @@ impl Connection {
         };
 
         if self.detect_spurious_loss(&ack, space, path) {
-            self.path_stats.for_path(path).spurious_congestion_events += 1;
+            self.path_stats.get_mut(path).spurious_congestion_events += 1;
             self.path_data_mut(path)
                 .congestion
                 .on_spurious_congestion_event();
@@ -3135,7 +3135,7 @@ impl Connection {
             }
             Ok(false) => {}
             Ok(true) => {
-                self.path_stats.for_path(path).congestion_events += 1;
+                self.path_stats.get_mut(path).congestion_events += 1;
                 self.path_data_mut(path).congestion.on_congestion_event(
                     now,
                     largest_sent_time,
@@ -3440,7 +3440,7 @@ impl Connection {
                 .get(largest_lost)
                 .unwrap()
                 .time_sent;
-            let path_stats = self.path_stats.for_path(path_id);
+            let path_stats = self.path_stats.get_mut(path_id);
             path_stats.lost_packets += lost_packets.len() as u64;
             path_stats.lost_bytes += size_of_lost_packets;
             trace!(
@@ -3488,7 +3488,7 @@ impl Connection {
                     self.datagrams.send_blocked = false;
                     self.events.push_back(Event::DatagramsUnblocked);
                 }
-                self.path_stats.for_path(path_id).black_holes_detected += 1;
+                self.path_stats.get_mut(path_id).black_holes_detected += 1;
             }
 
             // Don't apply congestion penalty for lost ack-only packets
@@ -3496,7 +3496,7 @@ impl Connection {
                 old_bytes_in_flight != self.path_data_mut(path_id).in_flight.bytes;
 
             if lost_ack_eliciting {
-                self.path_stats.for_path(path_id).congestion_events += 1;
+                self.path_stats.get_mut(path_id).congestion_events += 1;
                 self.path_data_mut(path_id).congestion.on_congestion_event(
                     now,
                     largest_lost_sent,
@@ -3520,7 +3520,7 @@ impl Connection {
                 .unwrap()
                 .remove_in_flight(&info);
             self.path_data_mut(path_id).mtud.on_probe_lost();
-            self.path_stats.for_path(path_id).lost_plpmtud_probes += 1;
+            self.path_stats.get_mut(path_id).lost_plpmtud_probes += 1;
         }
     }
 
@@ -4528,10 +4528,7 @@ impl Connection {
 
                     trace!(?frame, "processing frame in closed state");
 
-                    self.path_stats
-                        .for_path(path_id)
-                        .frame_rx
-                        .record(frame.ty());
+                    self.path_stats.get_mut(path_id).frame_rx.record(frame.ty());
 
                     if let Frame::Close(_error) = frame {
                         self.state.move_to_draining(None);
@@ -4835,10 +4832,7 @@ impl Connection {
                 _ => Some(trace_span!("frame", ty = %frame.ty(), path = tracing::field::Empty)),
             };
 
-            self.path_stats
-                .for_path(path_id)
-                .frame_rx
-                .record(frame.ty());
+            self.path_stats.get_mut(path_id).frame_rx.record(frame.ty());
 
             let _guard = span.as_ref().map(|x| x.enter());
             ack_eliciting |= frame.is_ack_eliciting();
@@ -4915,10 +4909,7 @@ impl Connection {
                 _ => trace_span!("frame", ty = %frame.ty(), path = tracing::field::Empty),
             };
 
-            self.path_stats
-                .for_path(path_id)
-                .frame_rx
-                .record(frame.ty());
+            self.path_stats.get_mut(path_id).frame_rx.record(frame.ty());
             // Crypto, Stream and Datagram frames are special cased in order no pollute
             // the log with payload data
             match &frame {
@@ -6079,7 +6070,7 @@ impl Connection {
         let is_multipath_negotiated = self.is_multipath_negotiated();
         let space_has_keys = self.crypto_state.has_keys(space_id.encryption_level());
         let is_0rtt = space_id == SpaceId::Data && !space_has_keys;
-        let stats = &mut self.path_stats.for_path(path_id).frame_tx;
+        let stats = &mut self.path_stats.get_mut(path_id).frame_tx;
         let space = &mut self.spaces[space_id];
         let path = &mut self.paths.get_mut(&path_id).expect("known path").data;
         space

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -360,8 +360,12 @@ pub(super) struct PathStatsMap(FxHashMap<PathId, PathStats>);
 
 impl PathStatsMap {
     /// Returns the [`PathStats`] for the path.
-    pub(super) fn for_path(&mut self, path_id: PathId) -> &mut PathStats {
+    pub(super) fn get_mut(&mut self, path_id: PathId) -> &mut PathStats {
         self.0.entry(path_id).or_default()
+    }
+
+    pub(super) fn get(&self, path_id: PathId) -> Option<PathStats> {
+        self.0.get(&path_id).copied()
     }
 
     /// An iterator over all contained [`PathStats`].

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -351,7 +351,7 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
 
 /// Helper to make [`PathStats`] infallibly available.
 ///
-/// This helper also helps with borrowing issues compared to having the [`Self::for_path`]
+/// This helper also helps with borrowing issues compared to having the [`Self::get_mut`]
 /// function as a helper directly on [`Connection`].
 ///
 /// [`Connection`]: super::Connection


### PR DESCRIPTION

## Description

Continuing perusing stats, `path_stats` and `stats` both require `&mut self`, which is unintuitive and actually not even needed.
- `stats` doesn't even need a change beside updating the api, so no change for this function, just noted here for completeness.
- `path_stats` was taking the stats mutably, updating them and then returning.
  There is no point in the update, as this is never read. The next call to
  `path_stats` overwrites whatever is in there. Instead of updating the stored
  value with the snapshot fields, it updates the returned stats. This allows
  us to polish the public API and remove the unexpected `&mut self` in favor
  of the more natural `&self`.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
