### PR TITLE
chore(proto): Demote error! log to debug! log

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3223,7 +3223,7 @@ impl Connection {
         }
 
         let Some((_, space)) = self.pto_time_and_space(now, path_id) else {
-            error!(%path_id, "PTO expired while unset");
+            debug!(%path_id, "PTO expired while unset");
             return;
         };
         trace!(


### PR DESCRIPTION
## Description

Demotes this `error!` log to a `debug!` log instead.
Although we don't *expect* this situation to happen, it's benign when it *does* happen, it just wastes some cycles and indicates that we have not upheld some weak invariants somewhere.

## Breaking Changes

None

## Notes & open questions

Could also change it to a `warn!` log instead, but IMO even that is a bit too much. There's nothing the user can do about this and it doesn't really indicate that something dangerous is going on to be "warned" about. The system is left in a good state and immediately heals on its own.

## Change checklist

- [x] Self-review.
