### PR TITLE
chore: auto format and wrap comments

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -38,7 +38,7 @@ args = [
      "--config",
      "unstable_features=true",
      "--config",
-     "imports_granularity=Crate,group_imports=Preserve,reorder_imports=false,format_code_in_doc_comments=true",
+     "imports_granularity=Crate,group_imports=Preserve,reorder_imports=false,format_code_in_doc_comments=true,comment_width=100,wrap_comments=true",
 ]
 
 [tasks.format-check]
@@ -52,7 +52,7 @@ args = [
      "--config",
      "unstable_features=true",
      "--config",
-     "imports_granularity=Crate,group_imports=Preserve,reorder_imports=false,format_code_in_doc_comments=true",
+     "imports_granularity=Crate,group_imports=Preserve,reorder_imports=false,format_code_in_doc_comments=true,comment_width=100,wrap_comments=true",
 ]
 
 [tasks.check]

--- a/docs/book/src/bin/set-up-connection.rs
+++ b/docs/book/src/bin/set-up-connection.rs
@@ -24,7 +24,8 @@ async fn client() -> Result<(), Box<dyn Error>> {
     // Bind this endpoint to a UDP socket on the given client address.
     let endpoint = Endpoint::client(CLIENT_ADDR)?;
 
-    // Connect to the server passing in the server name which is supposed to be in the server certificate.
+    // Connect to the server passing in the server name which is supposed to be in the server
+    // certificate.
     let connection = endpoint.connect(SERVER_ADDR, SERVER_NAME)?.await?;
 
     // Start transferring, receiving data, see data transfer page.

--- a/noq-proto/src/cid_generator.rs
+++ b/noq-proto/src/cid_generator.rs
@@ -29,7 +29,8 @@ pub trait ConnectionIdGenerator: Send + Sync {
     fn cid_len(&self) -> usize;
     /// Returns the lifetime of generated Connection IDs
     ///
-    /// Connection IDs will be retired after the returned `Duration`, if any. Assumed to be constant.
+    /// Connection IDs will be retired after the returned `Duration`, if any. Assumed to be
+    /// constant.
     fn cid_lifetime(&self) -> Option<Duration>;
 }
 

--- a/noq-proto/src/config/mod.rs
+++ b/noq-proto/src/config/mod.rs
@@ -217,8 +217,8 @@ pub struct ServerConfig {
 
     /// Whether to allow clients to migrate to new addresses
     ///
-    /// Improves behavior for clients that move between different internet connections or suffer NAT
-    /// rebinding. Enabled by default.
+    /// Improves behavior for clients that move between different internet connections or suffer
+    /// NAT rebinding. Enabled by default.
     pub(crate) migration: bool,
 
     pub(crate) preferred_address_v4: Option<SocketAddrV4>,

--- a/noq-proto/src/config/qlog.rs
+++ b/noq-proto/src/config/qlog.rs
@@ -29,7 +29,8 @@ pub trait QlogFactory: Send + Sync + 'static {
 /// This struct is returned from [`QlogFactory::for_connection`] if qlog logging should
 /// be enabled for a connection. It allows to set metadata for the qlog trace.
 ///
-/// The trace will be written to the provided writer in the [`JSON-SEQ format`] defined in the qlog spec.
+/// The trace will be written to the provided writer in the [`JSON-SEQ format`] defined in the qlog
+/// spec.
 ///
 /// [`JSON-SEQ format`](https://www.ietf.org/archive/id/draft-ietf-quic-qlog-main-schema-13.html#section-5)
 #[cfg(feature = "qlog")]

--- a/noq-proto/src/config/transport.rs
+++ b/noq-proto/src/config/transport.rs
@@ -266,7 +266,8 @@ impl TransportConfig {
         self
     }
 
-    /// Number of consecutive PTOs after which network is considered to be experiencing persistent congestion.
+    /// Number of consecutive PTOs after which network is considered to be experiencing persistent
+    /// congestion.
     pub fn persistent_congestion_threshold(&mut self, value: u32) -> &mut Self {
         self.persistent_congestion_threshold = value;
         self
@@ -276,9 +277,9 @@ impl TransportConfig {
     ///
     /// Keep-alive packets prevent an inactive but otherwise healthy connection from timing out.
     ///
-    /// `None` to disable, which is the default. Only one side of any given connection needs keep-alive
-    /// enabled for the connection to be preserved. Must be set lower than the idle_timeout of both
-    /// peers to be effective.
+    /// `None` to disable, which is the default. Only one side of any given connection needs
+    /// keep-alive enabled for the connection to be preserved. Must be set lower than the
+    /// idle_timeout of both peers to be effective.
     pub fn keep_alive_interval(&mut self, value: Option<Duration>) -> &mut Self {
         self.keep_alive_interval = value;
         self
@@ -561,7 +562,8 @@ impl Default for TransportConfig {
 
             packet_threshold: 3,
             time_threshold: 9.0 / 8.0,
-            initial_rtt: Duration::from_millis(333), // per spec, intentionally distinct from EXPECTED_RTT
+            initial_rtt: Duration::from_millis(333), /* per spec, intentionally distinct from
+                                                      * EXPECTED_RTT */
             initial_mtu: INITIAL_MTU,
             min_mtu: INITIAL_MTU,
             mtu_discovery_config: Some(MtuDiscoveryConfig::default()),

--- a/noq-proto/src/congestion.rs
+++ b/noq-proto/src/congestion.rs
@@ -39,7 +39,8 @@ pub trait Controller: Send + Sync + std::fmt::Debug {
     ) {
     }
 
-    /// Packets are acked in batches, all with the same `now` argument. This indicates one of those batches has completed.
+    /// Packets are acked in batches, all with the same `now` argument. This indicates one of those
+    /// batches has completed.
     #[allow(unused_variables)]
     fn on_end_acks(
         &mut self,
@@ -101,8 +102,8 @@ pub trait Controller: Send + Sync + std::fmt::Debug {
     /// Number of ack-eliciting bytes that may be in flight
     fn window(&self) -> u64;
 
-    /// Retrieve implementation-specific metrics used to populate `qlog` traces when they are enabled
-    /// This is also used to alter the pacing of the connection with
+    /// Retrieve implementation-specific metrics used to populate `qlog` traces when they are
+    /// enabled This is also used to alter the pacing of the connection with
     /// `pacing_rate` and `send_quantum`
     fn metrics(&self) -> ControllerMetrics {
         ControllerMetrics {

--- a/noq-proto/src/congestion/bbr3/mod.rs
+++ b/noq-proto/src/congestion/bbr3/mod.rs
@@ -19,7 +19,8 @@ const EXTRA_ACKED_FILTER_LEN: usize = 10;
 
 /// safety mechanism to flag packets as stale within our tracking VecDeque. rounds refer to <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1>.
 /// The value of 10 rounds is picked because normally after max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity) <https://datatracker.ietf.org/doc/html/rfc9002#section-6.1.2>
-/// the packet should have been declared lost already, this is just to guarantee that the VecDeque doesn't grow indefinitely.
+/// the packet should have been declared lost already, this is just to guarantee that the VecDeque
+/// doesn't grow indefinitely.
 const ROUND_COUNT_WINDOW: u64 = 10;
 
 /// the minimum for the maximum datagram size <https://datatracker.ietf.org/doc/html/rfc9000#section-14>
@@ -43,9 +44,10 @@ const PACING_RATE_24MBPS: f64 = 24000.0 * 1000.0;
 /// inspired by a previous version of BBR2 used in cloudflare's quiche
 const HIGH_PACE_MAX_QUANTUM: u64 = 64 * 1000;
 
-/// equivalent to BBR.StartupPacingGain: A constant specifying the minimum gain value for calculating the pacing rate that will allow
-/// the sending rate to double each round (4 * ln(2) ~= 2.77)
-/// BBRStartupPacingGain; used in Startup mode for BBR.pacing_gain. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+/// equivalent to BBR.StartupPacingGain: A constant specifying the minimum gain value for
+/// calculating the pacing rate that will allow the sending rate to double each round
+/// `(4 * ln(2) ~= 2.77)` BBRStartupPacingGain; used in Startup mode for
+/// BBR.pacing_gain. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const STARTUP_PACING_GAIN: f64 = 2.773;
 
 /// default pacing gain is 1, when cruising, probing for RTT or refilling <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
@@ -57,18 +59,20 @@ const PROBE_BW_DOWN_PACING_GAIN: f64 = 0.9;
 /// pacing gain when probing bandwidth up <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const PROBE_BW_UP_PACING_GAIN: f64 = 1.25;
 
-/// equivalent to BBR.PacingMarginPercent: The static discount factor of 1% used to scale BBR.bw to produce C.pacing_rate.
+/// equivalent to BBR.PacingMarginPercent: The static discount factor of 1% used to scale BBR.bw to
+/// produce C.pacing_rate.
 const PACING_MARGIN_PERCENT: f64 = 1.0;
 
-/// equivalent to BBR.DefaultCwndGain: A constant specifying the minimum gain value that allows the sending rate to double each round (2) BBRStartupCwndGain.
-/// Used by default in most phases for BBR.cwnd_gain.
+/// equivalent to BBR.DefaultCwndGain: A constant specifying the minimum gain value that allows the
+/// sending rate to double each round (2) BBRStartupCwndGain. Used by default in most phases for
+/// BBR.cwnd_gain.
 const DEFAULT_CWND_GAIN: f64 = 2.0;
 
-/// equivalent to BBR.DrainPacingGain: A constant specifying the pacing gain value used in Drain mode,
-/// to attempt to drain the estimated queue at the bottleneck link in one round-trip or less.
-/// As noted in BBRDrainPacingGain, any value at or below 1 / BBRStartupCwndGain = 1 / 2 = 0.5 will theoretically achieve this.
-/// BBR uses the value 0.5, which has been shown to offer good performance when compared with other alternatives.
-/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.4>
+/// equivalent to BBR.DrainPacingGain: A constant specifying the pacing gain value used in Drain
+/// mode, to attempt to drain the estimated queue at the bottleneck link in one round-trip or less.
+/// As noted in BBRDrainPacingGain, any value at or below 1 / BBRStartupCwndGain = 1 / 2 = 0.5 will
+/// theoretically achieve this. BBR uses the value 0.5, which has been shown to offer good
+/// performance when compared with other alternatives. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.4>
 /// <https://github.com/google/bbr/blob/master/Documentation/startup/gain/analysis/bbr_drain_gain.pdf>
 const DRAIN_PACING_GAIN: f64 = 1.0 / DEFAULT_CWND_GAIN;
 
@@ -78,24 +82,30 @@ const PROBE_BW_UP_CWND_GAIN: f64 = 2.25;
 /// cwnd gain used when probing RTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const PROBE_RTT_CWND_GAIN: f64 = 0.5;
 
-/// equivalent to BBR.ProbeRTTDuration: A constant specifying the minimum duration for which ProbeRTT state holds C.inflight to BBR.MinPipeCwnd or fewer packets: 200 ms.
+/// equivalent to BBR.ProbeRTTDuration: A constant specifying the minimum duration for which
+/// ProbeRTT state holds C.inflight to BBR.MinPipeCwnd or fewer packets: 200 ms.
 const PROBE_RTT_DURATION_MS: u64 = 200;
 
-/// equivalent to BBR.ProbeRTTInterval: A constant specifying the minimum time interval between ProbeRTT states: 5 secs.
+/// equivalent to BBR.ProbeRTTInterval: A constant specifying the minimum time interval between
+/// ProbeRTT states: 5 secs.
 const PROBE_RTT_INTERVAL_SEC: u64 = 5;
 
-/// equivalent to BBR.LossThresh: A constant specifying the maximum tolerated per-round-trip packet loss rate when probing for bandwidth (the default is 2%).
+/// equivalent to BBR.LossThresh: A constant specifying the maximum tolerated per-round-trip packet
+/// loss rate when probing for bandwidth (the default is 2%).
 const LOSS_THRESH: f64 = 0.02;
 
-/// equivalent to BBR.Beta: A constant specifying the default multiplicative decrease to make upon each round trip during which the connection detects packet loss (the value is 0.7).
+/// equivalent to BBR.Beta: A constant specifying the default multiplicative decrease to make upon
+/// each round trip during which the connection detects packet loss (the value is 0.7).
 const BETA: f64 = 0.7;
 
-/// equivalent to BBR.Headroom: A constant specifying the multiplicative factor to apply to BBR.inflight_longterm when calculating
-/// a volume of free headroom to try to leave unused in the path
-/// (e.g. free space in the bottleneck buffer or free time slots in the bottleneck link) that can be used by cross traffic (the value is 0.15).
+/// equivalent to BBR.Headroom: A constant specifying the multiplicative factor to apply to
+/// BBR.inflight_longterm when calculating a volume of free headroom to try to leave unused in the
+/// path (e.g. free space in the bottleneck buffer or free time slots in the bottleneck link) that
+/// can be used by cross traffic (the value is 0.15).
 const HEADROOM: f64 = 0.15;
 
-/// equivalent to BBR.MinRTTFilterLen: A constant specifying the length of the BBR.min_rtt min filter window, BBR.MinRTTFilterLen is 10 secs.
+/// equivalent to BBR.MinRTTFilterLen: A constant specifying the length of the BBR.min_rtt min
+/// filter window, BBR.MinRTTFilterLen is 10 secs.
 const MIN_RTT_FILTER_LEN: u64 = 10;
 
 /// multiplier used to check growth when validating if the full bandwidth has been reached
@@ -105,8 +115,8 @@ const FULL_BW_GROWTH: f64 = 1.25;
 /// maximum number of rounds needed before we consider that the pipe is full <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-6>
 const MAX_FULL_BW_COUNT: u64 = 3;
 
-/// when setting `bw_probe_up_rounds` when raising our inflight long term slope we don't go above this
-/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
+/// when setting `bw_probe_up_rounds` when raising our inflight long term slope we don't go above
+/// this <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
 const MAX_LONG_TERM_PROBE_UP_ROUNDS: u32 = 30;
 
 /// max number of rounds used when deciding to coexist with Reno / CUBIC <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.1>
@@ -180,15 +190,18 @@ enum AckPhase {
 /// equivalent to P <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.2.1.2>
 #[derive(Debug, Clone, Copy)]
 struct BbrPacket {
-    /// equivalent to P.delivered: C.delivered when the packet was sent from transport connection C.
+    /// equivalent to P.delivered: C.delivered when the packet was sent from transport connection
+    /// C.
     delivered: u64,
     /// equivalent to P.delivered_time: C.delivered_time when the packet was sent.
     delivered_time: Instant,
     /// equivalent to P.first_send_time: C.first_send_time when the packet was sent.
     first_send_time: Instant,
-    /// equivalent to P.send_time: The pacing departure time selected when the packet was scheduled to be sent.
+    /// equivalent to P.send_time: The pacing departure time selected when the packet was scheduled
+    /// to be sent.
     send_time: Instant,
-    /// equivalent to P.is_app_limited: true if C.app_limited was non-zero when the packet was sent, else false.
+    /// equivalent to P.is_app_limited: true if C.app_limited was non-zero when the packet was
+    /// sent, else false.
     is_app_limited: bool,
     /// equivalent to P.tx_in_flight: C.inflight immediately after the transmission of packet P.
     tx_in_flight: u64,
@@ -198,29 +211,34 @@ struct BbrPacket {
     size: u16,
     /// equivalent to P.lost: C.lost when the packet was sent
     lost: u64,
-    /// used to flag acknowledgement within our VecDeque, a packet can be flagged lost after having been flagged acknowledged
-    /// hence the necessity of this flag being set before we remove it from packets.
+    /// used to flag acknowledgement within our VecDeque, a packet can be flagged lost after having
+    /// been flagged acknowledged hence the necessity of this flag being set before we remove
+    /// it from packets.
     acknowledged: bool,
-    /// once a packet has been acknowledged on a given round it is marked for removal on the next round.
+    /// once a packet has been acknowledged on a given round it is marked for removal on the next
+    /// round.
     stale: bool,
     /// used to mark packets stale if they're far from the current round <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1>
     round_count: u64,
 }
 
-/// Description of a per-ack rate sample state that will allow us to determine a short term evolution of the connection
-/// equivalent to RS <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.2>
+/// Description of a per-ack rate sample state that will allow us to determine a short term
+/// evolution of the connection equivalent to RS <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.2>
 #[derive(Debug, Clone, Copy)]
 struct BbrRateSample {
-    /// equivalent to RS.delivery_rate: The delivery rate (aka bandwidth) sample obtained from the packet that has just been ACKed.
+    /// equivalent to RS.delivery_rate: The delivery rate (aka bandwidth) sample obtained from the
+    /// packet that has just been ACKed.
     delivery_rate: f64,
     /// equivalent to RS.is_app_limited: The P.is_app_limited from the most recent packet
     ///    delivered; indicates whether the rate sample is application-limited.
     is_app_limited: bool,
     /// equivalent to RS.interval: The length of the sampling interval.
     interval: Duration,
-    /// equivalent to RS.delivered: The volume of data delivered between the transmission of the packet that has just been ACKed and the current time.
+    /// equivalent to RS.delivered: The volume of data delivered between the transmission of the
+    /// packet that has just been ACKed and the current time.
     delivered: u64,
-    /// equivalent to RS.prior_delivered: The P.delivered count from the most recent packet delivered.
+    /// equivalent to RS.prior_delivered: The P.delivered count from the most recent packet
+    /// delivered.
     prior_delivered: u64,
     /// equivalent to RS.prior_time: The P.delivered_time from the most recent packet delivered.
     prior_time: Instant,
@@ -230,17 +248,22 @@ struct BbrRateSample {
     /// equivalent to RS.ack_elapsed: ACK time interval calculated from the most recent
     ///    packet delivered (see the "ACK Rate" section above).
     ack_elapsed: Duration,
-    /// equivalent to RS.rtt: The RTT sample calculated based on the most recently-sent packet of the packets that have just been ACKed.
+    /// equivalent to RS.rtt: The RTT sample calculated based on the most recently-sent packet of
+    /// the packets that have just been ACKed.
     rtt: Duration,
-    /// equivalent to RS.tx_in_flight: C.inflight at the time of the transmission of the packet that has just been ACKed
-    /// (the most recently sent packet among packets ACKed by the ACK that was just received).
+    /// equivalent to RS.tx_in_flight: C.inflight at the time of the transmission of the packet
+    /// that has just been ACKed (the most recently sent packet among packets ACKed by the ACK
+    /// that was just received).
     tx_in_flight: u64,
-    /// equivalent to RS.newly_acked: The volume of data in bytes cumulatively or selectively acknowledged upon the ACK that was just received.
+    /// equivalent to RS.newly_acked: The volume of data in bytes cumulatively or selectively
+    /// acknowledged upon the ACK that was just received.
     newly_acked: u64,
-    /// equivalent to RS.newly_lost: The volume of data in bytes newly marked lost upon the ACK that was just received.
+    /// equivalent to RS.newly_lost: The volume of data in bytes newly marked lost upon the ACK
+    /// that was just received.
     newly_lost: u64,
-    /// equivalent to RS.lost: The volume of data in bytes that was declared lost between the transmission
-    /// and acknowledgment of the packet that has just been ACKed (the most recently sent packet among packets ACKed by the ACK that was just received).
+    /// equivalent to RS.lost: The volume of data in bytes that was declared lost between the
+    /// transmission and acknowledgment of the packet that has just been ACKed (the most
+    /// recently sent packet among packets ACKed by the ACK that was just received).
     lost: u64,
     /// equivalent to RS.last_end_seq
     last_end_seq: u64,
@@ -250,8 +273,8 @@ struct BbrRateSample {
 
 /// Experimental! Use at your own risk.
 ///
-/// Aims for reduced buffer bloat and improved performance over high bandwidth-delay product networks.
-/// Based on <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html>
+/// Aims for reduced buffer bloat and improved performance over high bandwidth-delay product
+/// networks. Based on <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html>
 /// equivalent to a combination of BBR and C states
 /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.4>
 /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.1>
@@ -260,54 +283,72 @@ pub struct Bbr3 {
     /// equivalent to C.SMSS The Sender Maximum Send Size in bytes. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.1>
     /// <https://www.rfc-editor.org/rfc/rfc9000#name-datagram-size>
     smss: u64,
-    /// equivalent to C.InitialCwnd: The initial congestion window set by the transport protocol implementation for the connection at initialization time.
+    /// equivalent to C.InitialCwnd: The initial congestion window set by the transport protocol
+    /// implementation for the connection at initialization time.
     initial_cwnd: u64,
-    /// equivalent to C.delivered: The total amount of data delivered so far over the lifetime of the transport connection C.
-    /// This MUST NOT include pure ACK packets. It SHOULD include spurious retransmissions that have been acknowledged as delivered.
+    /// equivalent to C.delivered: The total amount of data delivered so far over the lifetime of
+    /// the transport connection C. This MUST NOT include pure ACK packets. It SHOULD include
+    /// spurious retransmissions that have been acknowledged as delivered.
     delivered: u64,
-    /// equivalent to C.inflight: The connection's best estimate of the number of bytes outstanding in the network.
-    /// This includes the number of bytes that have been sent and have not been acknowledged or marked as lost since their last transmission
-    /// (e.g. "pipe" from RFC6675 or "bytes_in_flight" from RFC9002). This MUST NOT include pure ACK packets.
+    /// equivalent to C.inflight: The connection's best estimate of the number of bytes outstanding
+    /// in the network. This includes the number of bytes that have been sent and have not been
+    /// acknowledged or marked as lost since their last transmission (e.g. "pipe" from RFC6675
+    /// or "bytes_in_flight" from RFC9002). This MUST NOT include pure ACK packets.
     inflight: u64,
-    /// equivalent to C.is_cwnd_limited: True if the connection has fully utilized C.cwnd at any point in the last packet-timed round trip.
+    /// equivalent to C.is_cwnd_limited: True if the connection has fully utilized C.cwnd at any
+    /// point in the last packet-timed round trip.
     is_cwnd_limited: bool,
     /// equivalent to BBR.cycle_count: The virtual time used by the BBR.max_bw filter window.
-    /// since the BBR.max_bw_filter only needs to track samples from two time slots: the previous ProbeBW cycle and the current ProbeBW cycle.
+    /// since the BBR.max_bw_filter only needs to track samples from two time slots: the previous
+    /// ProbeBW cycle and the current ProbeBW cycle.
     cycle_count: u64,
-    /// equivalent to C.cwnd: The transport sender's congestion window. When transmitting data, the sending connection ensures that C.inflight does not exceed C.cwnd.
+    /// equivalent to C.cwnd: The transport sender's congestion window. When transmitting data, the
+    /// sending connection ensures that C.inflight does not exceed C.cwnd.
     cwnd: u64,
-    /// equivalent to C.pacing_rate: The current pacing rate for a BBR flow, which controls inter-packet spacing.
+    /// equivalent to C.pacing_rate: The current pacing rate for a BBR flow, which controls
+    /// inter-packet spacing.
     pacing_rate: f64,
-    /// equivalent to C.send_quantum: The maximum size of a data aggregate scheduled and transmitted together as a unit, e.g., to amortize per-packet transmission overheads.
+    /// equivalent to C.send_quantum: The maximum size of a data aggregate scheduled and
+    /// transmitted together as a unit, e.g., to amortize per-packet transmission overheads.
     send_quantum: u64,
-    /// equivalent to BBR.pacing_gain: The dynamic gain factor used to scale BBR.bw to produce C.pacing_rate.
+    /// equivalent to BBR.pacing_gain: The dynamic gain factor used to scale BBR.bw to produce
+    /// C.pacing_rate.
     pacing_gain: f64,
-    /// default pacing gain is 1, when cruising, probing for RTT or refilling <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+    /// default pacing gain is 1, when cruising, probing for RTT or refilling
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     default_pacing_gain: f64,
-    /// pacing gain when probing bandwidth down <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+    /// pacing gain when probing bandwidth down
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     probe_bw_down_pacing_gain: f64,
-    /// pacing gain when probing bandwidth up <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+    /// pacing gain when probing bandwidth up
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     probe_bw_up_pacing_gain: f64,
-    /// equivalent to BBR.StartupPacingGain: A constant specifying the minimum gain value for calculating the pacing rate that will allow
-    /// the sending rate to double each round (4 * ln(2) ~= 2.77)
-    /// BBRStartupPacingGain; used in Startup mode for BBR.pacing_gain. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+    /// equivalent to BBR.StartupPacingGain: A constant specifying the minimum gain value for
+    /// calculating the pacing rate that will allow the sending rate to double each round
+    /// `(4 * ln(2) ~= 2.77)` BBRStartupPacingGain; used in Startup mode for BBR.pacing_gain.
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     startup_pacing_gain: f64,
-    /// equivalent to BBR.DrainPacingGain: A constant specifying the pacing gain value used in Drain mode,
-    /// to attempt to drain the estimated queue at the bottleneck link in one round-trip or less.
-    /// As noted in BBRDrainPacingGain, any value at or below 1 / BBRStartupCwndGain = 1 / 2 = 0.5 will theoretically achieve this.
-    /// BBR uses the value 0.5, which has been shown to offer good performance when compared with other alternatives.
+    /// equivalent to BBR.DrainPacingGain: A constant specifying the pacing gain value used in
+    /// Drain mode, to attempt to drain the estimated queue at the bottleneck link in one
+    /// round-trip or less. As noted in BBRDrainPacingGain, any value at or below 1 /
+    /// BBRStartupCwndGain = 1 / 2 = 0.5 will theoretically achieve this. BBR uses the value
+    /// 0.5, which has been shown to offer good performance when compared with other alternatives.
     /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     drain_pacing_gain: f64,
-    /// equivalent to BBR.PacingMarginPercent: The static discount factor of 1% used to scale BBR.bw to produce C.pacing_rate.
+    /// equivalent to BBR.PacingMarginPercent: The static discount factor of 1% used to scale
+    /// BBR.bw to produce C.pacing_rate.
     pacing_margin_percent: f64,
-    /// equivalent to BBR.cwnd_gain: The dynamic gain factor used to scale the estimated BDP to produce a congestion window (C.cwnd).
+    /// equivalent to BBR.cwnd_gain: The dynamic gain factor used to scale the estimated BDP to
+    /// produce a congestion window (C.cwnd).
     cwnd_gain: f64,
-    /// equivalent to BBR.DefaultCwndGain: A constant specifying the minimum gain value that allows the sending rate to double each round (2) BBRStartupCwndGain.
-    /// Used by default in most phases for BBR.cwnd_gain.
+    /// equivalent to BBR.DefaultCwndGain: A constant specifying the minimum gain value that allows
+    /// the sending rate to double each round (2) BBRStartupCwndGain. Used by default in most
+    /// phases for BBR.cwnd_gain.
     default_cwnd_gain: f64,
     /// used to generate random numbers when deciding how long to wait before probing again
-    /// using Pcg32 as it's a fast general purpose random number generator and fits our purpose here
-    /// these numbers will not be security critical as they're only used to decide when to probe the connection next.
+    /// using Pcg32 as it's a fast general purpose random number generator and fits our purpose
+    /// here these numbers will not be security critical as they're only used to decide when to
+    /// probe the connection next.
     probe_rng: Pcg32,
     /// cwnd gain used when probing up <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     probe_bw_up_cwnd_gain: f64,
@@ -319,105 +360,149 @@ pub struct Bbr3 {
     undo_state: BbrState,
     /// equivalent to BBR.round_count: Count of packet-timed round trips elapsed so far.
     round_count: u64,
-    /// equivalent to BBR.round_start: A boolean that BBR sets to true once per packet-timed round trip, on ACKs that advance BBR.round_count.
+    /// equivalent to BBR.round_start: A boolean that BBR sets to true once per packet-timed round
+    /// trip, on ACKs that advance BBR.round_count.
     round_start: bool,
-    /// equivalent to BBR.next_round_delivered: P.delivered value denoting the end of a packet-timed round trip.
+    /// equivalent to BBR.next_round_delivered: P.delivered value denoting the end of a
+    /// packet-timed round trip.
     next_round_delivered: u64,
-    /// equivalent to BBR.idle_restart: A boolean that is true if and only if a connection is restarting after being idle.
+    /// equivalent to BBR.idle_restart: A boolean that is true if and only if a connection is
+    /// restarting after being idle.
     idle_restart: bool,
-    /// equivalent to BBR.MinPipeCwnd: The minimal C.cwnd value BBR targets, to allow pipelining with endpoints that follow an "ACK every other packet" delayed-ACK policy: 4 * C.SMSS.
+    /// equivalent to BBR.MinPipeCwnd: The minimal C.cwnd value BBR targets, to allow pipelining
+    /// with endpoints that follow an "ACK every other packet" delayed-ACK policy: 4 * C.SMSS.
     min_pipe_cwnd: u64,
-    /// equivalent to BBR.max_bw: The windowed maximum recent bandwidth sample, obtained using the BBR delivery rate sampling algorithm in
-    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1>,
-    /// measured during the current or previous bandwidth probing cycle (or during Startup, if the flow is still in that state). (Part of the long-term model.)
+    /// equivalent to BBR.max_bw: The windowed maximum recent bandwidth sample, obtained using the
+    /// BBR delivery rate sampling algorithm in <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1>,
+    /// measured during the current or previous bandwidth probing cycle (or during Startup, if the
+    /// flow is still in that state). (Part of the long-term model.)
     max_bw: f64,
-    /// equivalent to BBR.bw_shortterm: The short-term maximum sending bandwidth that the algorithm estimates is safe for matching the current network path delivery rate,
-    /// based on any loss signals in the current bandwidth probing cycle. This is generally lower than max_bw. (Part of the short-term model.)
+    /// equivalent to BBR.bw_shortterm: The short-term maximum sending bandwidth that the algorithm
+    /// estimates is safe for matching the current network path delivery rate, based on any
+    /// loss signals in the current bandwidth probing cycle. This is generally lower than max_bw.
+    /// (Part of the short-term model.)
     bw_shortterm: f64,
-    /// equivalent to BBR.undo_bw_shortterm: The short-term maximum sending bandwidth that the algorithm estimates is safe for matching the current network path delivery rate,
-    /// based on any loss signals in the current bandwidth probing cycle. This is generally lower than max_bw. (Part of the short-term model.)
-    /// saved state in case a loss episode is later declared spurious
+    /// equivalent to BBR.undo_bw_shortterm: The short-term maximum sending bandwidth that the
+    /// algorithm estimates is safe for matching the current network path delivery rate,
+    /// based on any loss signals in the current bandwidth probing cycle. This is generally lower
+    /// than max_bw. (Part of the short-term model.) saved state in case a loss episode is
+    /// later declared spurious
     undo_bw_shortterm: f64,
-    /// equivalent to BBR.bw: The maximum sending bandwidth that the algorithm estimates is appropriate for matching the current network path delivery rate,
-    /// given all available signals in the model, at any time scale. It is the min() of max_bw and bw_shortterm.
+    /// equivalent to BBR.bw: The maximum sending bandwidth that the algorithm estimates is
+    /// appropriate for matching the current network path delivery rate, given all available
+    /// signals in the model, at any time scale. It is the min() of max_bw and bw_shortterm.
     bw: f64,
-    /// equivalent to BBR.min_rtt: The windowed minimum round-trip time sample measured over the last BBR.MinRTTFilterLen = 10 seconds.
-    /// This attempts to estimate the two-way propagation delay of the network path when all connections sharing a bottleneck are using BBR,
-    /// but also allows BBR to estimate the value required for a BBR.bdp estimate that allows full throughput if there are legacy loss-based Reno or CUBIC flows sharing the bottleneck.
+    /// equivalent to BBR.min_rtt: The windowed minimum round-trip time sample measured over the
+    /// last BBR.MinRTTFilterLen = 10 seconds. This attempts to estimate the two-way
+    /// propagation delay of the network path when all connections sharing a bottleneck are using
+    /// BBR, but also allows BBR to estimate the value required for a BBR.bdp estimate that
+    /// allows full throughput if there are legacy loss-based Reno or CUBIC flows sharing the
+    /// bottleneck.
     min_rtt: Duration,
-    /// equivalent to BBR.bdp: The estimate of the network path's BDP (Bandwidth-Delay Product), computed as: BBR.bdp = BBR.bw * BBR.min_rtt.
+    /// equivalent to BBR.bdp: The estimate of the network path's BDP (Bandwidth-Delay Product),
+    /// computed as: BBR.bdp = BBR.bw * BBR.min_rtt.
     bdp: u64,
-    /// equivalent to BBR.extra_acked: A volume of data that is the estimate of the recent degree of aggregation in the network path.
+    /// equivalent to BBR.extra_acked: A volume of data that is the estimate of the recent degree
+    /// of aggregation in the network path.
     extra_acked: u64,
-    /// equivalent to BBR.offload_budget: The estimate of the minimum volume of data necessary to achieve full throughput when using sender
-    /// (TSO/GSO) and receiver (LRO, GRO) host offload mechanisms.
+    /// equivalent to BBR.offload_budget: The estimate of the minimum volume of data necessary to
+    /// achieve full throughput when using sender (TSO/GSO) and receiver (LRO, GRO) host
+    /// offload mechanisms.
     offload_budget: u64,
-    /// equivalent to BBR.max_inflight: The estimate of C.inflight required to fully utilize the bottleneck bandwidth available to the flow,
-    /// based on the BDP estimate (BBR.bdp), the aggregation estimate (BBR.extra_acked), the offload budget (BBR.offload_budget), and BBR.MinPipeCwnd.
+    /// equivalent to BBR.max_inflight: The estimate of C.inflight required to fully utilize the
+    /// bottleneck bandwidth available to the flow, based on the BDP estimate (BBR.bdp), the
+    /// aggregation estimate (BBR.extra_acked), the offload budget (BBR.offload_budget), and
+    /// BBR.MinPipeCwnd.
     max_inflight: u64,
-    /// equivalent to BBR.inflight_longterm: The long-term maximum inflight that the algorithm estimates will produce acceptable queue pressure,
-    /// based on signals in the current or previous bandwidth probing cycle, as measured by loss. That is, if a flow is probing for bandwidth,
-    /// and observes that sending a particular inflight causes a loss rate higher than the loss rate threshold,
-    /// it sets inflight_longterm to that volume of data. (Part of the long-term model.)
+    /// equivalent to BBR.inflight_longterm: The long-term maximum inflight that the algorithm
+    /// estimates will produce acceptable queue pressure, based on signals in the current or
+    /// previous bandwidth probing cycle, as measured by loss. That is, if a flow is probing for
+    /// bandwidth, and observes that sending a particular inflight causes a loss rate higher
+    /// than the loss rate threshold, it sets inflight_longterm to that volume of data. (Part
+    /// of the long-term model.)
     inflight_longterm: u64,
-    /// equivalent to BBR.inflight_longterm: The long-term maximum inflight that the algorithm estimates will produce acceptable queue pressure,
-    /// based on signals in the current or previous bandwidth probing cycle, as measured by loss. That is, if a flow is probing for bandwidth,
-    /// and observes that sending a particular inflight causes a loss rate higher than the loss rate threshold,
-    /// it sets inflight_longterm to that volume of data. (Part of the long-term model.)
-    /// saved state in case a loss episode is later declared spurious
+    /// equivalent to BBR.inflight_longterm: The long-term maximum inflight that the algorithm
+    /// estimates will produce acceptable queue pressure, based on signals in the current or
+    /// previous bandwidth probing cycle, as measured by loss. That is, if a flow is probing for
+    /// bandwidth, and observes that sending a particular inflight causes a loss rate higher
+    /// than the loss rate threshold, it sets inflight_longterm to that volume of data. (Part
+    /// of the long-term model.) saved state in case a loss episode is later declared spurious
     undo_inflight_longterm: u64,
     /// equivalent to BBR.inflight_shortterm: Analogous to BBR.bw_shortterm,
-    /// the short-term maximum inflight that the algorithm estimates is safe for matching the current network path delivery process,
-    /// based on any loss signals in the current bandwidth probing cycle. This is generally lower than max_inflight or inflight_longterm. (Part of the short-term model.)
+    /// the short-term maximum inflight that the algorithm estimates is safe for matching the
+    /// current network path delivery process, based on any loss signals in the current
+    /// bandwidth probing cycle. This is generally lower than max_inflight or inflight_longterm.
+    /// (Part of the short-term model.)
     inflight_shortterm: u64,
     /// equivalent to BBR.undo_inflight_shortterm: Analogous to BBR.bw_shortterm,
-    /// the short-term maximum inflight that the algorithm estimates is safe for matching the current network path delivery process,
-    /// based on any loss signals in the current bandwidth probing cycle. This is generally lower than max_inflight or inflight_longterm. (Part of the short-term model.)
-    /// saved state in case a loss episode is later declared spurious
+    /// the short-term maximum inflight that the algorithm estimates is safe for matching the
+    /// current network path delivery process, based on any loss signals in the current
+    /// bandwidth probing cycle. This is generally lower than max_inflight or inflight_longterm.
+    /// (Part of the short-term model.) saved state in case a loss episode is later declared
+    /// spurious
     undo_inflight_shortterm: u64,
     /// equivalent to BBR.bw_latest: a 1-round-trip max of delivered bandwidth (RS.delivery_rate).
     bw_latest: f64,
-    /// equivalent to BBR.inflight_latest: a 1-round-trip max of delivered volume of data (RS.delivered).
+    /// equivalent to BBR.inflight_latest: a 1-round-trip max of delivered volume of data
+    /// (RS.delivered).
     inflight_latest: u64,
-    /// equivalent to BBR.max_bw_filter: A windowed max filter for RS.delivery_rate samples, for estimating BBR.max_bw.
+    /// equivalent to BBR.max_bw_filter: A windowed max filter for RS.delivery_rate samples, for
+    /// estimating BBR.max_bw.
     max_bw_filter: MaxFilter,
-    /// equivalent to BBR.extra_acked_interval_start: The start of the time interval for estimating the excess amount of data acknowledged due to aggregation effects.
+    /// equivalent to BBR.extra_acked_interval_start: The start of the time interval for estimating
+    /// the excess amount of data acknowledged due to aggregation effects.
     extra_acked_interval_start: Option<Instant>,
-    /// equivalent to BBR.extra_acked_delivered: The volume of data marked as delivered since BBR.extra_acked_interval_start.
+    /// equivalent to BBR.extra_acked_delivered: The volume of data marked as delivered since
+    /// BBR.extra_acked_interval_start.
     extra_acked_delivered: u64,
-    /// equivalent to BBR.extra_acked_filter: A windowed max filter for tracking the degree of aggregation in the path.
+    /// equivalent to BBR.extra_acked_filter: A windowed max filter for tracking the degree of
+    /// aggregation in the path.
     extra_acked_filter: MaxFilter,
-    /// equivalent to BBR.full_bw_reached: A boolean that records whether BBR estimates that it has ever fully utilized its available bandwidth over the lifetime of the connection.
+    /// equivalent to BBR.full_bw_reached: A boolean that records whether BBR estimates that it has
+    /// ever fully utilized its available bandwidth over the lifetime of the connection.
     full_bw_reached: bool,
-    /// equivalent to BBR.full_bw_now: A boolean that records whether BBR estimates that it has fully utilized its available bandwidth since it most recetly started looking.
+    /// equivalent to BBR.full_bw_now: A boolean that records whether BBR estimates that it has
+    /// fully utilized its available bandwidth since it most recetly started looking.
     full_bw_now: bool,
-    /// equivalent to BBR.full_bw: A recent baseline BBR.max_bw to estimate if BBR has "filled the pipe" in Startup.
+    /// equivalent to BBR.full_bw: A recent baseline BBR.max_bw to estimate if BBR has "filled the
+    /// pipe" in Startup.
     full_bw: f64,
-    /// equivalent to BBR.full_bw_count: The number of non-app-limited round trips without large increases in BBR.full_bw.
+    /// equivalent to BBR.full_bw_count: The number of non-app-limited round trips without large
+    /// increases in BBR.full_bw.
     full_bw_count: u64,
-    /// equivalent to BBR.min_rtt_stamp: The wall clock time at which the current BBR.min_rtt sample was obtained.
+    /// equivalent to BBR.min_rtt_stamp: The wall clock time at which the current BBR.min_rtt
+    /// sample was obtained.
     min_rtt_stamp: Option<Instant>,
-    /// equivalent to BBR.ProbeRTTDuration: A constant specifying the minimum duration for which ProbeRTT state holds C.inflight to BBR.MinPipeCwnd or fewer packets: 200 ms.
+    /// equivalent to BBR.ProbeRTTDuration: A constant specifying the minimum duration for which
+    /// ProbeRTT state holds C.inflight to BBR.MinPipeCwnd or fewer packets: 200 ms.
     probe_rtt_duration: Duration,
-    /// equivalent to BBR.ProbeRTTInterval: A constant specifying the minimum time interval between ProbeRTT states: 5 secs.
+    /// equivalent to BBR.ProbeRTTInterval: A constant specifying the minimum time interval between
+    /// ProbeRTT states: 5 secs.
     probe_rtt_interval: Duration,
-    /// equivalent to BBR.probe_rtt_min_delay: The minimum RTT sample recorded in the last ProbeRTTInterval.
+    /// equivalent to BBR.probe_rtt_min_delay: The minimum RTT sample recorded in the last
+    /// ProbeRTTInterval.
     probe_rtt_min_delay: Duration,
-    /// equivalent to BBR.probe_rtt_min_stamp: The wall clock time at which the current BBR.probe_rtt_min_delay sample was obtained.
+    /// equivalent to BBR.probe_rtt_min_stamp: The wall clock time at which the current
+    /// BBR.probe_rtt_min_delay sample was obtained.
     probe_rtt_min_stamp: Option<Instant>,
-    /// equivalent to BBR.probe_rtt_expired: A boolean recording whether the BBR.probe_rtt_min_delay has expired and
-    /// is due for a refresh with an application idle period or a transition into ProbeRTT state.
+    /// equivalent to BBR.probe_rtt_expired: A boolean recording whether the
+    /// BBR.probe_rtt_min_delay has expired and is due for a refresh with an application idle
+    /// period or a transition into ProbeRTT state.
     probe_rtt_expired: bool,
     /// equivalent to C.delivered_time: The wall clock time when C.delivered was last updated. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.1.2.1>
     delivered_time: Option<Instant>,
-    /// equivalent to C.first_send_time: If packets are in flight, then this holds the send time of the packet that was most recently marked as delivered.
-    /// Else, if the connection was recently idle, then this holds the send time of most recently sent packet.
+    /// equivalent to C.first_send_time: If packets are in flight, then this holds the send time of
+    /// the packet that was most recently marked as delivered. Else, if the connection was
+    /// recently idle, then this holds the send time of most recently sent packet.
     first_send_time: Option<Instant>,
-    /// equivalent to C.app_limited: The index of the last transmitted packet marked as application-limited, or 0 if the connection is not currently application-limited.
+    /// equivalent to C.app_limited: The index of the last transmitted packet marked as
+    /// application-limited, or 0 if the connection is not currently application-limited.
     app_limited: u64,
-    /// equivalent to C.lost: the number of bytes that have been lost during the lifetime of this connection
+    /// equivalent to C.lost: the number of bytes that have been lost during the lifetime of this
+    /// connection
     lost: u64,
-    /// equivalent to C.srtt: The smoothed RTT, an exponentially weighted moving average of the observed RTT of the connection.
+    /// equivalent to C.srtt: The smoothed RTT, an exponentially weighted moving average of the
+    /// observed RTT of the connection.
     srtt: Duration,
     /// collection of packets in flight or just acknowledged / lost.
     packets: VecDeque<BbrPacket>,
@@ -427,11 +512,14 @@ pub struct Bbr3 {
     rounds_since_bw_probe: u64,
     /// equivalent to BBR.bw_probe_wait: random wait time before entering probing state again
     bw_probe_wait: Duration,
-    /// equivalent to BBR.bw_probe_up_rounds: number of rounds that have been executed in probe up state
+    /// equivalent to BBR.bw_probe_up_rounds: number of rounds that have been executed in probe up
+    /// state
     bw_probe_up_rounds: u32,
-    /// equivalent to BBR.bw_probe_up_acks: volume of data in bytes that has been acknowledged during probe up state
+    /// equivalent to BBR.bw_probe_up_acks: volume of data in bytes that has been acknowledged
+    /// during probe up state
     bw_probe_up_acks: u64,
-    /// equivalent to BBR.probe_up_cnt: count of the number of times we've grown the cwnd during probe up state
+    /// equivalent to BBR.probe_up_cnt: count of the number of times we've grown the cwnd during
+    /// probe up state
     probe_up_cnt: u64,
     /// equivalent to BBR.cycle_stamp: timestamp when we start probing down state
     cycle_stamp: Option<Instant>,
@@ -445,11 +533,13 @@ pub struct Bbr3 {
     loss_in_round: bool,
     /// equivalent to BBR.probe_rtt_done_stamp: timestamp when probe RTT state is finished
     probe_rtt_done_stamp: Option<Instant>,
-    /// equivalent to BBR.probe_rtt_round_done: set once per round when BBR.probe_rtt_done_stamp to check if we need to switch state
+    /// equivalent to BBR.probe_rtt_round_done: set once per round when BBR.probe_rtt_done_stamp to
+    /// check if we need to switch state
     probe_rtt_round_done: bool,
     /// equivalent to BBR.prior_cwnd: cwnd from last round
     prior_cwnd: u64,
-    /// equivalent to BBR.loss_round_start: flag set to true at the very beginning of a round where loss occurred
+    /// equivalent to BBR.loss_round_start: flag set to true at the very beginning of a round where
+    /// loss occurred
     loss_round_start: bool,
     /// equivalent to BBR.drain_start_round: The value of round_count when Drain state started.
     drain_start_round: u64,
@@ -505,7 +595,7 @@ impl Bbr3 {
             cycle_count: 0,
             cwnd: initial_cwnd,
             pacing_rate,
-            send_quantum: 2 * smss, // we start high, but it will be adjusted in set_send_quantum <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.3>
+            send_quantum: 2 * smss, /* we start high, but it will be adjusted in set_send_quantum <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.3> */
             pacing_gain: startup_pacing_gain,
             startup_pacing_gain,
             default_pacing_gain,
@@ -523,7 +613,7 @@ impl Bbr3 {
             round_start: true,
             next_round_delivered: 0,
             idle_restart: false,
-            min_pipe_cwnd: 4 * smss, // 4 * C.SMSS as defined in <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.7-4>
+            min_pipe_cwnd: 4 * smss, /* 4 * C.SMSS as defined in <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.7-4> */
             max_bw: 0.0,
             bw_shortterm: f64::INFINITY,
             undo_bw_shortterm: f64::INFINITY,

--- a/noq-proto/src/congestion/bbr3/mod.rs
+++ b/noq-proto/src/congestion/bbr3/mod.rs
@@ -17,10 +17,12 @@ const MAX_BW_FILTER_LEN: usize = 2;
 /// equivalent to BBR.ExtraAckedFilterLen <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.11>
 const EXTRA_ACKED_FILTER_LEN: usize = 10;
 
-/// safety mechanism to flag packets as stale within our tracking VecDeque. rounds refer to <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1>.
-/// The value of 10 rounds is picked because normally after max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity) <https://datatracker.ietf.org/doc/html/rfc9002#section-6.1.2>
-/// the packet should have been declared lost already, this is just to guarantee that the VecDeque
-/// doesn't grow indefinitely.
+/// safety mechanism to flag packets as stale within our tracking VecDeque. rounds refer to
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1>.  The value
+/// of 10 rounds is picked because normally after max(kTimeThreshold * max(smoothed_rtt,
+/// latest_rtt), kGranularity) <https://datatracker.ietf.org/doc/html/rfc9002#section-6.1.2>
+/// the packet should have been declared lost already, this is just to guarantee that the
+/// VecDeque doesn't grow indefinitely.
 const ROUND_COUNT_WINDOW: u64 = 10;
 
 /// the minimum for the maximum datagram size <https://datatracker.ietf.org/doc/html/rfc9000#section-14>
@@ -50,36 +52,42 @@ const HIGH_PACE_MAX_QUANTUM: u64 = 64 * 1000;
 /// BBR.pacing_gain. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const STARTUP_PACING_GAIN: f64 = 2.773;
 
-/// default pacing gain is 1, when cruising, probing for RTT or refilling <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+/// default pacing gain is 1, when cruising, probing for RTT or refilling
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const DEFAULT_PACING_GAIN: f64 = 1.0;
 
-/// pacing gain when probing bandwidth down <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+/// pacing gain when probing bandwidth down
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const PROBE_BW_DOWN_PACING_GAIN: f64 = 0.9;
 
-/// pacing gain when probing bandwidth up <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+/// pacing gain when probing bandwidth up
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const PROBE_BW_UP_PACING_GAIN: f64 = 1.25;
 
 /// equivalent to BBR.PacingMarginPercent: The static discount factor of 1% used to scale BBR.bw to
 /// produce C.pacing_rate.
 const PACING_MARGIN_PERCENT: f64 = 1.0;
 
-/// equivalent to BBR.DefaultCwndGain: A constant specifying the minimum gain value that allows the
-/// sending rate to double each round (2) BBRStartupCwndGain. Used by default in most phases for
-/// BBR.cwnd_gain.
+/// equivalent to BBR.DefaultCwndGain: A constant specifying the minimum gain value that
+/// allows the sending rate to double each round (2) BBRStartupCwndGain. Used by default in
+/// most phases for BBR.cwnd_gain.
 const DEFAULT_CWND_GAIN: f64 = 2.0;
 
-/// equivalent to BBR.DrainPacingGain: A constant specifying the pacing gain value used in Drain
-/// mode, to attempt to drain the estimated queue at the bottleneck link in one round-trip or less.
-/// As noted in BBRDrainPacingGain, any value at or below 1 / BBRStartupCwndGain = 1 / 2 = 0.5 will
-/// theoretically achieve this. BBR uses the value 0.5, which has been shown to offer good
-/// performance when compared with other alternatives. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.4>
+/// equivalent to BBR.DrainPacingGain: A constant specifying the pacing gain value used in
+/// Drain mode, to attempt to drain the estimated queue at the bottleneck link in one
+/// round-trip or less.  As noted in BBRDrainPacingGain, any value at or below
+/// `1 / BBRStartupCwndGain = 1 / 2 = 0.5` will theoretically achieve this. BBR uses the value
+/// 0.5, which has been shown to offer good performance when compared with other
+/// alternatives. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.4>
 /// <https://github.com/google/bbr/blob/master/Documentation/startup/gain/analysis/bbr_drain_gain.pdf>
 const DRAIN_PACING_GAIN: f64 = 1.0 / DEFAULT_CWND_GAIN;
 
-/// cwnd gain used when probing up <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+/// cwnd gain used when probing up
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const PROBE_BW_UP_CWND_GAIN: f64 = 2.25;
 
-/// cwnd gain used when probing RTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+/// cwnd gain used when probing RTT
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
 const PROBE_RTT_CWND_GAIN: f64 = 0.5;
 
 /// equivalent to BBR.ProbeRTTDuration: A constant specifying the minimum duration for which
@@ -112,17 +120,20 @@ const MIN_RTT_FILTER_LEN: u64 = 10;
 /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-6>
 const FULL_BW_GROWTH: f64 = 1.25;
 
-/// maximum number of rounds needed before we consider that the pipe is full <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-6>
+/// maximum number of rounds needed before we consider that the pipe is full
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-6>
 const MAX_FULL_BW_COUNT: u64 = 3;
 
 /// when setting `bw_probe_up_rounds` when raising our inflight long term slope we don't go above
 /// this <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
 const MAX_LONG_TERM_PROBE_UP_ROUNDS: u32 = 30;
 
-/// max number of rounds used when deciding to coexist with Reno / CUBIC <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.1>
+/// max number of rounds used when deciding to coexist with Reno / CUBIC
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.1>
 const MAX_RENO_ROUNDS: u64 = 63;
 
-/// minimum amount of time to wait before probing again <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-5>
+/// minimum amount of time to wait before probing again
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-5>
 const MIN_PROBE_WAIT_MS: u64 = 2000;
 
 /// when waiting before probing again we add up to one second of added wait time
@@ -133,46 +144,65 @@ const MAX_ADDED_PROBE_WAIT_MS: u64 = 1000;
 /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3>
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum ProbeBwSubstate {
-    /// Deceleration: sends slower than delivery rate to reduce queue
-    /// equivalent to ProbeBW_DOWN <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.1>
+    /// Deceleration: sends slower than delivery rate to reduce queue.
+    ///
+    /// Equivalent to ProbeBW_DOWN
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.1>.
     Down,
 
-    /// Cruising: sends at delivery rate to maintain high utilization
-    /// equivalent to ProbeBW_CRUISE <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.2>
+    /// Cruising: sends at delivery rate to maintain high utilization.
+    ///
+    /// Equivalent to ProbeBW_CRUISE
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.2>.
     Cruise,
 
-    /// Refill: sends at BBR.bw for one RTT to fill pipe before probing up
-    /// equivalent to ProbeBW_REFILL <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.3>
+    /// Refill: sends at BBR.bw for one RTT to fill pipe before probing up.
+    ///
+    /// Equivalent to ProbeBW_REFILL
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.3>.
     Refill,
 
-    /// Acceleration: sends faster than delivery rate to probe for more bandwidth
-    /// equivalent to ProbeBW_UP <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.4>
+    /// Acceleration: sends faster than delivery rate to probe for more bandwidth.
+    ///
+    /// Equivalent to ProbeBW_UP
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.4>.
     Up,
 }
 
-/// State Machine description from BBR3
+/// State Machine description from BBR3.
+///
 /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3>
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum BbrState {
-    /// Initial state: rapidly probes for bandwidth using high pacing_gain
-    /// equivalent to Startup <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1>
+    /// Initial state: rapidly probes for bandwidth using high pacing_gain.
+    ///
+    /// Equivalent to Startup
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1>.
     Startup,
 
-    /// Drains queue created during Startup by using low pacing_gain (< 1.0)
-    /// equivalent to Drain <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.2>
+    /// Drains queue created during Startup by using low pacing_gain (< 1.0).
+    ///
+    /// Equivalent to Drain
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.2>.
     Drain,
 
-    /// Steady-state phase that cycles through bandwidth probing tactics
-    /// equivalent to ProbeBW states <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3>
+    /// Steady-state phase that cycles through bandwidth probing tactics.
+    ///
+    /// Equivalent to ProbeBW states
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3>.
     ProbeBw(ProbeBwSubstate),
 
-    /// Temporarily reduces inflight to measure true min_rtt
-    /// equivalent to ProbeRTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4>
+    /// Temporarily reduces inflight to measure true min_rtt.
+    ///
+    /// Equivalent to ProbeRTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4>.
     ProbeRtt,
 }
 
-/// Ack phases used during ProbeBW states
-/// equivalent to BBR.ack_phase states <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6>
+/// Ack phases used during ProbeBW states.
+///
+/// Equivalent to BBR.ack_phase states
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6>.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum AckPhase {
     /// equivalent to ACKS_PROBE_STARTING
@@ -185,9 +215,10 @@ enum AckPhase {
     ProbeFeedback,
 }
 
-/// Description of a packet for the purposes of analysis through BBR3
-/// all volumes of data use bytes, all rates of data use bytes/sec
-/// equivalent to P <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.2.1.2>
+/// Description of a packet for the purposes of analysis through BBR3.
+///
+/// All volumes of data use bytes, all rates of data use bytes/sec equivalent to P
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.2.1.2>.
 #[derive(Debug, Clone, Copy)]
 struct BbrPacket {
     /// equivalent to P.delivered: C.delivered when the packet was sent from transport connection
@@ -218,12 +249,14 @@ struct BbrPacket {
     /// once a packet has been acknowledged on a given round it is marked for removal on the next
     /// round.
     stale: bool,
-    /// used to mark packets stale if they're far from the current round <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1>
+    /// used to mark packets stale if they're far from the current round
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1>
     round_count: u64,
 }
 
 /// Description of a per-ack rate sample state that will allow us to determine a short term
-/// evolution of the connection equivalent to RS <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.2>
+/// evolution of the connection equivalent to RS
+/// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.2>
 #[derive(Debug, Clone, Copy)]
 struct BbrRateSample {
     /// equivalent to RS.delivery_rate: The delivery rate (aka bandwidth) sample obtained from the
@@ -280,7 +313,8 @@ struct BbrRateSample {
 /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.1>
 #[derive(Debug, Clone)]
 pub struct Bbr3 {
-    /// equivalent to C.SMSS The Sender Maximum Send Size in bytes. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.1>
+    /// equivalent to C.SMSS The Sender Maximum Send Size in
+    /// bytes. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.1>
     /// <https://www.rfc-editor.org/rfc/rfc9000#name-datagram-size>
     smss: u64,
     /// equivalent to C.InitialCwnd: The initial congestion window set by the transport protocol
@@ -352,11 +386,15 @@ pub struct Bbr3 {
     probe_rng: Pcg32,
     /// cwnd gain used when probing up <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     probe_bw_up_cwnd_gain: f64,
-    /// cwnd gain used when probing RTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
+    /// cwnd gain used when probing RTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.1>
     probe_rtt_cwnd_gain: f64,
-    /// equivalent to BBR.state: The current state of a BBR flow in the BBR state machine. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-3.3>
+    /// equivalent to BBR.state: The current state of a BBR flow in the BBR state
+    /// machine. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-3.3>
     state: BbrState,
-    /// equivalent to BBR.undo_state: The state of a BBR flow in the BBR state machine saved in case a loss episode is later declared spurious. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-3.3>
+    /// equivalent to BBR.undo_state: The state of a BBR flow in the BBR state machine saved
+    /// in case a loss episode is later declared
+    /// spurious. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-3.3>
     undo_state: BbrState,
     /// equivalent to BBR.round_count: Count of packet-timed round trips elapsed so far.
     round_count: u64,
@@ -372,9 +410,10 @@ pub struct Bbr3 {
     /// equivalent to BBR.MinPipeCwnd: The minimal C.cwnd value BBR targets, to allow pipelining
     /// with endpoints that follow an "ACK every other packet" delayed-ACK policy: 4 * C.SMSS.
     min_pipe_cwnd: u64,
-    /// equivalent to BBR.max_bw: The windowed maximum recent bandwidth sample, obtained using the
-    /// BBR delivery rate sampling algorithm in <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1>,
-    /// measured during the current or previous bandwidth probing cycle (or during Startup, if the
+    /// equivalent to BBR.max_bw: The windowed maximum recent bandwidth sample, obtained
+    /// using the BBR delivery rate sampling algorithm in
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1>, measured
+    /// during the current or previous bandwidth probing cycle (or during Startup, if the
     /// flow is still in that state). (Part of the long-term model.)
     max_bw: f64,
     /// equivalent to BBR.bw_shortterm: The short-term maximum sending bandwidth that the algorithm
@@ -489,7 +528,8 @@ pub struct Bbr3 {
     /// BBR.probe_rtt_min_delay has expired and is due for a refresh with an application idle
     /// period or a transition into ProbeRTT state.
     probe_rtt_expired: bool,
-    /// equivalent to C.delivered_time: The wall clock time when C.delivered was last updated. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.1.2.1>
+    /// equivalent to C.delivered_time: The wall clock time when C.delivered was last
+    /// updated. <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.1.2.1>
     delivered_time: Option<Instant>,
     /// equivalent to C.first_send_time: If packets are in flight, then this holds the send time of
     /// the packet that was most recently marked as delivered. Else, if the connection was
@@ -506,7 +546,8 @@ pub struct Bbr3 {
     srtt: Duration,
     /// collection of packets in flight or just acknowledged / lost.
     packets: VecDeque<BbrPacket>,
-    /// equivalent to RS: Per-ACK Rate Sample State <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.2>
+    /// equivalent to RS: Per-ACK Rate Sample State
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-2.2>
     rs: Option<BbrRateSample>,
     /// equivalent to BBR.rounds_since_bw_probe: rounds since last bw probe state.
     rounds_since_bw_probe: u64,
@@ -525,7 +566,8 @@ pub struct Bbr3 {
     cycle_stamp: Option<Instant>,
     /// equivalent to BBR.ack_phase: ACK phase during probing states
     ack_phase: AckPhase,
-    /// equivalent to BBR.bw_probe_samples: <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2>
+    /// equivalent to BBR.bw_probe_samples:
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2>
     bw_probe_samples: bool,
     /// equivalent to BBR.loss_round_delivered: C.delivered during the first loss of the round
     loss_round_delivered: u64,
@@ -583,7 +625,8 @@ impl Bbr3 {
             .probe_bw_up_cwnd_gain
             .unwrap_or(PROBE_BW_UP_CWND_GAIN);
         let probe_rtt_cwnd_gain = config.probe_rtt_cwnd_gain.unwrap_or(PROBE_RTT_CWND_GAIN);
-        // the calculation for initial pacing rate described here <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.2-5>
+        // the calculation for initial pacing rate described here
+        // <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.2-5>
         let nominal_bandwidth = initial_cwnd as f64 / 0.001;
         let pacing_rate = startup_pacing_gain * nominal_bandwidth;
         Self {
@@ -595,7 +638,7 @@ impl Bbr3 {
             cycle_count: 0,
             cwnd: initial_cwnd,
             pacing_rate,
-            send_quantum: 2 * smss, /* we start high, but it will be adjusted in set_send_quantum <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.3> */
+            send_quantum: 2 * smss, /* we start. high, but it will be adjusted in set_send_quantum <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.3> */
             pacing_gain: startup_pacing_gain,
             startup_pacing_gain,
             default_pacing_gain,
@@ -674,21 +717,24 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBREnterStartup <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.1-3>
+    /// equivalent to BBREnterStartup
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.1-3>
     fn enter_startup(&mut self) {
         self.state = BbrState::Startup;
         self.pacing_gain = self.startup_pacing_gain;
         self.cwnd_gain = self.default_cwnd_gain;
     }
 
-    /// equivalent to BBRResetFullBW <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-4>
+    /// equivalent to BBRResetFullBW
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-4>
     fn reset_full_bw(&mut self) {
         self.full_bw = 0.0;
         self.full_bw_count = 0;
         self.full_bw_now = false;
     }
 
-    /// equivalent to BBRNoteLoss <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-11>
+    /// equivalent to BBRNoteLoss
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-11>
     fn note_loss(&mut self) {
         if !self.loss_in_round {
             self.loss_round_delivered = self.delivered;
@@ -697,8 +743,9 @@ impl Bbr3 {
         self.loss_in_round = true;
     }
 
-    /// equivalent to BBRSaveStateUponLoss <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.11.1>
-    /// Save state in case a loss episode is later declared spurious
+    /// equivalent to BBRSaveStateUponLoss
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.11.1> Save
+    /// state in case a loss episode is later declared spurious
     fn save_state_upon_loss(&mut self) {
         self.undo_state = self.state;
         self.undo_bw_shortterm = self.bw_shortterm;
@@ -706,8 +753,9 @@ impl Bbr3 {
         self.undo_inflight_longterm = self.inflight_longterm;
     }
 
-    /// equivalent to BBRInflightAtLoss <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-11>
-    /// We check at what prefix of packet did losses exceed `loss_thresh`
+    /// equivalent to BBRInflightAtLoss
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-11> We
+    /// check at what prefix of packet did losses exceed `loss_thresh`
     fn inflight_at_loss(&mut self, packet_size: u64) -> u64 {
         if let Some(rate_sample) = self.rs {
             let inflight_prev = rate_sample.tx_in_flight.saturating_sub(packet_size);
@@ -721,7 +769,8 @@ impl Bbr3 {
         0
     }
 
-    /// equivalent to BBRSaveCwnd <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.4-13>
+    /// equivalent to BBRSaveCwnd
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.4-13>
     fn save_cwnd(&mut self) {
         if !self.loss_in_round && self.state != BbrState::ProbeRtt {
             self.prior_cwnd = self.cwnd;
@@ -730,31 +779,36 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRRestoreCwnd <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.4-13>
+    /// equivalent to BBRRestoreCwnd
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.4-13>
     fn restore_cwnd(&mut self) {
         self.cwnd = max(self.cwnd, self.prior_cwnd);
     }
 
-    /// equivalent to BBRProbeRTTCwnd <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.5-1>
+    /// equivalent to BBRProbeRTTCwnd
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.5-1>
     fn probe_rtt_cwnd(&mut self) -> u64 {
         let mut probe_rtt_cwnd = self.bdp_multiple(self.bw, self.probe_rtt_cwnd_gain);
         probe_rtt_cwnd = max(probe_rtt_cwnd, self.min_pipe_cwnd);
         probe_rtt_cwnd
     }
 
-    /// equivalent to BBRBoundCwndForProbeRTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.5-1>
+    /// equivalent to BBRBoundCwndForProbeRTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.5-1>
     fn bound_cwnd_for_probe_rtt(&mut self) {
         if self.state == BbrState::ProbeRtt {
             self.cwnd = min(self.cwnd, self.probe_rtt_cwnd());
         }
     }
 
-    /// equivalent to BBRTargetInflight <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
+    /// equivalent to BBRTargetInflight
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
     fn target_inflight(&self) -> u64 {
         min(self.bdp, self.cwnd)
     }
 
-    /// equivalent to BBRHandleInflightTooHigh <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-1>
+    /// equivalent to BBRHandleInflightTooHigh
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-1>
     fn handle_inflight_too_high(&mut self, now: Instant) {
         self.bw_probe_samples = false;
         if let Some(rate_sample) = self.rs
@@ -771,7 +825,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to IsInflightTooHigh <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-1>
+    /// equivalent to IsInflightTooHigh
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-1>
     fn is_inflight_too_high(&self) -> bool {
         if let Some(rate_sample) = self.rs {
             return rate_sample.lost as f64 > rate_sample.tx_in_flight as f64 * LOSS_THRESH;
@@ -779,7 +834,8 @@ impl Bbr3 {
         false
     }
 
-    /// equivalent to BBRCheckStartupHighLoss <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.3>
+    /// equivalent to BBRCheckStartupHighLoss
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.3>
     fn check_startup_high_loss(&mut self) {
         if self.full_bw_reached {
             return;
@@ -797,13 +853,15 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBREnterProbeBW <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6>
+    /// equivalent to BBREnterProbeBW
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6>
     fn enter_probe_bw(&mut self, now: Instant) {
         self.cwnd_gain = self.default_cwnd_gain;
         self.start_probe_bw_down(now);
     }
 
-    /// equivalent to BBRPickProbeWait <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
+    /// equivalent to BBRPickProbeWait
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
     fn pick_probe_wait(&mut self) {
         // 0 or 1
         self.rounds_since_bw_probe = self.probe_rng.random_bool(0.5) as u64;
@@ -812,7 +870,8 @@ impl Bbr3 {
         );
     }
 
-    /// equivalent to BBRHasElapsedInPhase <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
+    /// equivalent to BBRHasElapsedInPhase
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
     fn has_elapsed_in_phase(&mut self, interval: Duration, now: Instant) -> bool {
         if let Some(cycle_stamp) = self.cycle_stamp {
             now > cycle_stamp.checked_add(interval).unwrap_or(cycle_stamp)
@@ -821,7 +880,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRExitProbeRTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.4>
+    /// equivalent to BBRExitProbeRTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.4>
     fn exit_probe_rtt(&mut self, now: Instant) {
         self.reset_short_term_model();
         if self.full_bw_reached {
@@ -832,7 +892,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRCheckProbeRTTDone <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
+    /// equivalent to BBRCheckProbeRTTDone
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
     fn check_probe_rtt_done(&mut self, now: Instant) {
         if let Some(probe_rtt_done_stamp) = self.probe_rtt_done_stamp
             && now > probe_rtt_done_stamp
@@ -843,7 +904,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRIsTimeToProbeBW <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
+    /// equivalent to BBRIsTimeToProbeBW
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
     fn maybe_enter_probe_bw_refill(&mut self, now: Instant) -> bool {
         if self.has_elapsed_in_phase(self.bw_probe_wait, now)
             || self.is_reno_coexistence_probe_time()
@@ -854,7 +916,8 @@ impl Bbr3 {
         false
     }
 
-    /// equivalent to BBRIsTimeToGoDown <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-6>
+    /// equivalent to BBRIsTimeToGoDown
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-6>
     fn maybe_go_down(&mut self) -> bool {
         if self.is_cwnd_limited && self.cwnd >= self.inflight_longterm {
             self.reset_full_bw();
@@ -867,14 +930,16 @@ impl Bbr3 {
         false
     }
 
-    /// equivalent to BBRIsRenoCoexistenceProbeTime <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
+    /// equivalent to BBRIsRenoCoexistenceProbeTime
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.5.3-6>
     fn is_reno_coexistence_probe_time(&self) -> bool {
         let reno_rounds = self.target_inflight();
         let rounds = min(reno_rounds, MAX_RENO_ROUNDS);
         self.rounds_since_bw_probe >= rounds
     }
 
-    /// equivalent to BBRBDPMultiple <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
+    /// equivalent to BBRBDPMultiple
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
     fn bdp_multiple(&mut self, bw: f64, gain: f64) -> u64 {
         if self.min_rtt == Duration::from_secs(u64::MAX) {
             return self.initial_cwnd;
@@ -901,7 +966,8 @@ impl Bbr3 {
         self.offload_budget = base.saturating_add(delayed_ack_term);
     }
 
-    /// equivalent to BBRQuantizationBudget <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
+    /// equivalent to BBRQuantizationBudget
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
     fn quantization_budget(&mut self, inflight_cap: u64) -> u64 {
         self.update_offload_budget();
         let mut inflight_cap = max(inflight_cap, self.offload_budget);
@@ -912,33 +978,38 @@ impl Bbr3 {
         inflight_cap
     }
 
-    /// equivalent to BBRInflight <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
+    /// equivalent to BBRInflight
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
     fn get_inflight(&mut self, gain: f64) -> u64 {
         let inflight_cap = self.bdp_multiple(self.max_bw, gain);
         self.quantization_budget(inflight_cap)
     }
 
-    /// equivalent to BBRUpdateMaxInflight <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
+    /// equivalent to BBRUpdateMaxInflight
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.2-2>
     fn update_max_inflight(&mut self) {
         let mut inflight_cap = self.bdp_multiple(self.max_bw, self.cwnd_gain);
         inflight_cap += self.extra_acked;
         self.max_inflight = self.quantization_budget(inflight_cap);
     }
 
-    /// equivalent to BBRResetCongestionSignals <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRResetCongestionSignals
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn reset_congestion_signals(&mut self) {
         self.loss_in_round = false;
         self.bw_latest = 0.0;
         self.inflight_latest = 0;
     }
 
-    /// equivalent to BBRStartRound <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1-9>
+    /// equivalent to BBRStartRound
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1-9>
     fn start_round(&mut self) {
         self.next_round_delivered = self.delivered;
         self.is_cwnd_limited = false;
     }
 
-    /// equivalent to BBRUpdateRound <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1-9>
+    /// equivalent to BBRUpdateRound
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.1-9>
     fn update_round(&mut self, packet: BbrPacket) {
         if packet.delivered >= self.next_round_delivered {
             self.start_round();
@@ -950,7 +1021,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRStartProbeBW_DOWN <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-4>
+    /// equivalent to BBRStartProbeBW_DOWN
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-4>
     fn start_probe_bw_down(&mut self, now: Instant) {
         self.reset_congestion_signals();
         self.probe_up_cnt = u64::MAX;
@@ -963,7 +1035,8 @@ impl Bbr3 {
         self.state = BbrState::ProbeBw(ProbeBwSubstate::Down);
     }
 
-    /// equivalent to BBRInflightWithHeadroom <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
+    /// equivalent to BBRInflightWithHeadroom
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
     fn inflight_with_headroom(&self) -> u64 {
         if self.inflight_longterm == u64::MAX {
             return u64::MAX;
@@ -976,7 +1049,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRSetPacingRateWithGain <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.2-7>
+    /// equivalent to BBRSetPacingRateWithGain
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.2-7>
     fn set_pacing_rate_with_gain(&mut self, gain: f64) {
         let rate = gain * self.bw * (100.0 - self.pacing_margin_percent) / 100.0;
         if self.full_bw_reached || rate > self.pacing_rate {
@@ -984,7 +1058,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRRaiseInflightLongtermSlope <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
+    /// equivalent to BBRRaiseInflightLongtermSlope
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
     fn raise_inflight_long_term_slope(&mut self) {
         let growth_this_round = self
             .smss
@@ -994,7 +1069,8 @@ impl Bbr3 {
         self.probe_up_cnt = max(self.cwnd / growth_this_round, 1);
     }
 
-    /// equivalent to BBRProbeInflightLongtermUpward <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
+    /// equivalent to BBRProbeInflightLongtermUpward
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
     fn probe_inflight_long_term_upward(&mut self) {
         if !self.is_cwnd_limited || self.cwnd < self.inflight_longterm {
             return;
@@ -1012,12 +1088,14 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRAdvanceMaxBwFilter <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.6>
+    /// equivalent to BBRAdvanceMaxBwFilter
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.6>
     fn advance_max_bw_filter(&mut self) {
         self.cycle_count = self.cycle_count.saturating_add(1);
     }
 
-    /// equivalent to BBRAdaptLongTermModel <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
+    /// equivalent to BBRAdaptLongTermModel
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
     fn adapt_long_term_model(&mut self) {
         if self.ack_phase == AckPhase::ProbeStarting && self.round_start {
             self.ack_phase = AckPhase::ProbeFeedback;
@@ -1045,7 +1123,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRIsTimeToCruise <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
+    /// equivalent to BBRIsTimeToCruise
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-8>
     fn maybe_update_budget_and_time_to_cruise(&mut self) -> bool {
         if self.inflight > self.inflight_with_headroom() {
             return false;
@@ -1056,20 +1135,23 @@ impl Bbr3 {
         true
     }
 
-    /// equivalent to BBRStartProbeBW_CRUISE <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.4-4>
+    /// equivalent to BBRStartProbeBW_CRUISE
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.4-4>
     fn start_probe_bw_cruise(&mut self) {
         self.state = BbrState::ProbeBw(ProbeBwSubstate::Cruise);
         self.pacing_gain = self.default_pacing_gain;
         self.cwnd_gain = self.default_cwnd_gain;
     }
 
-    /// equivalent to BBRResetShortTermModel <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRResetShortTermModel
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn reset_short_term_model(&mut self) {
         self.bw_shortterm = f64::INFINITY;
         self.inflight_shortterm = u64::MAX;
     }
 
-    /// equivalent to BBRInitLowerBounds <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRInitLowerBounds
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn init_lower_bounds(&mut self) {
         if self.bw_shortterm == f64::INFINITY {
             self.bw_shortterm = self.max_bw;
@@ -1079,7 +1161,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRLossLowerBounds <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRLossLowerBounds
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn loss_lower_bounds(&mut self) {
         // gives max of both f64
         self.bw_shortterm = [self.bw_latest, BETA * self.bw_shortterm]
@@ -1092,7 +1175,8 @@ impl Bbr3 {
         );
     }
 
-    /// equivalent to BBRBoundBWForModel <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRBoundBWForModel
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn bound_bw_for_model(&mut self) {
         // gives min of both f64
         self.bw = [self.max_bw, self.bw_shortterm]
@@ -1101,7 +1185,8 @@ impl Bbr3 {
             .fold(f64::NAN, f64::min);
     }
 
-    /// equivalent to BBRStartProbeBW_REFILL <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-4>
+    /// equivalent to BBRStartProbeBW_REFILL
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-4>
     fn start_probe_bw_refill(&mut self) {
         self.reset_short_term_model();
         self.bw_probe_up_rounds = 0;
@@ -1113,7 +1198,8 @@ impl Bbr3 {
         self.state = BbrState::ProbeBw(ProbeBwSubstate::Refill);
     }
 
-    /// equivalent to BBRStartProbeBW_UP <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-4>
+    /// equivalent to BBRStartProbeBW_UP
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-4>
     fn start_probe_bw_up(&mut self) {
         self.ack_phase = AckPhase::ProbeStarting;
         self.start_round();
@@ -1127,14 +1213,16 @@ impl Bbr3 {
         self.raise_inflight_long_term_slope();
     }
 
-    /// equivalent to BBREnterProbeRTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
+    /// equivalent to BBREnterProbeRTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
     fn enter_probe_rtt(&mut self) {
         self.state = BbrState::ProbeRtt;
         self.pacing_gain = self.default_pacing_gain;
         self.cwnd_gain = self.probe_rtt_cwnd_gain;
     }
 
-    /// equivalent to BBRHandleRestartFromIdle <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.4.1>
+    /// equivalent to BBRHandleRestartFromIdle
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.4.1>
     fn handle_restart_from_idle(&mut self, now: Instant) {
         if self.inflight == 0 && self.app_limited != 0 {
             self.idle_restart = true;
@@ -1151,7 +1239,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRUpdateProbeBWCyclePhase <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-6>
+    /// equivalent to BBRUpdateProbeBWCyclePhase
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.3.6-6>
     fn update_probe_bw_cycle_phase(&mut self, now: Instant) {
         if !self.full_bw_reached {
             return;
@@ -1180,7 +1269,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRUpdateLatestDeliverySignals <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRUpdateLatestDeliverySignals
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn update_latest_delivery_signals(&mut self) {
         self.loss_round_start = false;
         if let Some(rate_sample) = self.rs {
@@ -1197,7 +1287,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRAdaptLowerBoundsFromCongestion <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRAdaptLowerBoundsFromCongestion
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn adapt_lower_bounds_from_congestion(&mut self) {
         match self.state {
             BbrState::ProbeBw(ProbeBwSubstate::Refill)
@@ -1212,7 +1303,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRUpdateMaxBw <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.5>
+    /// equivalent to BBRUpdateMaxBw
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.5>
     fn update_max_bw(&mut self, p: BbrPacket) {
         self.update_round(p);
         if let Some(rate_sample) = self.rs
@@ -1226,7 +1318,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRUpdateCongestionSignals <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRUpdateCongestionSignals
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn update_congestion_signals(&mut self, p: BbrPacket) {
         self.update_max_bw(p);
         if !self.loss_round_start {
@@ -1236,7 +1329,8 @@ impl Bbr3 {
         self.loss_in_round = false;
     }
 
-    /// equivalent to BBRUpdateACKAggregation <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.9>
+    /// equivalent to BBRUpdateACKAggregation
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.9>
     fn update_ack_aggregation(&mut self, now: Instant) {
         let interval;
         if let Some(extra_acked_interval_start) = self.extra_acked_interval_start {
@@ -1266,7 +1360,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRCheckFullBWReached <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-6>
+    /// equivalent to BBRCheckFullBWReached
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.2-6>
     fn check_full_bw_reached(&mut self) {
         if self.full_bw_now || !self.round_start {
             return;
@@ -1288,7 +1383,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBREnterDrain <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.2>
+    /// equivalent to BBREnterDrain
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.2>
     fn enter_drain(&mut self) {
         self.state = BbrState::Drain;
         self.pacing_gain = self.drain_pacing_gain;
@@ -1296,7 +1392,8 @@ impl Bbr3 {
         self.drain_start_round = self.round_count;
     }
 
-    /// equivalent to BBRCheckStartupDone <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.1-6>
+    /// equivalent to BBRCheckStartupDone
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.1.1-6>
     fn check_startup_done(&mut self) {
         self.check_startup_high_loss();
         if self.state == BbrState::Startup && self.full_bw_reached {
@@ -1304,7 +1401,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRCheckDrainDone <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.2-3>
+    /// equivalent to BBRCheckDrainDone
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.2-3>
     fn check_drain_done(&mut self, now: Instant) {
         if self.state == BbrState::Drain
             && (self.inflight <= self.get_inflight(1.0)
@@ -1314,7 +1412,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRUpdateMinRTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3>
+    /// equivalent to BBRUpdateMinRTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3>
     fn update_min_rtt(&mut self, now: Instant) {
         if let Some(probe_rtt_min_stamp) = self.probe_rtt_min_stamp {
             self.probe_rtt_expired = now
@@ -1347,7 +1446,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRHandleProbeRTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
+    /// equivalent to BBRHandleProbeRTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
     fn handle_probe_rtt(&mut self, now: Instant) {
         if self.probe_rtt_done_stamp.is_none() && self.inflight <= self.probe_rtt_cwnd() {
             self.probe_rtt_done_stamp =
@@ -1364,7 +1464,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRCheckProbeRTT <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
+    /// equivalent to BBRCheckProbeRTT
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.3.4.3-4>
     fn check_probe_rtt(&mut self, now: Instant) {
         match self.state {
             BbrState::ProbeRtt => {
@@ -1387,7 +1488,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRAdvanceLatestDeliverySignals <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
+    /// equivalent to BBRAdvanceLatestDeliverySignals
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.3-8>
     fn advance_latest_delivery_signals(&mut self) {
         if self.loss_round_start
             && let Some(rate_sample) = self.rs
@@ -1397,7 +1499,8 @@ impl Bbr3 {
         }
     }
 
-    /// equivalent to BBRUpdateModelAndState <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.2.3>
+    /// equivalent to BBRUpdateModelAndState
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.2.3>
     fn update_model_and_state(&mut self, p: BbrPacket, now: Instant) {
         self.update_latest_delivery_signals();
         self.reset_congestion_signals();
@@ -1413,13 +1516,15 @@ impl Bbr3 {
         self.bound_bw_for_model();
     }
 
-    /// equivalent to BBRSetPacingRate <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.2-7>
+    /// equivalent to BBRSetPacingRate
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.2-7>
     fn set_pacing_rate(&mut self) {
         self.set_pacing_rate_with_gain(self.pacing_gain);
     }
 
-    /// equivalent to BBRSetSendQuantum <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.3>
-    /// this version is based on a version of bbr2 from quiche
+    /// equivalent to BBRSetSendQuantum
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.3> this
+    /// version is based on a version of bbr2 from quiche
     fn set_send_quantum(&mut self) {
         self.send_quantum = match self.pacing_rate {
             rate if rate < PACING_RATE_1_2MBPS => MAX_DATAGRAM_SIZE,
@@ -1428,7 +1533,8 @@ impl Bbr3 {
         };
     }
 
-    /// equivalent to BBRBoundCwndForModel <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.7>
+    /// equivalent to BBRBoundCwndForModel
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.7>
     fn bound_cwnd_for_model(&mut self) {
         let mut cap = u64::MAX;
         match self.state {
@@ -1448,7 +1554,8 @@ impl Bbr3 {
         self.cwnd = min(self.cwnd, cap);
     }
 
-    /// equivalent to BBRSetCwnd <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.6>
+    /// equivalent to BBRSetCwnd
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.6.4.6>
     fn set_cwnd(&mut self) {
         self.update_max_inflight();
         if self.full_bw_reached {
@@ -1467,14 +1574,16 @@ impl Bbr3 {
         self.bound_cwnd_for_model();
     }
 
-    /// equivalent to BBRUpdateControlParameters <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.2.3>
+    /// equivalent to BBRUpdateControlParameters
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.2.3>
     fn update_control_parameters(&mut self) {
         self.set_pacing_rate();
         self.set_send_quantum();
         self.set_cwnd();
     }
 
-    /// equivalent to IsNewestPacket <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.2.3-3>
+    /// equivalent to IsNewestPacket
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.2.3-3>
     fn is_newest_packet(&self, send_time: Instant, end_seq: u64) -> bool {
         if let Some(first_send_time) = self.first_send_time {
             if send_time > first_send_time {
@@ -1489,7 +1598,8 @@ impl Bbr3 {
         false
     }
 
-    /// equivalent to BBRHandleLostPacket <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-11>
+    /// equivalent to BBRHandleLostPacket
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.10.2-11>
     fn process_lost_packet(&mut self, lost_bytes: u64, packet_index: usize, now: Instant) {
         let p = self.packets[packet_index];
         self.note_loss();
@@ -1627,7 +1737,8 @@ impl Controller for Bbr3 {
                 }
                 rate_sample.interval = max(rate_sample.send_elapsed, rate_sample.ack_elapsed);
                 rate_sample.delivered = self.delivered.saturating_sub(rate_sample.prior_delivered);
-                // ignore this condition on an initially high min rtt as per <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.2.3-5>
+                // ignore this condition on an initially high min rtt as per
+                // <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-4.1.2.3-5>
                 if rate_sample.interval < self.min_rtt
                     && self.min_rtt != Duration::from_secs(u64::MAX)
                 {
@@ -1682,7 +1793,8 @@ impl Controller for Bbr3 {
         }
     }
 
-    /// equivalent to BBRHandleSpuriousLossDetection: <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.11.2>
+    /// equivalent to BBRHandleSpuriousLossDetection:
+    /// <https://www.ietf.org/archive/id/draft-ietf-ccwg-bbr-05.html#section-5.5.11.2>
     fn on_spurious_congestion_event(&mut self) {
         self.loss_in_round = false;
         self.reset_full_bw();

--- a/noq-proto/src/connection/ack_frequency.rs
+++ b/noq-proto/src/connection/ack_frequency.rs
@@ -9,7 +9,6 @@ use super::PathId;
 pub(super) struct AckFrequencyState {
     //
     // Sending ACK_FREQUENCY frames
-    //
     /// The path ID, packet number and value of the in-flight ACK_FREQUENCY frame
     in_flight_ack_frequency_frame: Option<(PathId, u64, Duration)>,
     next_outgoing_sequence_number: VarInt,
@@ -17,7 +16,6 @@ pub(super) struct AckFrequencyState {
 
     //
     // Receiving ACK_FREQUENCY frames
-    //
     /// The sequence number of the most recently received ACK_FREQUENCY frame
     last_ack_frequency_frame: Option<u64>,
     pub(super) max_ack_delay: Duration,

--- a/noq-proto/src/connection/assembler.rs
+++ b/noq-proto/src/connection/assembler.rs
@@ -17,9 +17,9 @@ pub(super) struct Assembler {
     buffered: usize,
     /// Estimated number of allocated bytes, will never be less than `buffered`.
     allocated: usize,
-    /// Number of bytes read by the application. When only ordered reads have been used, this is the
-    /// length of the contiguous prefix of the stream which has been consumed by the application,
-    /// aka the stream offset.
+    /// Number of bytes read by the application. When only ordered reads have been used, this is
+    /// the length of the contiguous prefix of the stream which has been consumed by the
+    /// application, aka the stream offset.
     bytes_read: u64,
     end: u64,
 }
@@ -652,7 +652,8 @@ mod test {
 
     #[test]
     fn no_duplicate_after_mode_switch() {
-        // Regression test: bytes read in ordered mode should not be returned again in unordered mode
+        // Regression test: bytes read in ordered mode should not be returned again in unordered
+        // mode
         let mut x = Assembler::new();
         x.insert(0, Bytes::from_static(b"a"), 1);
         x.insert(0, Bytes::from_static(b"a"), 1); // duplicate

--- a/noq-proto/src/connection/cid_state.rs
+++ b/noq-proto/src/connection/cid_state.rs
@@ -21,7 +21,8 @@ pub(super) struct CidState {
     issued: u64,
     /// Sequence numbers of local connection IDs not yet retired by the peer
     active_seq: FxHashSet<u64>,
-    /// Sequence number the peer has already retired all CIDs below at our request via `retire_prior_to`
+    /// Sequence number the peer has already retired all CIDs below at our request via
+    /// `retire_prior_to`
     prev_retire_seq: u64,
     /// Sequence number to set in retire_prior_to field in NEW_CONNECTION_ID frame
     retire_seq: u64,
@@ -95,7 +96,8 @@ impl CidState {
 
     /// Update local CID state when previously issued CID is retired
     ///
-    /// Return whether a new CID needs to be pushed that notifies remote peer to respond `RETIRE_CONNECTION_ID`
+    /// Return whether a new CID needs to be pushed that notifies remote peer to respond
+    /// `RETIRE_CONNECTION_ID`
     pub(crate) fn on_cid_timeout(&mut self) -> bool {
         // Whether the peer hasn't retired all the CIDs we asked it to yet
         let unretired_ids_found =
@@ -129,8 +131,9 @@ impl CidState {
         // NEW_CONNECTION_ID frame also requires the retirement of any excess,
         // by including a sufficiently large value in the Retire Prior To field.
         //
-        // If yes (return true), a new CID must be pushed with updated `retire_prior_to` field to remote peer.
-        // If no (return false), it means CIDs that reach the end of lifetime have been retired already. Do not push a new CID in order to avoid violating above RFC.
+        // If yes (return true), a new CID must be pushed with updated `retire_prior_to` field to
+        // remote peer. If no (return false), it means CIDs that reach the end of lifetime
+        // have been retired already. Do not push a new CID in order to avoid violating above RFC.
         (current_retire_prior_to..self.retire_seq).any(|seq| self.active_seq.contains(&seq))
     }
 
@@ -180,7 +183,8 @@ impl CidState {
         // Peer B first send a NEW_CONNECTION_ID with cid 3 and retire_prior_to set to 1.
         // Peer A processes this NEW_CONNECTION_ID frame; update remote cid to 1,2,3
         // and meanwhile send a RETIRE_CONNECTION_ID to retire cid 0 to peer B.
-        // If peer B doesn't check the cid limit here and send a new cid again, peer A will then face CONNECTION_ID_LIMIT_ERROR
+        // If peer B doesn't check the cid limit here and send a new cid again, peer A will then
+        // face CONNECTION_ID_LIMIT_ERROR
         Ok(limit > self.active_seq.len() as u64)
     }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -5397,9 +5397,10 @@ impl Connection {
                     }
                 }
                 Frame::PathsBlocked(frame::PathsBlocked(max_path_id)) => {
-                    // Receipt of a value of Maximum Path Identifier or Path Identifier that is
-                    // higher than the local maximum value MUST be treated as a
-                    // connection error of type PROTOCOL_VIOLATION. Ref <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
+                    // Receipt of a value of Maximum Path Identifier or Path Identifier that
+                    // is higher than the local maximum value MUST be treated as a
+                    // connection error of type PROTOCOL_VIOLATION. Ref
+                    // <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
                     if self.is_multipath_negotiated() {
                         if max_path_id > self.local_max_path_id {
                             return Err(TransportError::PROTOCOL_VIOLATION(
@@ -5417,9 +5418,10 @@ impl Connection {
                     // always issue all CIDs we're allowed to issue, so either this is an
                     // impatient peer or a bug on our side.
 
-                    // Receipt of a value of Maximum Path Identifier or Path Identifier that is
-                    // higher than the local maximum value MUST be treated as a
-                    // connection error of type PROTOCOL_VIOLATION. Ref <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
+                    // Receipt of a value of Maximum Path Identifier or Path Identifier that
+                    // is higher than the local maximum value MUST be treated as a
+                    // connection error of type PROTOCOL_VIOLATION. Ref
+                    // <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
                     if self.is_multipath_negotiated() {
                         if path_id > self.local_max_path_id {
                             return Err(TransportError::PROTOCOL_VIOLATION(
@@ -7725,15 +7727,17 @@ impl SentFrames {
     }
 }
 
-/// Compute the negotiated idle timeout based on local and remote max_idle_timeout transport
-/// parameters.
+/// Computes the negotiated idle timeout based on the transport parameters.
 ///
-/// According to the definition of max_idle_timeout, a value of `0` means the timeout is disabled; see <https://www.rfc-editor.org/rfc/rfc9000#section-18.2-4.4.1.>
+/// According to the definition of max_idle_timeout, a value of `0` means the timeout is
+/// disabled; see <https://www.rfc-editor.org/rfc/rfc9000#section-18.2-4.4.1.>
 ///
-/// According to the negotiation procedure, either the minimum of the timeouts or one specified is used as the negotiated value; see <https://www.rfc-editor.org/rfc/rfc9000#section-10.1-2.>
+/// According to the negotiation procedure, either the minimum of the timeouts or one
+/// specified is used as the negotiated value; see
+/// <https://www.rfc-editor.org/rfc/rfc9000#section-10.1-2.>
 ///
-/// Returns the negotiated idle timeout as a `Duration`, or `None` when both endpoints have opted
-/// out of idle timeout.
+/// Returns the negotiated idle timeout as a `Duration`, or `None` when both endpoints have
+/// opted out of idle timeout.
 fn negotiate_max_idle_timeout(x: Option<VarInt>, y: Option<VarInt>) -> Option<Duration> {
     match (x, y) {
         (Some(VarInt(0)) | None, Some(VarInt(0)) | None) => None,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -132,8 +132,7 @@ use state::StateType;
 ///   refer to this as "performing I/O" below, however as per the design of this library none of the
 ///   functions actually perform system-level I/O. For example, [`read`](RecvStream::read) and
 ///   [`write`](SendStream::write), but also things like [`reset`](SendStream::reset).
-/// - D. Polling functions for outgoing events or actions for the caller to
-///   take, named `poll_*`.
+/// - D. Polling functions for outgoing events or actions for the caller to take, named `poll_*`.
 ///
 /// The simplest way to use this API correctly is to call (B) and (C) whenever
 /// appropriate, then after each of those calls, as soon as feasible call all
@@ -215,18 +214,15 @@ pub struct Connection {
 
     //
     // Queued non-retransmittable 1-RTT data
-    //
     /// If the CONNECTION_CLOSE frame needs to be sent
     connection_close_pending: bool,
 
     //
     // ACK frequency
-    //
     ack_frequency: AckFrequencyState,
 
     //
     // Congestion Control
-    //
     /// Whether the most recently received packet had an ECN codepoint set
     receiving_ecn: bool,
     /// Number of packets authenticated
@@ -234,7 +230,6 @@ pub struct Connection {
 
     //
     // ObservedAddr
-    //
     /// Sequence number for the next observed address frame sent to the peer.
     next_observed_addr_seq_no: VarInt,
 
@@ -267,7 +262,6 @@ pub struct Connection {
 
     //
     // Multipath
-    //
     /// Maximum number of concurrent paths
     ///
     /// Initially set from the [`TransportConfig::max_concurrent_multipath_paths`]. Even
@@ -686,7 +680,8 @@ impl Connection {
         pending_space.new_cids.retain(|cid| cid.path_id != path_id);
         pending_space.path_status.retain(|&id| id != path_id);
 
-        // Cleanup retransmits across ALL paths (CIDs for path_id may have been transmitted on other paths)
+        // Cleanup retransmits across ALL paths (CIDs for path_id may have been transmitted on other
+        // paths)
         for space in self.spaces[SpaceId::Data].iter_paths_mut() {
             for sent_packet in space.sent_packets.values_mut() {
                 if let Some(retransmits) = sent_packet.retransmits.get_mut() {
@@ -923,7 +918,8 @@ impl Connection {
         })
         // TODO(@divma): we might want to ensure the path has been recently active to consider the
         // address validated
-        // matheus23: Perhaps looking at !self.abandoned_paths.contains(path_id) is enough, given keep-alives?
+        // matheus23: Perhaps looking at !self.abandoned_paths.contains(path_id) is enough, given
+        // keep-alives?
     }
 
     /// Creates the [`PathData`] for a new [`PathId`].
@@ -1435,9 +1431,9 @@ impl Connection {
         // - If not coalescing, complete the datagram:
         //   - Finish packet with padding.
         //   - Set the transmit segment size if this is the first datagram.
-        // - Loop: next iteration will exit the loop if nothing more to send in this
-        //   space. The TransmitBuf will contain a started datagram with space if
-        //   coalescing, or completely filled datagram if not coalescing.
+        // - Loop: next iteration will exit the loop if nothing more to send in this space. The
+        //   TransmitBuf will contain a started datagram with space if coalescing, or completely
+        //   filled datagram if not coalescing.
         loop {
             // Determine if anything can be sent in this packet number space.
             let max_packet_size = if transmit.datagram_remaining_mut() > 0 {
@@ -2426,7 +2422,8 @@ impl Connection {
                             self.endpoint_events.push_back(EndpointEventInner::Draining);
                         }
                         // move_to_drained checks that we weren't in drained before.
-                        // Adding events to endpoint_events is only legal if `Drained` was never queued before.
+                        // Adding events to endpoint_events is only legal if `Drained` was never
+                        // queued before.
                         self.endpoint_events.push_back(EndpointEventInner::Drained);
                     }
                     ConnTimer::Idle => {
@@ -2850,9 +2847,10 @@ impl Connection {
 
     /// Current number of remotely initiated streams that may be concurrently open
     ///
-    /// If the target for this limit is reduced using [`set_max_concurrent_streams`](Self::set_max_concurrent_streams),
-    /// it will not change immediately, even if fewer streams are open. Instead, it will
-    /// decrement by one for each time a remotely initiated stream of matching directionality is closed.
+    /// If the target for this limit is reduced using
+    /// [`set_max_concurrent_streams`](Self::set_max_concurrent_streams), it will not change
+    /// immediately, even if fewer streams are open. Instead, it will decrement by one for each
+    /// time a remotely initiated stream of matching directionality is closed.
     pub fn max_concurrent_streams(&self, dir: Dir) -> u64 {
         self.streams.max_concurrent(dir)
     }
@@ -2994,7 +2992,8 @@ impl Connection {
                         .on_mtu_update(path_data.mtud.current_mtu());
                 }
 
-                // Notify ack frequency that a packet was acked, because it might contain an ACK_FREQUENCY frame
+                // Notify ack frequency that a packet was acked, because it might contain an
+                // ACK_FREQUENCY frame
                 self.ack_frequency.on_acked(path, packet);
 
                 self.on_packet_acked(now, path, packet, info);
@@ -3051,10 +3050,10 @@ impl Connection {
         // find a way to make this work without two lookups
         if self.path_data(path).sending_ecn {
             if let Some(ecn) = ack.ecn {
-                // We only examine ECN counters from ACKs that we are certain we received in transmit
-                // order, allowing us to compute an increase in ECN counts to compare against the number
-                // of newly acked packets that remains well-defined in the presence of arbitrary packet
-                // reordering.
+                // We only examine ECN counters from ACKs that we are certain we received in
+                // transmit order, allowing us to compute an increase in ECN counts
+                // to compare against the number of newly acked packets that remains
+                // well-defined in the presence of arbitrary packet reordering.
                 if let Some(largest_sent_pn) = new_largest_pn {
                     let sent = self.spaces[space]
                         .for_path(path)
@@ -3070,7 +3069,8 @@ impl Connection {
                     );
                 }
             } else {
-                // We always start out sending ECN, so any ack that doesn't acknowledge it disables it.
+                // We always start out sending ECN, so any ack that doesn't acknowledge it disables
+                // it.
                 debug!("ECN not acknowledged by peer");
                 self.path_data_mut(path).sending_ecn = false;
             }
@@ -3257,9 +3257,9 @@ impl Connection {
     /// There are two cases in which we detects lost packets:
     ///
     /// - We received an ACK packet.
-    /// - The [`PathTimer::LossDetection`] timer expired. So there is an un-acknowledged packet
-    ///   that was followed by an acknowledged packet. The loss timer for this
-    ///   un-acknowledged packet expired and we need to detect that packet as lost.
+    /// - The [`PathTimer::LossDetection`] timer expired. So there is an un-acknowledged packet that
+    ///   was followed by an acknowledged packet. The loss timer for this un-acknowledged packet
+    ///   expired and we need to detect that packet as lost.
     ///
     /// Packets are lost if they are both (See RFC9002 §6.1):
     ///
@@ -3809,7 +3809,8 @@ impl Connection {
                 if self.crypto_state.has_keys(EncryptionLevel::Initial)
                     && space_id == SpaceKind::Handshake
                 {
-                    // A server stops sending and processing Initial packets when it receives its first Handshake packet.
+                    // A server stops sending and processing Initial packets when it receives its
+                    // first Handshake packet.
                     self.discard_space(now, SpaceKind::Initial);
                 }
                 if self.crypto_state.has_keys(EncryptionLevel::ZeroRtt) && is_1rtt {
@@ -4575,13 +4576,11 @@ impl Connection {
                             || !is_valid_retry
                 {
                     trace!("discarding invalid Retry");
-                    // - After the client has received and processed an Initial or Retry
-                    //   packet from the server, it MUST discard any subsequent Retry
-                    //   packets that it receives.
-                    // - A client MUST discard a Retry packet with a zero-length Retry Token
-                    //   field.
-                    // - Clients MUST discard Retry packets that have a Retry Integrity Tag
-                    //   that cannot be validated
+                    // - After the client has received and processed an Initial or Retry packet from
+                    //   the server, it MUST discard any subsequent Retry packets that it receives.
+                    // - A client MUST discard a Retry packet with a zero-length Retry Token field.
+                    // - Clients MUST discard Retry packets that have a Retry Integrity Tag that
+                    //   cannot be validated
                     return Ok(());
                 }
 
@@ -5398,9 +5397,9 @@ impl Connection {
                     }
                 }
                 Frame::PathsBlocked(frame::PathsBlocked(max_path_id)) => {
-                    // Receipt of a value of Maximum Path Identifier or Path Identifier that is higher than the local maximum value MUST
-                    // be treated as a connection error of type PROTOCOL_VIOLATION.
-                    // Ref <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
+                    // Receipt of a value of Maximum Path Identifier or Path Identifier that is
+                    // higher than the local maximum value MUST be treated as a
+                    // connection error of type PROTOCOL_VIOLATION. Ref <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
                     if self.is_multipath_negotiated() {
                         if max_path_id > self.local_max_path_id {
                             return Err(TransportError::PROTOCOL_VIOLATION(
@@ -5418,9 +5417,9 @@ impl Connection {
                     // always issue all CIDs we're allowed to issue, so either this is an
                     // impatient peer or a bug on our side.
 
-                    // Receipt of a value of Maximum Path Identifier or Path Identifier that is higher than the local maximum value MUST
-                    // be treated as a connection error of type PROTOCOL_VIOLATION.
-                    // Ref <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
+                    // Receipt of a value of Maximum Path Identifier or Path Identifier that is
+                    // higher than the local maximum value MUST be treated as a
+                    // connection error of type PROTOCOL_VIOLATION. Ref <https://www.ietf.org/archive/id/draft-ietf-quic-multipath-14.html#name-paths_blocked-and-path_cids>
                     if self.is_multipath_negotiated() {
                         if path_id > self.local_max_path_id {
                             return Err(TransportError::PROTOCOL_VIOLATION(
@@ -5430,8 +5429,9 @@ impl Connection {
                         if self
                             .local_cid_state
                             .get(&path_id)
-                            // The PATH_CIDS_BLOCKED frame may arrive after we've discarded the path state.
-                            // In that case, we can't check for the protocol violation.
+                            // The PATH_CIDS_BLOCKED frame may arrive after we've discarded the path
+                            // state. In that case, we can't check for
+                            // the protocol violation.
                             .is_some_and(|cid_state| next_seq.0 > cid_state.active_seq().1 + 1)
                         {
                             return Err(TransportError::PROTOCOL_VIOLATION(
@@ -7096,8 +7096,8 @@ impl Connection {
 
     /// Returns whether this connection has a socket that supports IPv6.
     ///
-    /// TODO(matheus23): This is related to noq endpoint state's `ipv6` bool. We should move that info
-    /// here instead of trying to hack around not knowing it exactly.
+    /// TODO(matheus23): This is related to noq endpoint state's `ipv6` bool. We should move that
+    /// info here instead of trying to hack around not knowing it exactly.
     pub(crate) fn is_ipv6(&self) -> bool {
         self.paths
             .values()
@@ -7725,13 +7725,15 @@ impl SentFrames {
     }
 }
 
-/// Compute the negotiated idle timeout based on local and remote max_idle_timeout transport parameters.
+/// Compute the negotiated idle timeout based on local and remote max_idle_timeout transport
+/// parameters.
 ///
 /// According to the definition of max_idle_timeout, a value of `0` means the timeout is disabled; see <https://www.rfc-editor.org/rfc/rfc9000#section-18.2-4.4.1.>
 ///
 /// According to the negotiation procedure, either the minimum of the timeouts or one specified is used as the negotiated value; see <https://www.rfc-editor.org/rfc/rfc9000#section-10.1-2.>
 ///
-/// Returns the negotiated idle timeout as a `Duration`, or `None` when both endpoints have opted out of idle timeout.
+/// Returns the negotiated idle timeout as a `Duration`, or `None` when both endpoints have opted
+/// out of idle timeout.
 fn negotiate_max_idle_timeout(x: Option<VarInt>, y: Option<VarInt>) -> Option<Duration> {
     match (x, y) {
         (Some(VarInt(0)) | None, Some(VarInt(0)) | None) => None,

--- a/noq-proto/src/connection/mtud.rs
+++ b/noq-proto/src/connection/mtud.rs
@@ -136,9 +136,9 @@ impl MtuDiscovery {
 
     /// Notifies the [`MtuDiscovery`] that a non-probe packet was lost
     ///
-    /// When done notifying of lost packets, [`MtuDiscovery::black_hole_detected`] must be called, to
-    /// ensure the last loss burst is properly processed and to trigger black hole recovery logic if
-    /// necessary.
+    /// When done notifying of lost packets, [`MtuDiscovery::black_hole_detected`] must be called,
+    /// to ensure the last loss burst is properly processed and to trigger black hole recovery
+    /// logic if necessary.
     pub(crate) fn on_non_probe_lost(&mut self, pn: u64, len: u16) {
         self.black_hole_detector.on_non_probe_lost(pn, len);
     }
@@ -185,8 +185,8 @@ impl EnabledMtuDiscovery {
     ///
     /// - There is no current in-flight probe.
     /// - A search for a new MTU is in progress.
-    /// - The MTU discovery was completed but the [`MtuDiscoveryConfig::interval`] expired,
-    ///   this re-starts a n MTU search.
+    /// - The MTU discovery was completed but the [`MtuDiscoveryConfig::interval`] expired, this
+    ///   re-starts a n MTU search.
     fn poll_transmit(&mut self, now: Instant, current_mtu: u16, next_pn: u64) -> Option<u16> {
         if let Phase::Initial = &self.phase {
             // Start the first search
@@ -376,8 +376,8 @@ struct BlackHoleDetector {
     /// Packet number of the biggest packet larger than `min_mtu` which we've received
     /// acknowledgment of more recently than any suspicious loss burst, if any
     largest_post_loss_packet: u64,
-    /// The maximum of `min_mtu` and the size of `largest_post_loss_packet`, or exactly `min_mtu` if
-    /// no larger packets have been received since the most recent loss burst.
+    /// The maximum of `min_mtu` and the size of `largest_post_loss_packet`, or exactly `min_mtu`
+    /// if no larger packets have been received since the most recent loss burst.
     acked_mtu: u16,
     /// The UDP payload size guaranteed to be supported by the network
     min_mtu: u16,

--- a/noq-proto/src/connection/packet_crypto.rs
+++ b/noq-proto/src/connection/packet_crypto.rs
@@ -42,8 +42,8 @@ pub(super) struct PrevCrypto {
     /// The keys used for the previous key phase, temporarily retained to decrypt packets sent by
     /// the peer prior to its own key update.
     pub(super) crypto: KeyPair<Box<dyn PacketKey>>,
-    /// The incoming packet that ends the interval for which these keys are applicable, and the time
-    /// of its receipt.
+    /// The incoming packet that ends the interval for which these keys are applicable, and the
+    /// time of its receipt.
     ///
     /// Incoming packets should be decrypted using these keys iff this is `None` or their packet
     /// number is lower. `None` indicates that we have not yet received a packet using newer keys,
@@ -199,7 +199,8 @@ impl CryptoState {
         }
         // Packets that do not belong to known path ids are valid as long as they can be decrypted.
         // If we didn't have a path, that's for the purposes of this function equivalent to not
-        // having received packets on that path yet. So both of these cases are represented by `None`.
+        // having received packets on that path yet. So both of these cases are represented by
+        // `None`.
         let rx_packet_number = spaces[space]
             .path_space(path_id)
             .and_then(|s| s.largest_received_packet_number);
@@ -266,9 +267,9 @@ impl CryptoState {
 
         if crypto_update {
             // Validate incoming key update
-            // If `rx_packet` is `None`, then either the path is entirely new, or we haven't received
-            // any packets on this path yet. In that case, having the first packet be a crypto update
-            // is fine.
+            // If `rx_packet` is `None`, then either the path is entirely new, or we haven't
+            // received any packets on this path yet. In that case, having the first
+            // packet be a crypto update is fine.
             let invalid_packet_number =
                 rx_packet_number.is_some_and(|rx_packet| packet_number <= rx_packet);
             if invalid_packet_number || self.prev_crypto.as_ref().is_some_and(|x| x.update_unacked)

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -140,13 +140,13 @@ pub(super) struct SentChallengeInfo {
 /// to a different 4-tuple, in a similar manner as an RFC9000 connection can use "path
 /// migration" to move to a different 4-tuple. There are thus two states we keep for paths:
 ///
-/// - [`PacketNumberSpace`]: The state for a single packet number space, i.e. [`PathId`],
-///   which remains in place across path migrations to different 4-tuples.
+/// - [`PacketNumberSpace`]: The state for a single packet number space, i.e. [`PathId`], which
+///   remains in place across path migrations to different 4-tuples.
 ///
 ///   This is stored in [`PacketSpace::number_spaces`] indexed on [`PathId`].
 ///
-/// - [`PathData`]: The state we keep for each unique 4-tuple within a space. Of note is
-///   that a single [`PathData`] can never belong to a different [`PacketNumberSpace`].
+/// - [`PathData`]: The state we keep for each unique 4-tuple within a space. Of note is that a
+///   single [`PathData`] can never belong to a different [`PacketNumberSpace`].
 ///
 ///   This is stored in [`Connection::paths`] indexed by the current [`PathId`] for which
 ///   space it exists. Either as the primary 4-tuple or as the previous 4-tuple just after a
@@ -172,14 +172,15 @@ pub(super) struct PathData {
     /// no outgoing application data.
     ///
     /// The RFC writes:
-    /// > When bytes in flight is smaller than the congestion window and sending is not pacing limited,
-    /// > the congestion window is underutilized. This can happen due to insufficient application data
-    /// > or flow control limits. When this occurs, the congestion window SHOULD NOT be increased in
-    /// > either slow start or congestion avoidance.
+    /// > When bytes in flight is smaller than the congestion window and sending is not pacing
+    /// > limited, the congestion window is underutilized. This can happen due to insufficient
+    /// > application data or flow control limits. When this occurs, the congestion window SHOULD
+    /// > NOT be increased in either slow start or congestion avoidance.
     ///
     /// (RFC9002, section 7.8)
     ///
-    /// I.e. when app_limited is true, the congestion controller doesn't increase the congestion window.
+    /// I.e. when app_limited is true, the congestion controller doesn't increase the congestion
+    /// window.
     pub(super) app_limited: bool,
 
     /// Whether to trigger sending another PATH_CHALLENGE in the next poll_transmit.
@@ -220,7 +221,8 @@ pub(super) struct PathData {
     pub(super) in_flight: InFlight,
     /// Queue of data that must be sent over this specific [`PathData::generation`] path.
     pub(super) pending: PathRetransmits,
-    /// Observed address frame with the largest sequence number received from the peer on this path.
+    /// Observed address frame with the largest sequence number received from the peer on this
+    /// path.
     pub(super) last_observed_addr_report: Option<ObservedAddr>,
     /// The QUIC-MULTIPATH path status
     pub(super) status: PathStatusState,
@@ -242,7 +244,6 @@ pub(super) struct PathData {
 
     //
     // Per-path idle & keep alive
-    //
     /// Idle timeout for the path
     ///
     /// If expired, the path will be abandoned.  This is different from the connection-wide
@@ -944,8 +945,8 @@ pub(super) struct InFlight {
     /// Number of packets in flight containing frames other than ACK and PADDING
     ///
     /// This can be 0 even when bytes is not 0 because PADDING frames cause a packet to be
-    /// considered "in flight" by congestion control. However, if this is nonzero, bytes will always
-    /// also be nonzero.
+    /// considered "in flight" by congestion control. However, if this is nonzero, bytes will
+    /// always also be nonzero.
     pub(super) ack_eliciting: u64,
 }
 
@@ -1135,7 +1136,8 @@ pub enum SetPathStatusError {
     /// Error indicating that a path has not been opened or has already been abandoned
     #[error("closed path")]
     ClosedPath,
-    /// Error indicating that this operation requires multipath to be negotiated whereas it hasn't been
+    /// Error indicating that this operation requires multipath to be negotiated whereas it hasn't
+    /// been
     #[error("multipath not negotiated")]
     MultipathNotNegotiated,
 }

--- a/noq-proto/src/connection/qlog.rs
+++ b/noq-proto/src/connection/qlog.rs
@@ -298,8 +298,8 @@ impl QlogSink {
 
     /// Emits a timer event.
     ///
-    /// This function is not public: Instead, create a [`QlogSinkWithTime`] via [`Self::with_time`] and use
-    /// its `emit_timer_` methods.
+    /// This function is not public: Instead, create a [`QlogSinkWithTime`] via [`Self::with_time`]
+    /// and use its `emit_timer_` methods.
     #[cfg(feature = "qlog")]
     fn emit_timer(&self, timer: Timer, op: TimerOp, now: Instant) {
         let Some(stream) = self.stream.as_ref() else {
@@ -459,8 +459,9 @@ impl QlogSentPacket {
 
     /// Adds a frame by pushing a [`QuicFrame`].
     ///
-    /// This function is only available if the `qlog` feature is enabled, because constructing a [`QuicFrame`] may involve
-    /// calculations which shouldn't be performed if the `qlog` feature is disabled.
+    /// This function is only available if the `qlog` feature is enabled, because constructing a
+    /// [`QuicFrame`] may involve calculations which shouldn't be performed if the `qlog`
+    /// feature is disabled.
     #[cfg(feature = "qlog")]
     fn frame_raw(&mut self, frame: QuicFrame) {
         self.inner.frames.get_or_insert_default().push(frame);

--- a/noq-proto/src/connection/send_buffer.rs
+++ b/noq-proto/src/connection/send_buffer.rs
@@ -242,9 +242,9 @@ impl SendBuffer {
     ///
     /// The method returns a tuple:
     /// - The first return value indicates the range of data to send
-    /// - The second return value indicates whether the length needs to be encoded
-    ///   in the STREAM frames metadata (`true`), or whether it can be omitted
-    ///   since the selected range will fill the whole packet.
+    /// - The second return value indicates whether the length needs to be encoded in the STREAM
+    ///   frames metadata (`true`), or whether it can be omitted since the selected range will fill
+    ///   the whole packet.
     pub(super) fn poll_transmit(&mut self, mut max_len: usize) -> (Range<u64>, bool) {
         debug_assert!(max_len >= 8 + 8);
         let mut encode_length = false;

--- a/noq-proto/src/connection/spaces.rs
+++ b/noq-proto/src/connection/spaces.rs
@@ -283,7 +283,6 @@ pub(super) struct PacketNumberSpace {
 
     //
     // Loss Detection
-    //
     /// The time the most recently sent retransmittable packet was sent.
     pub(super) time_of_last_ack_eliciting_packet: Option<Instant>,
     /// Earliest time when we might declare a packet lost.
@@ -509,13 +508,14 @@ pub(super) enum OpenStatus {
 /// Represents one or more packets subject to retransmission
 #[derive(Debug, Clone)]
 pub(super) struct SentPacket {
-    /// [`PathData::generation`](super::PathData::generation) of the path on which this packet was sent
+    /// [`PathData::generation`](super::PathData::generation) of the path on which this packet was
+    /// sent
     pub(super) path_generation: u64,
     /// The time the packet was sent.
     pub(super) time_sent: Instant,
-    /// The number of bytes sent in the packet, not including UDP or IP overhead, but including QUIC
-    /// framing overhead. Zero if this packet is not counted towards congestion control, i.e. not an
-    /// "in flight" packet.
+    /// The number of bytes sent in the packet, not including UDP or IP overhead, but including
+    /// QUIC framing overhead. Zero if this packet is not counted towards congestion control,
+    /// i.e. not an "in flight" packet.
     pub(super) size: u16,
     /// Whether an acknowledgement is expected directly in response to this packet.
     pub(super) ack_eliciting: bool,
@@ -564,8 +564,8 @@ pub struct Retransmits {
     ///
     /// Stores the remote_max_path_id at the time this was generated.
     /// This frame is entirely informational, so when it's retransmitted, the remote_max_path_id is
-    /// intentionally not updated to preserve the fact that this was the state of the client at some
-    /// point.
+    /// intentionally not updated to preserve the fact that this was the state of the client at
+    /// some point.
     pub(super) paths_blocked: Option<PathId>,
     /// For each enqueued NEW_TOKEN frame, a copy of the path's remote address
     ///
@@ -586,12 +586,13 @@ pub struct Retransmits {
     pub(super) new_tokens: Vec<FourTuple>,
     /// Paths which need to be abandoned
     pub(super) path_abandon: BTreeMap<PathId, TransportErrorCode>,
-    /// If a [`frame::PathStatusAvailable`] and [`frame::PathStatusBackup`] need to be sent for a path
+    /// If a [`frame::PathStatusAvailable`] and [`frame::PathStatusBackup`] need to be sent for a
+    /// path
     pub(super) path_status: BTreeSet<PathId>,
     /// Whether a PATH_CIDS_BLOCKED frame needs to be sent for a path.
     ///
-    /// Stores the next_seq number for the blocked path. This number can be "outdated" at the time of
-    /// sending when this is a retransmission. This is intentional, as this frame is purely
+    /// Stores the next_seq number for the blocked path. This number can be "outdated" at the time
+    /// of sending when this is a retransmission. This is intentional, as this frame is purely
     /// informational, and this would preserve this information.
     pub(super) path_cids_blocked: BTreeMap<PathId, VarInt>,
 
@@ -1102,7 +1103,8 @@ pub(super) struct PendingAcks {
     ///
     /// * `0`: no special action is taken
     /// * `1`: an ACK is immediately sent if it is out-of-order according to RFC 9000
-    /// * `>1`: an ACK is immediately sent if it is out-of-order according to the ACK frequency draft
+    /// * `>1`: an ACK is immediately sent if it is out-of-order according to the ACK frequency
+    ///   draft
     reordering_threshold: u64,
     /// The earliest ack-eliciting packet since the last ACK was sent, used to calculate the moment
     /// upon which `max_ack_delay` elapses

--- a/noq-proto/src/connection/state.rs
+++ b/noq-proto/src/connection/state.rs
@@ -383,7 +383,8 @@ enum InnerState {
     Established,
     /// See [`StateType::Closed`].
     Closed {
-        /// The reason the remote closed the connection, or the reason we are sending to the remote.
+        /// The reason the remote closed the connection, or the reason we are sending to the
+        /// remote.
         remote_reason: CloseReason,
         /// Set to true if we closed the connection locally.
         is_local: bool,

--- a/noq-proto/src/connection/streams/mod.rs
+++ b/noq-proto/src/connection/streams/mod.rs
@@ -90,11 +90,12 @@ impl<'a> Streams<'a> {
 
     /// The number of remotely initiated open streams of a certain directionality.
     ///
-    /// Includes remotely initiated streams, which have not been accepted via [`accept`](Self::accept).
-    /// These streams count against the respective concurrency limit reported by
+    /// Includes remotely initiated streams, which have not been accepted via
+    /// [`accept`](Self::accept). These streams count against the respective concurrency limit
+    /// reported by
     /// [`Connection::max_concurrent_streams`](super::Connection::max_concurrent_streams).
     pub fn remote_open_streams(&self, dir: Dir) -> u64 {
-        // total opened - total closed = total opened - ( total permitted - total permitted unclosed )
+        // total opened - total closed = total opened - (total permitted - total permitted unclosed)
         self.state.next_remote[dir as usize]
             - (self.state.max_remote[dir as usize]
                 - self.state.allocated_remote_count[dir as usize])
@@ -391,11 +392,13 @@ impl<'a> SendStream<'a> {
 /// A queue of streams with pending outgoing data, sorted by priority
 struct PendingStreamsQueue {
     streams: BinaryHeap<PendingStream>,
-    /// The next stream to write out. This is `Some` when `TransportConfig::send_fairness(false)` and writing a stream is
-    /// interrupted while the stream still has some pending data. See `reinsert_pending()`.
+    /// The next stream to write out. This is `Some` when `TransportConfig::send_fairness(false)`
+    /// and writing a stream is interrupted while the stream still has some pending data. See
+    /// `reinsert_pending()`.
     next: Option<PendingStream>,
-    /// A monotonically decreasing counter, used to implement round-robin scheduling for streams of the same priority.
-    /// Underflowing is not a practical concern, as it is initialized to u64::MAX and only decremented by 1 in `push_pending`
+    /// A monotonically decreasing counter, used to implement round-robin scheduling for streams of
+    /// the same priority. Underflowing is not a practical concern, as it is initialized to
+    /// u64::MAX and only decremented by 1 in `push_pending`
     recency: u64,
 }
 
@@ -419,16 +422,18 @@ impl PendingStreamsQueue {
         });
     }
 
-    /// Push a pending stream ID with the given priority, queued after any already-queued streams for the priority
+    /// Push a pending stream ID with the given priority, queued after any already-queued streams
+    /// for the priority
     fn push_pending(&mut self, id: StreamId, priority: i32) {
         // Note that in the case where fairness is disabled, if we have a reinserted stream we don't
         // bump it even if priority > next.priority. In order to minimize fragmentation we
         // always try to complete a stream once part of it has been written.
 
-        // As the recency counter is monotonically decreasing, we know that using its value to sort this stream will queue it
-        // after all other queued streams of the same priority.
-        // This is enough to implement round-robin scheduling for streams that are still pending even after being handled,
-        // as in that case they are removed from the `BinaryHeap`, handled, and then immediately reinserted.
+        // As the recency counter is monotonically decreasing, we know that using its value to sort
+        // this stream will queue it after all other queued streams of the same priority.
+        // This is enough to implement round-robin scheduling for streams that are still pending
+        // even after being handled, as in that case they are removed from the `BinaryHeap`,
+        // handled, and then immediately reinserted.
         self.recency -= 1;
         self.streams.push(PendingStream {
             priority,
@@ -460,18 +465,20 @@ impl PendingStreamsQueue {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct PendingStream {
     /// The priority of the stream
-    // Note that this field should be kept above the `recency` field, in order for the `Ord` derive to be correct
-    // (See https://doc.rust-lang.org/stable/std/cmp/trait.Ord.html#derivable)
+    // Note that this field should be kept above the `recency` field, in order for the `Ord` derive
+    // to be correct (See https://doc.rust-lang.org/stable/std/cmp/trait.Ord.html#derivable)
     priority: i32,
-    /// A tie-breaker for streams of the same priority, used to improve fairness by implementing round-robin scheduling:
-    /// Larger values are prioritized, so it is initialised to `u64::MAX`, and when a stream writes data, we know
-    /// that it currently has the highest recency value, so it is deprioritized by setting its recency to 1 less than the
-    /// previous lowest recency value, such that all other streams of this priority will get processed once before we get back
-    /// round to this one
+    /// A tie-breaker for streams of the same priority, used to improve fairness by implementing
+    /// round-robin scheduling: Larger values are prioritized, so it is initialised to
+    /// `u64::MAX`, and when a stream writes data, we know that it currently has the highest
+    /// recency value, so it is deprioritized by setting its recency to 1 less than the
+    /// previous lowest recency value, such that all other streams of this priority will get
+    /// processed once before we get back round to this one
     recency: u64,
     /// The ID of the stream
-    // The way this type is used ensures that every instance has a unique `recency` value, so this field should be kept below
-    // the `priority` and `recency` fields, so that it does not interfere with the behaviour of the `Ord` derive
+    // The way this type is used ensures that every instance has a unique `recency` value, so this
+    // field should be kept below the `priority` and `recency` fields, so that it does not
+    // interfere with the behaviour of the `Ord` derive
     id: StreamId,
 }
 

--- a/noq-proto/src/connection/streams/recv.rs
+++ b/noq-proto/src/connection/streams/recv.rs
@@ -267,7 +267,8 @@ impl<'a> Chunks<'a> {
         let mut recv =
             match get_or_insert_recv(streams.stream_receive_window)(entry.get_mut()).stopped {
                 true => return Err(ReadableError::ClosedStream),
-                false => entry.remove().unwrap().into_inner(), // this can't fail due to the previous get_or_insert_with
+                false => entry.remove().unwrap().into_inner(), /* this can't fail due to the
+                                                                * previous get_or_insert_with */
             };
 
         recv.assembler.ensure_ordering(ordered)?;
@@ -341,8 +342,9 @@ impl<'a> Chunks<'a> {
     ///
     /// If [`ShouldTransmit::should_transmit()`] returns `true`,
     /// a packet needs to be sent to the peer informing them that the stream is unblocked.
-    /// This means that you should call [`Connection::poll_transmit()`][crate::Connection::poll_transmit]
-    /// and send the returned packet as soon as is reasonable, to unblock the remote peer.
+    /// This means that you should call
+    /// [`Connection::poll_transmit()`][crate::Connection::poll_transmit] and send the returned
+    /// packet as soon as is reasonable, to unblock the remote peer.
     pub fn finalize(mut self) -> ShouldTransmit {
         self.finalize_inner()
     }

--- a/noq-proto/src/connection/streams/send.rs
+++ b/noq-proto/src/connection/streams/send.rs
@@ -13,8 +13,9 @@ pub(super) struct Send {
     pub(super) state: SendState,
     pub(super) pending: SendBuffer,
     pub(super) priority: i32,
-    /// Whether a frame containing a FIN bit must be transmitted, even if we don't have any new
-    /// data
+    /// Whether a frame containing a FIN bit must be transmitted.
+    ///
+    /// Even if we don't have any new data.
     pub(super) fin_pending: bool,
     /// Whether this stream is in the `connection_blocked` list of `Streams`
     pub(super) connection_blocked: bool,

--- a/noq-proto/src/connection/streams/send.rs
+++ b/noq-proto/src/connection/streams/send.rs
@@ -13,7 +13,8 @@ pub(super) struct Send {
     pub(super) state: SendState,
     pub(super) pending: SendBuffer,
     pub(super) priority: i32,
-    /// Whether a frame containing a FIN bit must be transmitted, even if we don't have any new data
+    /// Whether a frame containing a FIN bit must be transmitted, even if we don't have any new
+    /// data
     pub(super) fin_pending: bool,
     /// Whether this stream is in the `connection_blocked` list of `Streams`
     pub(super) connection_blocked: bool,
@@ -244,12 +245,11 @@ pub(super) trait BytesSource<'a> {
     /// Calling it will yield `Bytes` elements up to the configured `limit`.
     ///
     /// The method returns a tuple:
-    /// - The first item is the yielded `Bytes` element. The element will be
-    ///   empty if the limit is zero or no more data is available.
-    /// - The second item returns how many complete chunks inside the source had
-    ///   had been consumed. This can be less than 1, if a chunk inside the
-    ///   source had been truncated in order to adhere to the limit. It can also
-    ///   be more than 1, if zero-length chunks had been skipped.
+    /// - The first item is the yielded `Bytes` element. The element will be empty if the limit is
+    ///   zero or no more data is available.
+    /// - The second item returns how many complete chunks inside the source had had been consumed.
+    ///   This can be less than 1, if a chunk inside the source had been truncated in order to
+    ///   adhere to the limit. It can also be more than 1, if zero-length chunks had been skipped.
     fn pop_chunk<'b>(&'b mut self, limit: usize) -> (impl BytesOrSlice<'b>, usize)
     where
         'a: 'b;

--- a/noq-proto/src/connection/streams/state.rs
+++ b/noq-proto/src/connection/streams/state.rs
@@ -74,13 +74,13 @@ pub struct StreamsState {
     /// Maximum number of locally-initiated streams that may be opened over the lifetime of the
     /// connection so far, per direction
     pub(super) max: [u64; 2],
-    /// Maximum number of remotely-initiated streams that may be opened over the lifetime of the
-    /// connection so far, per direction
+    /// Maximum number of remotely-initiated streams that may be opened.
+    ///
+    /// This is over the lifetime of the connection so far, per direction.
     pub(super) max_remote: [u64; 2],
     /// Value of `max_remote` most recently transmitted to the peer in a `MAX_STREAMS` frame
     sent_max_remote: [u64; 2],
-    /// Number of streams that we've given the peer permission to open and which aren't fully
-    /// closed
+    /// Number of streams the peer may open and which aren't fully closed.
     pub(super) allocated_remote_count: [u64; 2],
     /// Size of the desired stream flow control window. May be smaller than
     /// `allocated_remote_count` due to `set_max_concurrent` calls.
@@ -89,8 +89,9 @@ pub struct StreamsState {
     flow_control_adjusted: bool,
     /// Lowest remotely-initiated stream index that haven't actually been opened by the peer
     pub(super) next_remote: [u64; 2],
-    /// Whether the remote endpoint has opened any streams the application doesn't know about yet,
-    /// per directionality
+    /// Whether the remote opened streams which are not yet reported to the application.
+    ///
+    /// Per directionality.
     opened: [bool; 2],
     // Next to report to the application, once opened
     pub(super) next_reported_remote: [u64; 2],

--- a/noq-proto/src/connection/streams/state.rs
+++ b/noq-proto/src/connection/streams/state.rs
@@ -79,10 +79,11 @@ pub struct StreamsState {
     pub(super) max_remote: [u64; 2],
     /// Value of `max_remote` most recently transmitted to the peer in a `MAX_STREAMS` frame
     sent_max_remote: [u64; 2],
-    /// Number of streams that we've given the peer permission to open and which aren't fully closed
+    /// Number of streams that we've given the peer permission to open and which aren't fully
+    /// closed
     pub(super) allocated_remote_count: [u64; 2],
-    /// Size of the desired stream flow control window. May be smaller than `allocated_remote_count`
-    /// due to `set_max_concurrent` calls.
+    /// Size of the desired stream flow control window. May be smaller than
+    /// `allocated_remote_count` due to `set_max_concurrent` calls.
     max_concurrent_remote_count: [u64; 2],
     /// Whether `max_concurrent_remote_count` has ever changed
     flow_control_adjusted: bool,
@@ -556,10 +557,11 @@ impl StreamsState {
             }
 
             if stream.is_pending() {
-                // If the stream still has pending data, reinsert it, possibly with an updated priority value
-                // Fairness with other streams is achieved by implementing round-robin scheduling,
-                // so that the other streams will have a chance to write data
-                // before we touch this stream again.
+                // If the stream still has pending data, reinsert it, possibly with an updated
+                // priority value Fairness with other streams is achieved by
+                // implementing round-robin scheduling, so that the other streams
+                // will have a chance to write data before we touch this stream
+                // again.
                 if fair {
                     self.pending.push_pending(id, stream.priority);
                 } else {
@@ -739,8 +741,8 @@ impl StreamsState {
                 debug_assert!(stream.connection_blocked);
                 stream.connection_blocked = false;
 
-                // If it's no longer sensible to write to a stream (even to detect an error) then don't
-                // report it.
+                // If it's no longer sensible to write to a stream (even to detect an error) then
+                // don't report it.
                 if stream.is_writable() && stream.max_data > stream.offset() {
                     return Some(StreamEvent::Writable { id });
                 }
@@ -842,8 +844,8 @@ impl StreamsState {
 
     /// Allocate any new remote streams when a packet arrives for a stream id.
     /// Any streams above `next_remote` are considered in the default state, avoiding allocations.
-    /// Once we receive a packet for a new remote stream, we advance `next_remote` and allocate actual state.
-    /// If there's a gap, we insert `None` placeholders for the missing streams.
+    /// Once we receive a packet for a new remote stream, we advance `next_remote` and allocate
+    /// actual state. If there's a gap, we insert `None` placeholders for the missing streams.
     /// Returns `true` if `id` was a newly allocated remote stream.
     fn ensure_remote(&mut self, id: StreamId) -> bool {
         let dir = id.dir();
@@ -2039,7 +2041,8 @@ mod tests {
         assert_eq!(server.receive_window_shrink_debt, shrink_diff);
         let prev_local_max_data = server.local_max_data;
 
-        // credit twice, local_max_data does not change as it is absorbed by receive_window_shrink_debt
+        // credit twice, local_max_data does not change as it is absorbed by
+        // receive_window_shrink_debt
         let credits = 1024u64;
         for _ in 0..2 {
             let expected_receive_window_shrink_debt = server.receive_window_shrink_debt - credits;

--- a/noq-proto/src/connection/timer.rs
+++ b/noq-proto/src/connection/timer.rs
@@ -63,11 +63,11 @@ pub(crate) enum PathTimer {
     /// When to abandon a path due to failed validation.
     ///
     /// There are two situations in which we give up a path from validation.
-    /// 1. When opening a path we validate it according to RFC9000 §8.2 as required by the
-    ///    multipath spec. This timer is armed to time-bound that validation.
-    /// 2. When validating an already opened multipath path for various reasons in which we
-    ///    expect the path to either work or not work and want to respond correspondingly in
-    ///    a timely manner.
+    /// 1. When opening a path we validate it according to RFC9000 §8.2 as required by the multipath
+    ///    spec. This timer is armed to time-bound that validation.
+    /// 2. When validating an already opened multipath path for various reasons in which we expect
+    ///    the path to either work or not work and want to respond correspondingly in a timely
+    ///    manner.
     AbandonFromValidation = 4,
     /// When to send a `PING` frame to keep the path alive
     PathKeepAlive = 5,

--- a/noq-proto/src/crypto/rustls.rs
+++ b/noq-proto/src/crypto/rustls.rs
@@ -272,9 +272,10 @@ pub struct HandshakeData {
 /// A QUIC-compatible TLS client configuration
 ///
 /// noq implicitly constructs a `QuicClientConfig` with reasonable defaults within
-/// [`ClientConfig::with_root_certificates()`][root_certs] and [`ClientConfig::try_with_platform_verifier()`][platform].
-/// Alternatively, `QuicClientConfig`'s [`TryFrom`] implementation can be used to wrap around a
-/// custom [`rustls::ClientConfig`], in which case care should be taken around certain points:
+/// [`ClientConfig::with_root_certificates()`][root_certs] and
+/// [`ClientConfig::try_with_platform_verifier()`][platform]. Alternatively, `QuicClientConfig`'s
+/// [`TryFrom`] implementation can be used to wrap around a custom [`rustls::ClientConfig`], in
+/// which case care should be taken around certain points:
 ///
 /// - If `enable_early_data` is not set to true, then sending 0-RTT data will not be possible on
 ///   outgoing connections.
@@ -319,8 +320,8 @@ impl QuicClientConfig {
 
     /// Initialize a sane QUIC-compatible TLS client configuration
     ///
-    /// QUIC requires that TLS 1.3 be enabled. Advanced users can use any [`rustls::ClientConfig`] that
-    /// satisfies this requirement.
+    /// QUIC requires that TLS 1.3 be enabled. Advanced users can use any [`rustls::ClientConfig`]
+    /// that satisfies this requirement.
     #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
     pub(crate) fn new(verifier: Arc<dyn ServerCertVerifier>) -> Self {
         let inner = Self::inner(verifier);

--- a/noq-proto/src/endpoint.rs
+++ b/noq-proto/src/endpoint.rs
@@ -1032,7 +1032,8 @@ struct ConnectionIndex {
     /// necessarily know what address we're sending from, and hence receiving at.
     ///
     /// Uses a standard `HashMap` to protect against hash collision attacks.
-    // TODO(matheus23): It's possible this could be changed now that we track the full 4-tuple on the client side, too.
+    // TODO(matheus23): It's possible this could be changed now that we track the full 4-tuple on
+    // the client side, too.
     outgoing_connection_remotes: HashMap<SocketAddr, ConnectionHandle>,
     /// Reset tokens provided by the peer for the CID each connection is currently sending to
     ///
@@ -1178,7 +1179,8 @@ pub(crate) struct ConnectionMeta {
     ///
     /// Each path has its own active CID. We use the [`PathId`] as a unique index, allowing
     /// us to retire the reset token when a path is abandoned.
-    // TODO(matheus23): Should be migrated to make reset tokens per 4-tuple instead of per remote addr
+    // TODO(matheus23): Should be migrated to make reset tokens per 4-tuple instead of per remote
+    // addr
     reset_token: FxHashMap<PathId, (SocketAddr, ResetToken)>,
 }
 
@@ -1283,7 +1285,8 @@ impl Incoming {
     /// Decrypt the Initial packet payload
     ///
     /// This clones and decrypts the packet payload (~1200 bytes).
-    /// Can be used to extract information from the TLS ClientHello without completing the handshake.
+    /// Can be used to extract information from the TLS ClientHello without completing the
+    /// handshake.
     pub fn decrypt(&self) -> Option<DecryptedInitial> {
         let packet_number = self.packet.header.number.expand(0);
         let mut payload = self.packet.payload.clone();

--- a/noq-proto/src/frame.rs
+++ b/noq-proto/src/frame.rs
@@ -528,8 +528,8 @@ impl Frame {
     pub(crate) fn is_1rtt(&self) -> bool {
         // See also https://www.ietf.org/archive/id/draft-ietf-quic-multipath-17.html#section-4-1:
         // > All frames defined in this document MUST only be sent in 1-RTT packets.
-        // > If an endpoint receives a multipath-specific frame in a different packet type, it MUST close the
-        // > connection with an error of type PROTOCOL_VIOLATION.
+        // > If an endpoint receives a multipath-specific frame in a different packet type, it MUST
+        // > close the connection with an error of type PROTOCOL_VIOLATION.
 
         self.is_multipath_frame() || self.is_qad_frame()
     }

--- a/noq-proto/src/packet.rs
+++ b/noq-proto/src/packet.rs
@@ -31,8 +31,9 @@ pub struct PartialDecode {
 
 #[allow(clippy::len_without_is_empty)]
 impl PartialDecode {
-    /// Begin decoding a QUIC packet from `bytes`, returning any trailing data not part of that
-    /// packet
+    /// Begins decoding a QUIC packet from `bytes`.
+    ///
+    /// Returns any trailing data not part of that packet.
     pub fn new(
         bytes: BytesMut,
         cid_parser: &(impl ConnectionIdParser + ?Sized),

--- a/noq-proto/src/packet.rs
+++ b/noq-proto/src/packet.rs
@@ -31,7 +31,8 @@ pub struct PartialDecode {
 
 #[allow(clippy::len_without_is_empty)]
 impl PartialDecode {
-    /// Begin decoding a QUIC packet from `bytes`, returning any trailing data not part of that packet
+    /// Begin decoding a QUIC packet from `bytes`, returning any trailing data not part of that
+    /// packet
     pub fn new(
         bytes: BytesMut,
         cid_parser: &(impl ConnectionIdParser + ?Sized),

--- a/noq-proto/src/range_set/array_range_set.rs
+++ b/noq-proto/src/range_set/array_range_set.rs
@@ -10,10 +10,10 @@ use tinyvec::TinyVec;
 /// a range.
 ///
 /// The array-based RangeSet provides 2 benefits:
-/// - There exists an inline representation, which avoids the need of heap
-///   allocating ACK ranges for SentFrames for small ranges.
-/// - Iterating over ranges should usually be faster since there is only
-///   a single cache-friendly contiguous range.
+/// - There exists an inline representation, which avoids the need of heap allocating ACK ranges for
+///   SentFrames for small ranges.
+/// - Iterating over ranges should usually be faster since there is only a single cache-friendly
+///   contiguous range.
 ///
 /// `ArrayRangeSet` is especially useful for tracking ACK ranges where the amount
 /// of ranges is usually very low (since ACK numbers are in consecutive fashion

--- a/noq-proto/src/shared.rs
+++ b/noq-proto/src/shared.rs
@@ -76,9 +76,9 @@ pub(crate) enum EndpointEventInner {
     ///
     /// The fields are:
     /// - The path ID for which the identifiers are needed.
-    /// - The time when the identifiers were needed, not used to generate the CIDs but sent
-    ///   back via the [`ConnectionEventInner::NewIdentifiers`] so the connection can track
-    ///   the lifetime of when it needs to be rotated.  should be rotated.
+    /// - The time when the identifiers were needed, not used to generate the CIDs but sent back via
+    ///   the [`ConnectionEventInner::NewIdentifiers`] so the connection can track the lifetime of
+    ///   when it needs to be rotated.  should be rotated.
     /// - The number of CIDs needed.
     NeedIdentifiers(PathId, Instant, u64),
     /// Retire a locally issued CID

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -60,8 +60,8 @@ mod token;
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 // Enable this if you want to run these tests in the browser.
-// Unfortunately it's either-or: Enable this and you can run in the browser, disable to run in nodejs.
-// #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+// Unfortunately it's either-or: Enable this and you can run in the browser, disable to run in
+// nodejs. #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 // wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]
@@ -3391,7 +3391,8 @@ fn ack_frequency_ack_sent_after_reordered_packets_above_threshold() {
         pair.drive_client();
     }
 
-    // Restore the default MTU and send another ping, which will arrive earlier than the dropped ones
+    // Restore the default MTU and send another ping, which will arrive earlier than the dropped
+    // ones
     pair.mtu = DEFAULT_MTU;
     pair.client_conn_mut(client_ch).ping();
     pair.drive_client();
@@ -3617,7 +3618,8 @@ fn datagram_gso() {
     let final_transmit_count = pair.client_conn_mut(client_ch).stats().transmits_tx;
     let final_bytes = pair.client_conn_mut(client_ch).stats().udp_tx.bytes;
     assert_eq!(final_transmit_count - initial_transmit_count, 1);
-    // Expected overhead: flags + CID + PN + tag + frame type + frame length = 1 + 8 + 1 + 16 + 1 + 2 = 29
+    // Expected overhead:
+    //    flags + CID + PN + tag + frame type + frame length = 1 + 8 + 1 + 16 + 1 + 2 = 29
     assert_eq!(
         final_bytes - initial_bytes,
         ((29 + DATAGRAM_LEN) * DATAGRAMS) as u64
@@ -3679,7 +3681,8 @@ fn pad_to_mtu() {
     pair.server.capture_inbound_packets = true;
 
     info!("sending");
-    // Send two datagrams significantly smaller than MTU, but large enough to require two UDP datagrams.
+    // Send two datagrams significantly smaller than MTU, but large enough to require two UDP
+    // datagrams.
     const LEN_1: usize = 800;
     const LEN_2: usize = 600;
     pair.client_datagrams(client_ch)
@@ -4382,12 +4385,11 @@ fn regression_maybe_frame_roundtrip() {
 
 /// Regression test simulating a situation that would trigger an unreachable! in noq.
 ///
-/// - noq expects that there always is a `ConnectionError` set at the end of draining
-///   a connection.
-/// - When the connection close is generated within noq-proto (or received remotely),
-///   then this error in noq is populated via connection events.
-/// - This test simulates a situation in which noq-proto would not generate a
-///   `ConnectionLost` event for a connection that has drained.
+/// - noq expects that there always is a `ConnectionError` set at the end of draining a connection.
+/// - When the connection close is generated within noq-proto (or received remotely), then this
+///   error in noq is populated via connection events.
+/// - This test simulates a situation in which noq-proto would not generate a `ConnectionLost` event
+///   for a connection that has drained.
 ///
 /// The issue is a race condition between `move_to_closed` and `move_to_draining(None)`.
 /// The latter overwrites the error from the former, making it impossible to generate a

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -2168,11 +2168,13 @@ fn regression_delayed_path_cids_blocked() -> TestResult {
     pair.drive_client(); // Client sends Initial
     pair.drive_server(); // Server receives Initial, sends Handshake
     pair.drive_client(); // Client receives Handshake, sends handshake confirmed
-    pair.drive_server(); // Server receives handshake confirmed, sends PATH_NEW_CONNECTION_ID and confirms handshake itself
-    // Capture the server's PATH_NEW_CONNECTION_ID frames so the client generates a
-    // PATH_CIDS_BLOCKED frame on the next open_path call. This only works, because the server's
-    // outbound packet is constructed inefficiently: The PATH_NEW_CONNECTION_ID frames should
-    // *actually* be coaleced together with the server's handshake response instead of being put into a separate datagram. See also <https://github.com/n0-computer/noq/issues/66>
+    pair.drive_server(); // Server receives handshake confirmed, sends
+    // PATH_NEW_CONNECTION_ID and confirms handshake itself Capture the server's
+    // PATH_NEW_CONNECTION_ID frames so the client generates a PATH_CIDS_BLOCKED frame on
+    // the next open_path call. This only works, because the server's outbound packet is
+    // constructed inefficiently: The PATH_NEW_CONNECTION_ID frames should *actually* be
+    // coaleced together with the server's handshake response instead of being put into a
+    // separate datagram. See also <https://github.com/n0-computer/noq/issues/66>
     let (_, captured_server_cids) = pair.client.inbound.pop_last().unwrap();
     pair.drive_client(); // Client receives confirmed handshake, but not PATH_NEW_CONNECTION_ID frames
     let server_ch = pair.server.assert_accept();

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -469,8 +469,8 @@ fn open_path_validation_fails_client_side() -> TestResult {
     // Sever the connection and run it to idle.
     // This makes sure that
     // - path validation can't succeed because path responses don't make it through and
-    // - the server needs to decide to close the path on its own, because path abandons
-    //   don't make it through.
+    // - the server needs to decide to close the path on its own, because path abandons don't make
+    //   it through.
     while pair.blackhole_step(true, true) {}
 
     assert_matches!(
@@ -2047,7 +2047,8 @@ fn on_path_challenge_lost_backoff() {
         expected_path_challenges_received: u64,
     ) {
         for _ in 0..10 {
-            // attempt to drive the server until it receives the PATH_CHALLENGE and sends a PATH_RESPONSE
+            // attempt to drive the server until it receives the PATH_CHALLENGE and sends a
+            // PATH_RESPONSE
             pair.time = pair
                 .server
                 .next_wakeup()
@@ -2150,8 +2151,8 @@ fn paths_blocked_retransmission() -> TestResult {
 
 /// This test used to generate a PROTOCOL_VIOLATION error from just packet loss and delayed packets.
 ///
-/// The problem was receiving a PATH_CIDS_BLOCKED frame with path_id=1 and next_seq=1 when the server
-/// side had already abandoned and discarded path 1.
+/// The problem was receiving a PATH_CIDS_BLOCKED frame with path_id=1 and next_seq=1 when the
+/// server side had already abandoned and discarded path 1.
 /// In that case, we assumed the other side would violate the protocol, whereas in reality it's just
 /// a (very) delayed packet.
 ///
@@ -2168,16 +2169,17 @@ fn regression_delayed_path_cids_blocked() -> TestResult {
     pair.drive_server(); // Server receives Initial, sends Handshake
     pair.drive_client(); // Client receives Handshake, sends handshake confirmed
     pair.drive_server(); // Server receives handshake confirmed, sends PATH_NEW_CONNECTION_ID and confirms handshake itself
-    // Capture the server's PATH_NEW_CONNECTION_ID frames so the client generates a PATH_CIDS_BLOCKED frame on the next open_path call.
-    // This only works, because the server's outbound packet is constructed inefficiently:
-    // The PATH_NEW_CONNECTION_ID frames should *actually* be coaleced together with the server's handshake response instead of
-    // being put into a separate datagram. See also <https://github.com/n0-computer/noq/issues/66>
+    // Capture the server's PATH_NEW_CONNECTION_ID frames so the client generates a
+    // PATH_CIDS_BLOCKED frame on the next open_path call. This only works, because the server's
+    // outbound packet is constructed inefficiently: The PATH_NEW_CONNECTION_ID frames should
+    // *actually* be coaleced together with the server's handshake response instead of being put into a separate datagram. See also <https://github.com/n0-computer/noq/issues/66>
     let (_, captured_server_cids) = pair.client.inbound.pop_last().unwrap();
     pair.drive_client(); // Client receives confirmed handshake, but not PATH_NEW_CONNECTION_ID frames
     let server_ch = pair.server.assert_accept();
     pair.finish_connect(client_ch, server_ch);
 
-    // Attempting to open a path on the client side will fail, because we're missing the CIDs for path 1 and more
+    // Attempting to open a path on the client side will fail, because we're missing the CIDs for
+    // path 1 and more
     let mut pair = ConnPair::new(pair, client_ch, server_ch);
     let server_addr = pair.routes.public_server_addr();
     pair.open_path(

--- a/noq-proto/src/tests/proptests.rs
+++ b/noq-proto/src/tests/proptests.rs
@@ -64,8 +64,8 @@ const SERVER_ADDRS: [SocketAddr; 3] = [
 /// this has several advantages:
 /// - On a proptest failure, it is easy to see which minimal setup the proptest fails with.
 /// - The definition of the setup itself is concise, e.g. when copying it into regression tests.
-/// - We can be more precise/smaller in the "search space" and have more efficient shrinking,
-///   see [`Seed`] or [`RoutingSetup`].
+/// - We can be more precise/smaller in the "search space" and have more efficient shrinking, see
+///   [`Seed`] or [`RoutingSetup`].
 #[derive(Debug, test_strategy::Arbitrary)]
 struct PairSetup {
     seed: Seed,
@@ -89,7 +89,8 @@ enum Extensions {
 pub(super) enum RoutingSetup {
     /// Set [`Pair::routes`] to [`BasicRouting`]
     Basic,
-    /// Use [`RoutingTable::simple_symmetric`] with the default [`CLIENT_ADDRS`] and [`SERVER_ADDRS`].
+    /// Use [`RoutingTable::simple_symmetric`] with the default [`CLIENT_ADDRS`] and
+    /// [`SERVER_ADDRS`].
     SimpleSymmetric,
     /// Use given generated routing table.
     Complex(#[strategy(routing_table())] ManyToManyRouting),
@@ -102,9 +103,9 @@ pub(super) enum RoutingSetup {
 /// but also we don't want to disable shrinking altogether: when the seed shrinks to zero, this
 /// helps us understand that the seed is likely irrelevant to the test failure.
 ///
-/// This struct achieves the best of both worlds: If the seed is generated as `Generated(some_seed)`,
-/// shrinking will try `Zeroes` once, and if that fails, fall back to using the generated seed
-/// and avoid doing any further shrinking of `some_seed`.
+/// This struct achieves the best of both worlds: If the seed is generated as
+/// `Generated(some_seed)`, shrinking will try `Zeroes` once, and if that fails, fall back to using
+/// the generated seed and avoid doing any further shrinking of `some_seed`.
 #[derive(Debug, test_strategy::Arbitrary)]
 enum Seed {
     /// The zero seed.
@@ -672,12 +673,10 @@ fn regression_peer_failed_to_respond_with_path_abandon2() {
 /// share the same IP address and don't both have the same two
 /// interfaces, but the resulting situation is the same:
 ///
-/// - The server sees the remote as 1.1.1.0 and had previously
-///   sent and received on that address in this connection and
-///   thus considers it valid, while
-/// - the client side first sends to 2.2.2.1 but gets the response
-///   from the remote 2.2.2.0, thus it fails validation on the
-///   client side and it ignores the packet.
+/// - The server sees the remote as 1.1.1.0 and had previously sent and received on that address in
+///   this connection and thus considers it valid, while
+/// - the client side first sends to 2.2.2.1 but gets the response from the remote 2.2.2.0, thus it
+///   fails validation on the client side and it ignores the packet.
 ///
 /// Originally this test produced a "PATH_ABANDON was ignored"
 /// error message, but that's secondary to the original problem.
@@ -998,9 +997,9 @@ fn regression_peer_ignored_path_abandon() {
 /// > DEBUG client:pkt{path_id=1}:recv{space=Data pn=3}:frame{ty=PATH_RESPONSE}:
 /// > noq_proto::connection: 4704:
 /// > ignoring invalid PATH_RESPONSE
-/// >  response=PATH_RESPONSE(ece9dc07f89ded7e)
-/// >  network_path=(local: ::ffff:1.1.1.2, remote: [::ffff:2.2.2.0]:4433)
-/// >  expected=(local: ::ffff:1.1.1.1, remote: [::ffff:2.2.2.0]:4433)
+/// > response=PATH_RESPONSE(ece9dc07f89ded7e)
+/// > network_path=(local: ::ffff:1.1.1.2, remote: [::ffff:2.2.2.0]:4433)
+/// > expected=(local: ::ffff:1.1.1.1, remote: [::ffff:2.2.2.0]:4433)
 ///
 /// The client will then never clear out the PATH_CHALLENGE from the "pending"
 /// challenges, and so it will never fully clear the path challenge timer.
@@ -1080,8 +1079,8 @@ fn regression_never_idle4() {
 /// due to an infinite LossDetection timer loop:
 /// - The loss detection timer would fire
 /// - Upon detecting loss, it would re-set the loss detection timer to `now` (0ms delay) again
-/// - Within a single `pair.step()` it would go back to the loss detection timer firing
-///   (it expects timers to fire in the future eventually.)
+/// - Within a single `pair.step()` it would go back to the loss detection timer firing (it expects
+///   timers to fire in the future eventually.)
 ///
 /// The reason this tight loop existed was because the loss detection timer is relative to the
 /// `time_of_last_ack_eliciting_packet`. If this becomes too old (and we cap the PTO duration to
@@ -1138,24 +1137,26 @@ fn regression_infinite_loop() {
     )));
 }
 
-/// This test reproduced a situation in which a QNT-enabled connection sends path challenges indefinitely.
+/// This test reproduced a situation in which a QNT-enabled connection sends path challenges
+/// indefinitely.
 ///
-/// In this test setup, we enable QNT, call the required functions for adding addresses to holepunch,
-/// and then eventually initiate the first holepunching round.
-/// Before that, we also trigger a passive migration on the server side, effectively severing the connection
-/// in the server -> client direction on path 0 (the only path at that time), because all packets are
-/// rejected on the client side as coming from the wrong address.
+/// In this test setup, we enable QNT, call the required functions for adding addresses to
+/// holepunch, and then eventually initiate the first holepunching round.
+/// Before that, we also trigger a passive migration on the server side, effectively severing the
+/// connection in the server -> client direction on path 0 (the only path at that time), because all
+/// packets are rejected on the client side as coming from the wrong address.
 ///
-/// What follows is that the server sends PATH_CHALLENGEs for path 0 (as that's what we've added as the
-/// "holepunching address"), and initiating the holepunching means that we reuse existing paths if we
-/// already have one on the required address, but we do *revalidate* them (triggering new PATH_CHALLENGEs).
+/// What follows is that the server sends PATH_CHALLENGEs for path 0 (as that's what we've added as
+/// the "holepunching address"), and initiating the holepunching means that we reuse existing paths
+/// if we already have one on the required address, but we do *revalidate* them (triggering new
+/// PATH_CHALLENGEs).
 ///
-/// However, in this code path, we didn't have anything that would prevent re-validated path challenges
-/// to ever be stopped, so this revalidation would keep the connection busy in the path challenge sent ->
-/// path challenge lost -> path challenge sent loop.
+/// However, in this code path, we didn't have anything that would prevent re-validated path
+/// challenges to ever be stopped, so this revalidation would keep the connection busy in the path
+/// challenge sent -> path challenge lost -> path challenge sent loop.
 ///
-/// We fixed this bug by introducing another `OpenState::Revalidating`, and arming the `PathOpenFailed`
-/// timer when we start revalidating a path.
+/// We fixed this bug by introducing another `OpenState::Revalidating`, and arming the
+/// `PathOpenFailed` timer when we start revalidating a path.
 #[test]
 fn regression_qnt_revalidating_path_forever() {
     let prefix = "regression_qnt_revalidating_path_forever";
@@ -1252,7 +1253,8 @@ fn regression_migration_probing_loop() {
     )));
 }
 
-/// Test for a case where we kept sending so many PATH_CHALLENGEs that we'd run out of `drive_bounded` budget.
+/// Test for a case where we kept sending so many PATH_CHALLENGEs that we'd run out of
+/// `drive_bounded` budget.
 ///
 /// The original proptest found a situation in which the newly opened path was working one-way.
 /// The client was able to send to the server, but the responses from the server back to the client
@@ -1262,18 +1264,18 @@ fn regression_migration_probing_loop() {
 /// didn't receive them.
 /// This in turn means that the client will re-send PATH_CHALLENGEs.
 ///
-/// At the same time, the PATH_CHALLENGEs were acknowledged by the server and the acknowledgements were
-/// sent over a different path.
+/// At the same time, the PATH_CHALLENGEs were acknowledged by the server and the acknowledgements
+/// were sent over a different path.
 ///
 /// This meant that the client had updated its RTT estimates for the path, even though the path was
 /// not yet working.
-/// Initially when the client opened the path, the RTT estimate was the initial RTT estimate of 333ms.
-/// This resulted in the `AbandonFromPathValidation` timer to be set at ~3s.
+/// Initially when the client opened the path, the RTT estimate was the initial RTT estimate of
+/// 333ms. This resulted in the `AbandonFromPathValidation` timer to be set at ~3s.
 /// After the first couple of ACKs, the path's RTT estimate quickly updated to 1ms though.
 ///
-/// When this test was failing, PATH_CHALLENGEs were re-sent after 1 PTO without a response. This meant
-/// that it would re-send challenges every 2ms, generating many hundreds of PATH_CHALLENGEs before the
-/// path would be abandoned.
+/// When this test was failing, PATH_CHALLENGEs were re-sent after 1 PTO without a response. This
+/// meant that it would re-send challenges every 2ms, generating many hundreds of PATH_CHALLENGEs
+/// before the path would be abandoned.
 ///
 /// The fix was to implement PATH_CHALLENGE re-sending backoffs, similar to tail loss probe backoff.
 #[test]

--- a/noq-proto/src/tests/random_interaction.rs
+++ b/noq-proto/src/tests/random_interaction.rs
@@ -269,7 +269,8 @@ impl TestOp {
 impl StreamOp {
     fn run(self, pair: &mut Pair, state: &mut State) -> Option<()> {
         let conn = state.conn(pair)?;
-        // We generally ignore application-level errors. It's legal to call these APIs, so we do. We don't expect them to work all the time.
+        // We generally ignore application-level errors. It's legal to call these APIs, so we do. We
+        // don't expect them to work all the time.
         match self {
             Self::Open(kind) => state.send_streams.extend(conn.streams().open(kind)),
             Self::Send { stream, num_bytes } => {

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -42,7 +42,8 @@ pub(super) struct Pair {
     pub(super) epoch: Instant,
     /// Current time
     pub(super) time: Instant,
-    /// Simulates the maximum size allowed for UDP payloads by the link (packets exceeding this size will be dropped)
+    /// Simulates the maximum size allowed for UDP payloads by the link (packets exceeding this
+    /// size will be dropped)
     pub(super) mtu: usize,
     /// Simulates explicit congestion notification
     pub(super) congestion_experienced: bool,
@@ -1864,8 +1865,9 @@ impl ManyToManyRouting {
 
     fn route_client_to_server(&mut self, transmit: &Transmit, now: Instant) -> RoutingDecision {
         if let Some(client_interface_ip) = transmit.src_ip {
-            // If we have a client interface IP, then we use that to build the packet coming in on the other side.
-            // But we need to check if that is even connected to the server.
+            // If we have a client interface IP, then we use that to build the packet coming in on
+            // the other side. But we need to check if that is even connected to the
+            // server.
             let Some(&(client_addr, _)) = self
                 .server_routes
                 .iter()
@@ -1904,8 +1906,9 @@ impl ManyToManyRouting {
 
     fn route_server_to_client(&mut self, transmit: &Transmit, now: Instant) -> RoutingDecision {
         if let Some(server_interface_ip) = transmit.src_ip {
-            // If we have a server interface IP, then we use that to build the packet coming in on the other side.
-            // But we need to check if that is even connected to the client.
+            // If we have a server interface IP, then we use that to build the packet coming in on
+            // the other side. But we need to check if that is even connected to the
+            // client.
             let Some(&(server_addr, _)) = self
                 .client_routes
                 .iter()
@@ -1986,13 +1989,15 @@ impl ManyToManyRouting {
         }
     }
 
-    /// Adds a new route from an existing server address (identified by index) to a new client address.
+    /// Adds a new route from an existing server address (identified by index) to a new client
+    /// address.
     pub(super) fn add_client_route(&mut self, client_addr: SocketAddr, server_addr_idx: usize) {
         assert!(server_addr_idx < self.server_routes.len());
         self.client_routes.push((client_addr, server_addr_idx));
     }
 
-    /// Adds a new route from an existing client address (identified by index) to a new server address.
+    /// Adds a new route from an existing client address (identified by index) to a new server
+    /// address.
     pub(super) fn add_server_route(&mut self, server_addr: SocketAddr, client_addr_idx: usize) {
         assert!(client_addr_idx < self.client_routes.len());
         self.server_routes.push((server_addr, client_addr_idx));
@@ -2049,9 +2054,8 @@ impl ManyToManyRouting {
 /// The client and server both have 2 interfaces:
 ///
 /// 1. One "direct" interface, which has a link to the peer's "direct" interface.
-/// 2. One "nat" interface, which has a link to the peer's "nat" interface. This link
-///    however does not allow an incoming packet unless it has seen an outgoing packet
-///    first.
+/// 2. One "nat" interface, which has a link to the peer's "nat" interface. This link however does
+///    not allow an incoming packet unless it has seen an outgoing packet first.
 ///
 /// When an outgoing transmit has no `src_ip` is set, the source IP is set based on the
 /// destination. This is the same as the kernel selecting the correct outbound interface. If

--- a/noq-proto/src/tests/util.rs
+++ b/noq-proto/src/tests/util.rs
@@ -42,8 +42,9 @@ pub(super) struct Pair {
     pub(super) epoch: Instant,
     /// Current time
     pub(super) time: Instant,
-    /// Simulates the maximum size allowed for UDP payloads by the link (packets exceeding this
-    /// size will be dropped)
+    /// Simulates the maximum size allowed for UDP payloads by the link.
+    ///
+    /// Packets exceeding this size will be dropped.
     pub(super) mtu: usize,
     /// Simulates explicit congestion notification
     pub(super) congestion_experienced: bool,
@@ -1989,15 +1990,13 @@ impl ManyToManyRouting {
         }
     }
 
-    /// Adds a new route from an existing server address (identified by index) to a new client
-    /// address.
+    /// Adds a new route from an existing server address to a new client address.
     pub(super) fn add_client_route(&mut self, client_addr: SocketAddr, server_addr_idx: usize) {
         assert!(server_addr_idx < self.server_routes.len());
         self.client_routes.push((client_addr, server_addr_idx));
     }
 
-    /// Adds a new route from an existing client address (identified by index) to a new server
-    /// address.
+    /// Adds a new route from an existing client address to a new server address.
     pub(super) fn add_server_route(&mut self, server_addr: SocketAddr, client_addr_idx: usize) {
         assert!(client_addr_idx < self.client_routes.len());
         self.server_routes.push((server_addr, client_addr_idx));

--- a/noq-proto/src/token.rs
+++ b/noq-proto/src/token.rs
@@ -37,8 +37,8 @@ pub trait TokenLog: Send + Sync {
     /// Parameters:
     /// - `nonce`: A server-generated random unique value for the token.
     /// - `issued`: The time the server issued the token.
-    /// - `lifetime`: The expiration time of address validation tokens sent via NEW_TOKEN frames,
-    ///   as configured by [`ServerValidationTokenConfig::lifetime`][1].
+    /// - `lifetime`: The expiration time of address validation tokens sent via NEW_TOKEN frames, as
+    ///   configured by [`ServerValidationTokenConfig::lifetime`][1].
     ///
     /// [1]: crate::ValidationTokenConfig::lifetime
     ///

--- a/noq-proto/src/transport_parameters.rs
+++ b/noq-proto/src/transport_parameters.rs
@@ -616,9 +616,10 @@ impl TransportParameters {
 /// A reserved transport parameter.
 ///
 /// It has an identifier of the form 31 * N + 27 for the integer value of N.
-/// Such identifiers are reserved to exercise the requirement that unknown transport parameters be ignored.
-/// The reserved transport parameter has no semantics and can carry arbitrary values.
-/// It may be included in transport parameters sent to the peer, and should be ignored when received.
+/// Such identifiers are reserved to exercise the requirement that unknown transport parameters be
+/// ignored. The reserved transport parameter has no semantics and can carry arbitrary values.
+/// It may be included in transport parameters sent to the peer, and should be ignored when
+/// received.
 ///
 /// See spec: <https://www.rfc-editor.org/rfc/rfc9000.html#section-18.1>
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/noq-udp/src/cmsg/mod.rs
+++ b/noq-udp/src/cmsg/mod.rs
@@ -26,9 +26,10 @@ pub(crate) struct Encoder<'a, M: MsgHdr> {
 
 impl<'a, M: MsgHdr> Encoder<'a, M> {
     /// # Safety
-    /// - `hdr` must contain a suitably aligned pointer to a big enough buffer to hold control messages
-    ///   bytes. All bytes of this buffer can be safely written.
-    /// - The `Encoder` must be dropped before `hdr` is passed to a system call, and must not be leaked.
+    /// - `hdr` must contain a suitably aligned pointer to a big enough buffer to hold control
+    ///   messages bytes. All bytes of this buffer can be safely written.
+    /// - The `Encoder` must be dropped before `hdr` is passed to a system call, and must not be
+    ///   leaked.
     pub(crate) unsafe fn new(hdr: &'a mut M) -> Self {
         Self {
             cmsg: unsafe { hdr.cmsg_first_hdr().as_mut() },

--- a/noq-udp/src/lib.rs
+++ b/noq-udp/src/lib.rs
@@ -12,8 +12,8 @@
 //!   addresses for sent packets, allowing responses to be sent from the address that the peer
 //!   expects when there are multiple possibilities. This is common when bound to a wildcard address
 //!   in IPv6 due to [RFC 8981] temporary addresses.
-//! - [Explicit Congestion Notification], which is required by QUIC to prevent packet loss and reduce
-//!   latency on congested links when supported by the network path.
+//! - [Explicit Congestion Notification], which is required by QUIC to prevent packet loss and
+//!   reduce latency on congested links when supported by the network path.
 //! - Disabled IP-layer fragmentation, which allows the true physical MTU to be detected and reduces
 //!   risk of QUIC packet loss.
 //!

--- a/noq-udp/src/unix.rs
+++ b/noq-udp/src/unix.rs
@@ -99,8 +99,9 @@ impl UdpSocketState {
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            // Forbid IPv4 fragmentation. Set even for IPv6 to account for IPv6 mapped IPv4 addresses.
-            // Set `may_fragment` to `true` if this option is not supported on the platform.
+            // Forbid IPv4 fragmentation. Set even for IPv6 to account for IPv6 mapped IPv4
+            // addresses. Set `may_fragment` to `true` if this option is not supported
+            // on the platform.
             may_fragment |= !set_socket_option_supported(
                 &*io,
                 libc::IPPROTO_IP,
@@ -125,8 +126,8 @@ impl UdpSocketState {
                 // #define UDP_GRO_CNT_MAX 64
                 //
                 // NOTE: this MUST be set to UDP_GRO_CNT_MAX to ensure that the receive buffer size
-                // (get_max_udp_payload_size() * gro_segments()) is large enough to hold the largest GRO
-                // list the kernel might potentially produce. See
+                // (get_max_udp_payload_size() * gro_segments()) is large enough to hold the largest
+                // GRO list the kernel might potentially produce. See
                 // https://github.com/quinn-rs/quinn/pull/1354.
                 gro_segments = NonZeroUsize::new(64).expect("known");
             }
@@ -197,8 +198,8 @@ impl UdpSocketState {
         match send(self, socket.0, transmit) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
-            // - EMSGSIZE is expected for MTU probes. Future work might be able to avoid
-            //   these by automatically clamping the MTUD upper bound to the interface MTU.
+            // - EMSGSIZE is expected for MTU probes. Future work might be able to avoid these by
+            //   automatically clamping the MTUD upper bound to the interface MTU.
             Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => Ok(()),
             Err(e) => {
                 log_sendmsg_error(&self.last_send_error, e, transmit);

--- a/noq-udp/src/windows.rs
+++ b/noq-udp/src/windows.rs
@@ -276,7 +276,8 @@ impl UdpSocketState {
     ) -> io::Result<usize> {
         let wsa_recvmsg_ptr = WSARECVMSG_PTR.expect("valid function pointer for WSARecvMsg");
 
-        // we cannot use [`socket2::MsgHdrMut`] as we do not have access to inner field which holds the WSAMSG
+        // we cannot use [`socket2::MsgHdrMut`] as we do not have access to inner field which holds
+        // the WSAMSG
         let mut ctrl_buf = cmsg::Aligned([0; CMSG_LEN]);
         let mut source: WinSock::SOCKADDR_INET = unsafe { mem::zeroed() };
         let mut data = WinSock::WSABUF {
@@ -606,7 +607,8 @@ fn set_socket_option(
 }
 
 pub(crate) const BATCH_SIZE: usize = 1;
-// Enough to store max(IP_PKTINFO + IP_ECN, IPV6_PKTINFO + IPV6_ECN) + max(UDP_SEND_MSG_SIZE, UDP_COALESCED_INFO) bytes (header + data) and some extra margin
+// Enough to store max(IP_PKTINFO + IP_ECN, IPV6_PKTINFO + IPV6_ECN) + max(UDP_SEND_MSG_SIZE,
+// UDP_COALESCED_INFO) bytes (header + data) and some extra margin
 const CMSG_LEN: usize = 128;
 const OPTION_ON: u32 = 1;
 
@@ -674,7 +676,8 @@ static WSARECVMSG_PTR: LazyLock<WinSock::LPFN_WSARECVMSG> = LazyLock::new(|| {
 ///
 /// See:
 /// - Wine's `convert_control_headers()`: <https://github.com/wine-mirror/wine/blob/master/dlls/ntdll/unix/socket.c>
-/// - Linux `in_pktinfo` fields: <https://man7.org/linux/man-pages/man7/ip.7.html> (`ipi_spec_dst` vs `ipi_addr`)
+/// - Linux `in_pktinfo` fields: <https://man7.org/linux/man-pages/man7/ip.7.html> (`ipi_spec_dst`
+///   vs `ipi_addr`)
 /// - Windows `IN_PKTINFO`: <https://learn.microsoft.com/en-us/windows/win32/api/ws2ipdef/ns-ws2ipdef-in_pktinfo>
 /// - Wine bug for original IP_PKTINFO impl: <https://bugs.winehq.org/show_bug.cgi?id=19493>
 pub(crate) fn is_wine() -> bool {

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -355,9 +355,10 @@ impl Connection {
 
     /// Accept the next incoming bidirectional stream
     ///
-    /// **Important Note**: The `Connection` that calls [`open_bi()`] must write to its [`SendStream`]
-    /// before the other `Connection` is able to `accept_bi()`. Calling [`open_bi()`] then
-    /// waiting on the [`RecvStream`] without writing anything to [`SendStream`] will never succeed.
+    /// **Important Note**: The `Connection` that calls [`open_bi()`] must write to its
+    /// [`SendStream`] before the other `Connection` is able to `accept_bi()`. Calling
+    /// [`open_bi()`] then waiting on the [`RecvStream`] without writing anything to
+    /// [`SendStream`] will never succeed.
     ///
     /// [`accept_bi()`]: crate::Connection::accept_bi
     /// [`open_bi()`]: crate::Connection::open_bi
@@ -476,11 +477,13 @@ impl Connection {
 
     /// A stream of [`PathEvent`]s for all paths in this connection.
     ///
-    /// The stream will yield a [`PathEvent`] whenever there is a change in the state of any path in this connection.
-    /// The events need to be processed immediately, since there isn't an unbounded buffer for them.
+    /// The stream will yield a [`PathEvent`] whenever there is a change in the state of any path in
+    /// this connection. The events need to be processed immediately, since there isn't an
+    /// unbounded buffer for them.
     ///
-    /// If processing of events lags behind too much, you will get an error of type [`crate::Lagged`] indicating
-    /// how many events were lost. The stream continues after a lag, delivering the oldest retained message next.
+    /// If processing of events lags behind too much, you will get an error of type
+    /// [`crate::Lagged`] indicating how many events were lost. The stream continues after a
+    /// lag, delivering the oldest retained message next.
     pub fn path_events(&self) -> crate::PathEvents {
         crate::PathEvents::new(
             self.0
@@ -494,8 +497,9 @@ impl Connection {
     ///
     /// The events need to be processed immediately, since there isn't an unbounded buffer for them.
     ///
-    /// If processing of events lags behind too much, you will get an error of type [`crate::Lagged`] indicating
-    /// how many events were lost. The stream continues after a lag, delivering the oldest retained message next.
+    /// If processing of events lags behind too much, you will get an error of type
+    /// [`crate::Lagged`] indicating how many events were lost. The stream continues after a
+    /// lag, delivering the oldest retained message next.
     pub fn nat_traversal_updates(&self) -> crate::NatTraversalUpdates {
         crate::NatTraversalUpdates::new(
             self.0
@@ -535,10 +539,11 @@ impl Connection {
     /// Returns a future that resolves, once the connection is closed, to a [`Closed`] struct
     /// describing the close reason and final connection and per-path statistics.
     ///
-    /// Calling [`Self::closed`] keeps the connection alive until it is either closed locally via [`Connection::close`]
-    /// or closed by the remote peer. This function instead does not keep the connection itself alive,
-    /// so if all *other* clones of the connection are dropped, the connection will be closed implicitly even
-    /// if there are futures returned from this function still being awaited.
+    /// Calling [`Self::closed`] keeps the connection alive until it is either closed locally via
+    /// [`Connection::close`] or closed by the remote peer. This function instead does not keep
+    /// the connection itself alive, so if all *other* clones of the connection are dropped, the
+    /// connection will be closed implicitly even if there are futures returned from this
+    /// function still being awaited.
     pub fn on_closed(&self) -> OnClosed {
         let (tx, rx) = oneshot::channel();
         let mut state = self.0.lock_without_waking("on_closed");
@@ -562,7 +567,8 @@ impl Connection {
     /// an internal error (such as an idle timeout or the peer closing the
     /// connection).
     ///
-    /// Note: when the connection is closed, `connection.close_reason().is_some()` will always be true.
+    /// Note: when the connection is closed, `connection.close_reason().is_some()` will always be
+    /// true.
     pub fn close_reason(&self) -> Option<ConnectionError> {
         self.0.lock_without_waking("close_reason").error.clone()
     }
@@ -1340,8 +1346,8 @@ pub(crate) struct ConnectionInner {
 impl ConnectionInner {
     /// Lock the state and return a guard that wakes the connection driver on drop.
     ///
-    /// Use this for operations that may queue frames. The wake ensures the driver sends queued frames.
-    /// If that's not needed, use [`Self::lock_without_waking`].
+    /// Use this for operations that may queue frames. The wake ensures the driver sends queued
+    /// frames. If that's not needed, use [`Self::lock_without_waking`].
     pub(crate) fn lock_and_wake(&self, purpose: &'static str) -> WakeGuard<'_> {
         WakeGuard {
             guard: self.state.lock(purpose),
@@ -1458,8 +1464,9 @@ pub(crate) struct State {
     pub(crate) path_refs: FxHashMap<PathId, PathRefOwner>,
     /// Final path stats for discarded paths.
     ///
-    /// We only insert entries if the discarded path has a non-zero reference count in [`Self::path_refs`].
-    /// When the last reference to a path is dropped its entry is removed from both maps.
+    /// We only insert entries if the discarded path has a non-zero reference count in
+    /// [`Self::path_refs`]. When the last reference to a path is dropped its entry is removed
+    /// from both maps.
     pub(crate) final_path_stats: FxHashMap<PathId, PathStats>,
     pub(crate) path_events: tokio::sync::broadcast::Sender<PathEvent>,
     sender: Pin<Box<dyn UdpSender>>,
@@ -1694,13 +1701,16 @@ impl State {
                 }
                 Path(ref evt @ PathEvent::Abandoned { id, .. }) => {
                     if let Some(sender) = self.open_path.remove(&id) {
-                        // We don't care for the reason why this path was closed here, because semantically
-                        // all close reasons for a path that has not yet been opened equals to `ValidationFailed`.
-                        // With the noq API, there is no way to application-close a not-yet-opened path, so
-                        // `ApplicationClosed` cannot occur. And all other variants will only occur for paths
-                        // that have already been opened.
-                        // The previous iteration of this code had another event `PathEvent::LocallyClosed` which
-                        // contained a `PathError`, but that was only ever set to `ValidationFailed`.
+                        // We don't care for the reason why this path was closed here, because
+                        // semantically all close reasons for a path that
+                        // has not yet been opened equals to `ValidationFailed`.
+                        // With the noq API, there is no way to application-close a not-yet-opened
+                        // path, so `ApplicationClosed` cannot occur. And
+                        // all other variants will only occur for paths that
+                        // have already been opened. The previous iteration
+                        // of this code had another event `PathEvent::LocallyClosed` which
+                        // contained a `PathError`, but that was only ever set to
+                        // `ValidationFailed`.
                         let error = PathError::ValidationFailed;
                         sender.send_modify(|value| *value = Err(error));
                     }

--- a/noq/src/endpoint.rs
+++ b/noq/src/endpoint.rs
@@ -368,8 +368,8 @@ impl Endpoint {
 
     /// Waits for all connections on the endpoint to be cleanly shut down and drained.
     ///
-    /// This is equivalent to [`wait_all_draining()`] with additionally waiting for the connections to be
-    /// drained. Please see its documentation for more information.
+    /// This is equivalent to [`wait_all_draining()`] with additionally waiting for the connections
+    /// to be drained. Please see its documentation for more information.
     ///
     /// Use `wait_idle()` in favor of `wait_all_draining()` if you care about waiting for the
     /// [`Connection`] structs to be dropped.
@@ -694,8 +694,7 @@ fn respond(
     // - A version negotiation response due to an unknown version
     // - A `CLOSE` due to a malformed or unwanted connection attempt
     // - A stateless reset due to an unrecognized connection
-    // - A `Retry` packet due to a connection attempt when
-    //   `use_retry` is set
+    // - A `Retry` packet due to a connection attempt when `use_retry` is set
     //
     // In each case, a well-behaved peer can be trusted to retry a
     // few times, which is guaranteed to produce the same response
@@ -720,8 +719,8 @@ fn respond(
         );
         RawWaker::new(std::ptr::null(), &VTABLE)
     };
-    // SAFETY: Copied from rust stdlib, the NOOP waker is thread-safe and doesn't violate the RawWakerVTable contract,
-    // it doesn't access the data pointer at all.
+    // SAFETY: Copied from rust stdlib, the NOOP waker is thread-safe and doesn't violate the
+    // RawWakerVTable contract, it doesn't access the data pointer at all.
     let waker = unsafe { Waker::from_raw(NOOP) };
     let mut cx = Context::from_waker(&waker);
     _ = sender.as_mut().poll_send(
@@ -750,7 +749,8 @@ struct ConnectionSet {
     /// Counter for all active (non-draining/drained) connections.
     ///
     /// This is directly related to the QUIC connection states "Initial", "Handshake",
-    /// "Established", "Closed", "Draining" and "Drained" (see also `proto/src/connection/state.rs`).
+    /// "Established", "Closed", "Draining" and "Drained" (see also
+    /// `proto/src/connection/state.rs`).
     ///
     /// Any connection state that is not "Draining" or "Drained" is considered active.
     ///
@@ -980,7 +980,8 @@ impl RecvState {
                                     }
                                 }
                                 Some(DatagramEvent::ConnectionEvent(handle, event)) => {
-                                    // Ignoring errors from dropped connections that haven't yet been cleaned up
+                                    // Ignoring errors from dropped connections that haven't yet
+                                    // been cleaned up
                                     received_connection_packet = true;
                                     let _ = self
                                         .connections

--- a/noq/src/incoming.rs
+++ b/noq/src/incoming.rs
@@ -102,7 +102,8 @@ impl Incoming {
     /// Decrypt the Initial packet payload
     ///
     /// This clones and decrypts the packet payload (~1200 bytes).
-    /// Can be used to extract information from the TLS ClientHello without completing the handshake.
+    /// Can be used to extract information from the TLS ClientHello without completing the
+    /// handshake.
     pub fn decrypt(&self) -> Option<DecryptedInitial> {
         self.0.as_ref()?.inner.decrypt()
     }

--- a/noq/src/lib.rs
+++ b/noq/src/lib.rs
@@ -129,8 +129,9 @@ fn udp_ecn(ecn: proto::EcnCodepoint) -> udp::EcnCodepoint {
     }
 }
 
-/// Maximum number of datagrams processed in send/recv calls to make before moving on to other
-/// processing
+/// Maximum number of datagrams processed at once in send/recv calls.
+///
+/// This after this the driver moves on to other processing.
 ///
 /// This helps ensure we don't starve anything when the CPU is slower than the link.
 /// Value is selected by picking a low number which didn't degrade throughput in benchmarks.

--- a/noq/src/lib.rs
+++ b/noq/src/lib.rs
@@ -129,7 +129,8 @@ fn udp_ecn(ecn: proto::EcnCodepoint) -> udp::EcnCodepoint {
     }
 }
 
-/// Maximum number of datagrams processed in send/recv calls to make before moving on to other processing
+/// Maximum number of datagrams processed in send/recv calls to make before moving on to other
+/// processing
 ///
 /// This helps ensure we don't starve anything when the CPU is slower than the link.
 /// Value is selected by picking a low number which didn't degrade throughput in benchmarks.

--- a/noq/src/path.rs
+++ b/noq/src/path.rs
@@ -178,11 +178,11 @@ impl Path {
     pub fn stats(&self) -> PathStats {
         // The `expect` is safe:
         // - `Path` can only be created for non-closed paths.
-        // - `Path` and its clones or `WeakPathHandle`s all increment the connection state's `path_ref`
-        //   reference counter
+        // - `Path` and its clones or `WeakPathHandle`s all increment the connection state's
+        //   `path_ref` reference counter
         // - As long as a path is not abandoned, its stats are available from `proto::Connection`
-        // - If a path is abandoned, the `crate::Connection` stores the final stats as long as
-        //   the path's refcount is not 0
+        // - If a path is abandoned, the `crate::Connection` stores the final stats as long as the
+        //   path's refcount is not 0
         // - Therefore, we always get stats here.
         self.conn
             .lock_without_waking("Path::stats")
@@ -298,10 +298,11 @@ impl PartialEq for Path {
 
 /// Weak handle for a [`Path`] that does not keep the connection alive.
 ///
-/// As long as a [`WeakPathHandle`] for a path exists, that path's final stats will not be dropped even if
-/// the path was abandoned.
+/// As long as a [`WeakPathHandle`] for a path exists, that path's final stats will not be dropped
+/// even if the path was abandoned.
 ///
-/// The [`WeakPathHandle`] can be upgraded to a [`Path`] as long as its [`Connection`] has not been dropped.
+/// The [`WeakPathHandle`] can be upgraded to a [`Path`] as long as its [`Connection`] has not been
+/// dropped.
 ///
 /// [`Connection`]: crate::Connection
 #[derive(Debug, Clone)]

--- a/noq/src/recv_stream.rs
+++ b/noq/src/recv_stream.rs
@@ -163,7 +163,8 @@ impl RecvStream {
     /// [`RecvStream::read_chunk`]; use [`bytes_read()`](Self::bytes_read) to query that offset
     /// explicitly.
     ///
-    /// For unordered reads, convert the stream into an unordered stream using [`Self::into_unordered`].
+    /// For unordered reads, convert the stream into an unordered stream using
+    /// [`Self::into_unordered`].
     ///
     /// Slightly more efficient than [`RecvStream::read`] due to not copying. Chunk boundaries do
     /// not correspond to peer writes, and hence cannot be used as framing.

--- a/noq/src/runtime/mod.rs
+++ b/noq/src/runtime/mod.rs
@@ -170,10 +170,11 @@ where
                 this.writable_fut
                     .set(Some((this.make_writable_fut_fn)(this.socket)));
             }
-            // We're forced to `unwrap` here because `Fut` may be `!Unpin`, which means we can't safely
-            // obtain an `&mut WritableFut` after storing it in `self.writable_fut` when `self` is already behind `Pin`,
-            // and if we didn't store it then we wouldn't be able to keep it alive between
-            // `poll_send` calls.
+            // We're forced to `unwrap` here because `Fut` may be `!Unpin`, which means we can't
+            // safely obtain an `&mut WritableFut` after storing it in
+            // `self.writable_fut` when `self` is already behind `Pin`, and if we didn't
+            // store it then we wouldn't be able to keep it alive between `poll_send`
+            // calls.
             let result =
                 std::task::ready!(this.writable_fut.as_mut().as_pin_mut().unwrap().poll(cx));
 
@@ -185,10 +186,10 @@ where
             result?;
 
             match this.socket.try_send(transmit) {
-                // We thought the socket was writable, but it wasn't, then retry so that either another
-                // `writable().await` call determines that the socket is indeed not writable and
-                // registers us for a wakeup, or the send succeeds if this really was just a
-                // transient failure.
+                // We thought the socket was writable, but it wasn't, then retry so that either
+                // another `writable().await` call determines that the socket is
+                // indeed not writable and registers us for a wakeup, or the send
+                // succeeds if this really was just a transient failure.
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => continue,
                 // In all other cases, either propagate the error or we're Ok
                 result => return Poll::Ready(result),

--- a/noq/src/send_stream.rs
+++ b/noq/src/send_stream.rs
@@ -27,8 +27,8 @@ use crate::{
 /// A `write` method is said to be *cancel-safe* when dropping its future before the future becomes
 /// ready will always result in no data being written to the stream. This is true of methods which
 /// succeed immediately when any progress is made, and is not true of methods which might need to
-/// perform multiple writes internally before succeeding. Each `write` method documents whether it is
-/// cancel-safe.
+/// perform multiple writes internally before succeeding. Each `write` method documents whether it
+/// is cancel-safe.
 ///
 /// [`reset()`]: SendStream::reset
 /// [`finish()`]: SendStream::finish
@@ -90,8 +90,8 @@ impl SendStream {
     /// On success, this method both mutates `bufs` and returns the number of bytes written:
     ///
     /// - `bufs` is advanced past chunks that were fully written.
-    /// - If a [`Bytes`] chunk was partially written, the chunk at the new front of `bufs` is
-    ///   [split to](Bytes::split_to) contain only the suffix of bytes that were not written.
+    /// - If a [`Bytes`] chunk was partially written, the chunk at the new front of `bufs` is [split
+    ///   to](Bytes::split_to) contain only the suffix of bytes that were not written.
     ///
     /// # Cancel safety
     ///
@@ -191,8 +191,8 @@ impl SendStream {
             conn.skip_waking();
             match e {
                 FinishError::ClosedStream => Err(ClosedStream::default()),
-                // Harmless. If the application needs to know about stopped streams at this point, it
-                // should call `stopped`.
+                // Harmless. If the application needs to know about stopped streams at this point,
+                // it should call `stopped`.
                 FinishError::Stopped(_) => Ok(()),
             }
         } else {
@@ -253,8 +253,8 @@ impl SendStream {
     /// determine whether the stream was rejected.
     pub fn stopped(&self) -> Stopped {
         let notified = {
-            // Create an `OwnedNotified` to move into the future. By creating it before the first poll,
-            // we make sure that we don't miss any notifications.
+            // Create an `OwnedNotified` to move into the future. By creating it before the first
+            // poll, we make sure that we don't miss any notifications.
             let mut conn = self.conn.lock_without_waking("SendStream::stopped");
             conn.stopped
                 .entry(self.stream)

--- a/noq/src/send_stream.rs
+++ b/noq/src/send_stream.rs
@@ -79,8 +79,9 @@ impl SendStream {
         Ok(())
     }
 
-    /// Writes [`Bytes`] from a slice of buffers into this stream, returning how many bytes were.
-    /// written
+    /// Writes [`Bytes`] from a slice of buffers into this stream.
+    ///
+    /// Returns how many bytes were written.
     ///
     /// Bytes to try to write are provided to this method as an array of cheaply cloneable chunks.
     /// Unless this method errors, it waits until some amount of those bytes can be written into


### PR DESCRIPTION
## Description

This enables the auto-formatting to automatically format and wrap
comments so they do not exceed the length of the code.

This is still an experimental feature it seems, but we've had good
results with the import ordering so this might work out as well.

## Breaking Changes

none

## Notes & open questions

This is quite the bloodbath, probably should have been
expected. Partially I wish we could enable this only for new code but
hey.

I've fixed up the worst things, let me know if there's still anything
else that needs fixing up.

I'd secretly like to set this to 92 rather than 100. But I guess that
would be pushing my personal preferences too far.

It this works we should probably also do this on iroh.

I love the irony that the line in the Makefile.toml is now well over
100 characters long.

I'd prefer to only merge this by consensus, vetos are also accepted.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.