### PR TITLE
chore: Update for rust 1.97

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,8 +5,7 @@ skip_core_tasks = true
 default_to_workspace = false
 
 [env]
-RUSTFLAGS = "-Dwarnings"
-RUSTDOCFLAGS = "-Dwarnings"
+CARGO_BUILD_WARNINGS = "deny"
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 # Workspace members to exclude when setting `workspace = true` for a task.
 # Must live at global env (not task-level) so it's read before workspace iteration
@@ -57,16 +56,25 @@ args = [
 
 [tasks.check]
 description = "Run cargo-check for entire project"
+# Allows us to use CARGO_BUILD_WARNINGS instead of
+# RUSTFLAGS=-Dwarnings which breaks the build cache.
+toolchain = { channel = "stable", min_version = "1.97.0" }
 command = "cargo"
 args = ["check", "--workspace", "--all-features", "--all-targets"]
 
 [tasks.clippy]
 description = "Run cargo-clippy for entire project"
+# Allows us to use CARGO_BUILD_WARNINGS instead of
+# RUSTFLAGS=-Dwarnings which breaks the build cache.
+toolchain = { channel = "stable", min_version = "1.97.0" }
 command = "cargo"
 args = ["clippy", "--workspace", "--all-features", "--all-targets"]
 
 [tasks.doc]
 description = "Check the documentation build"
+# Allows us to use CARGO_BUILD_WARNINGS instead of
+# RUSTDOCFLAGS=-Dwarnings which breaks the build cache.
+toolchain = { channel = "stable", min_version = "1.97.0" }
 command = "cargo"
 args = ["doc", "--workspace", "--all-features", "--no-deps", "--document-private-items"]
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1716,7 +1716,7 @@ impl Connection {
                 pad_datagram |= PadDatagram::ToMinMtu;
             }
 
-            for (path_id, _pn) in builder.sent_frames().largest_acked.iter() {
+            for path_id in builder.sent_frames().largest_acked.keys() {
                 self.spaces[space_id]
                     .for_path(*path_id)
                     .pending_acks

--- a/noq-proto/src/connection/packet_crypto.rs
+++ b/noq-proto/src/connection/packet_crypto.rs
@@ -217,16 +217,11 @@ impl CryptoState {
         } else if packet_key_phase == conn_key_phase || space != SpaceKind::Data {
             let (_, packet) = self.remote_crypto(space.encryption_level()).unwrap();
             packet
-        } else if let Some(prev) = self.prev_crypto.as_ref().and_then(|crypto| {
+        } else if let Some(prev) = self.prev_crypto.as_ref().filter(|crypto| {
             // If this packet comes prior to acknowledgment of the key update by the peer,
-            if crypto.end_packet.is_none_or(|(pn, _)| packet_number < pn) {
-                // use the previous keys.
-                Some(crypto)
-            } else {
-                // Otherwise, this must be a remotely-initiated key update, so fall through to the
-                // final case.
-                None
-            }
+            // use the previous keys. Otherwise this must be a remotely-initiated key update
+            // and we let this fall through to the final case.
+            crypto.end_packet.is_none_or(|(pn, _)| packet_number < pn)
         }) {
             &*prev.crypto.remote
         } else {

--- a/noq/src/recv_stream.rs
+++ b/noq/src/recv_stream.rs
@@ -612,7 +612,7 @@ impl Drop for RecvStream {
                     .blocked_readers
                     .contains_key(&self.stream),
                 "Stream {} should not have a blocked reader when all data read is true",
-                &self.stream
+                self.stream
             );
             return;
         }


### PR DESCRIPTION
## Description

This uses the new CARGO_BUILD_WARNINGS in Makefile.toml so that it no
longer needs to invalidate all of rust's cache for -Dwarnings.

The code changes are new clippy fixes.

## Breaking Changes

none

## Notes & open questions

We're forcing contributors to get the last rust, but that's not that
bad I think. And cargo-make is kind of still optional.

## Change checklist

- [x] Self-review.