### PR TITLE
fix(proto): Fix coalescing loop to avoid coalescing in Initial space

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1732,20 +1732,29 @@ impl Connection {
             // as well.  Because if this is the last packet in the datagram more padding
             // might be needed because of the packet type, or to fill the GSO segment size.
 
+            let max_packet_size = builder
+                .buf
+                .datagram_remaining_mut()
+                .saturating_sub(builder.predict_packet_end());
             // Are we allowed to coalesce AND is there enough space for another *packet* in
             // this datagram AND will we definitely send another packet?
-            if builder.can_coalesce && path_id == PathId::ZERO && {
-                let max_packet_size = builder
-                    .buf
-                    .datagram_remaining_mut()
-                    .saturating_sub(builder.predict_packet_end());
-                max_packet_size > MIN_PACKET_SPACE
-                    && self.has_pending_packet(space_id, max_packet_size, connection_close_pending)
-            } {
+            if builder.can_coalesce
+                && path_id == PathId::ZERO
+                && let Some(next_space_id) = space_id.next()
+                && max_packet_size > MIN_PACKET_SPACE
+                && self.has_pending_packet(next_space_id, max_packet_size, connection_close_pending)
+            {
                 // We can append/coalesce the next packet into the current
                 // datagram. Finish the current packet without adding extra padding.
                 trace!("will coalesce with next packet");
+                let last_pn = builder.packet_number;
                 builder.finish_and_track(now, self, path_id, PadDatagram::No);
+                // We need to return - this loop would re-try the same SpaceId, which we don't want.
+                // We want to coalesce with the next space_id.
+                return PollPathSpaceStatus::WrotePacket {
+                    last_packet_number: last_pn,
+                    pad_datagram,
+                };
             } else {
                 // We need a new datagram for the next packet.  Finish the current
                 // packet with padding.

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -1742,6 +1742,9 @@ impl Connection {
                 && path_id == PathId::ZERO
                 && let Some(next_space_id) = space_id.next()
                 && max_packet_size > MIN_PACKET_SPACE
+                && self
+                    .space_can_send(space_id, path_id, max_packet_size, connection_close_pending)
+                    .is_empty()
                 && self.has_pending_packet(next_space_id, max_packet_size, connection_close_pending)
             {
                 // We can append/coalesce the next packet into the current

--- a/noq-proto/src/endpoint.rs
+++ b/noq-proto/src/endpoint.rs
@@ -730,6 +730,8 @@ impl Endpoint {
         self.clean_up_incoming(&incoming);
         incoming.improper_drop_warner.dismiss();
 
+        trace!(?incoming.network_path, "refusing incoming");
+
         self.initial_close(
             incoming.packet.header.version,
             incoming.network_path,
@@ -745,8 +747,14 @@ impl Endpoint {
     /// Errors if `incoming.may_retry()` is false.
     pub fn retry(&mut self, incoming: Incoming, buf: &mut Vec<u8>) -> Result<Transmit, RetryError> {
         if !incoming.may_retry() {
+            trace!(
+                ?incoming.network_path,
+                "not responding retry on incoming due to missing src CID"
+            );
             return Err(RetryError(Box::new(incoming)));
         }
+
+        trace!(?incoming.network_path, "responding retry on incoming");
 
         self.clean_up_incoming(&incoming);
         incoming.improper_drop_warner.dismiss();
@@ -799,6 +807,8 @@ impl Endpoint {
     pub fn ignore(&mut self, incoming: Incoming) {
         self.clean_up_incoming(&incoming);
         incoming.improper_drop_warner.dismiss();
+
+        trace!(?incoming.network_path, "ignoring incoming");
     }
 
     /// Clean up endpoint data structures associated with an `Incoming`.

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -4617,3 +4617,32 @@ fn recv_bytes(mut recv_stream: crate::RecvStream<'_>, bytes_received: &mut usize
     // The callee needs to immediately pair.step()
     let _ = chunks.finalize();
 }
+
+/// Regression test: coalescing multiple Initial packets with 20-byte CIDs and a
+/// Retry token must not trigger `debug_assert!(max_size >= min_size)` in
+/// `PacketBuilder::new`.
+///
+/// With 20-byte CIDs, each coalesced Initial header is 133 bytes. The coalescing
+/// check only accounted for the `MIN_PACKET_SPACE = 87`, which only covers
+/// Handshake/0-RTT headers.
+#[test]
+fn regression_initial_coalescing_large_cid() {
+    let _guard = subscribe();
+
+    let mut endpoint_config = EndpointConfig::default();
+    endpoint_config.cid_generator(Arc::new(|| Box::new(RandomConnectionIdGenerator::new(20))));
+
+    let mut pair = Pair::new(Arc::new(endpoint_config), server_config());
+    pair.server.handle_incoming = Box::new(validate_incoming);
+    let _client_ch = pair.begin_connect(client_config());
+
+    pair.drive_client();
+    pair.drive_server();
+    pair.drive_client();
+    pair.advance_time();
+    pair.drive_client();
+    pair.drive_server();
+
+    pair.time = pair.time + Duration::from_secs(5);
+    pair.drive_client();
+}

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -4649,6 +4649,6 @@ fn regression_initial_coalescing_large_cid() {
 
     // Trigger loss probes, thus re-sending packets from the Initial space by moving forward
     // in time a bit:
-    pair.time = pair.time + Duration::from_secs(5);
+    pair.time += Duration::from_secs(5);
     pair.drive_client(); // this used to try to build a packet without enough datagram space
 }

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -4618,13 +4618,17 @@ fn recv_bytes(mut recv_stream: crate::RecvStream<'_>, bytes_received: &mut usize
     let _ = chunks.finalize();
 }
 
-/// Regression test: coalescing multiple Initial packets with 20-byte CIDs and a
-/// Retry token must not trigger `debug_assert!(max_size >= min_size)` in
-/// `PacketBuilder::new`.
+/// Regression test for when loss probes were coalesced, causing a `max_size >= min_size`
+/// assert to fail.
 ///
-/// With 20-byte CIDs, each coalesced Initial header is 133 bytes. The coalescing
-/// check only accounted for the `MIN_PACKET_SPACE = 87`, which only covers
-/// Handshake/0-RTT headers.
+/// This test used to send a bunch of Initial packets coalesced together because we
+/// didn't properly advance the space_id when coalescing.
+///
+/// To trigger the actual assertion, 20-byte CIDs and a retry token in the header were used.
+/// The MIN_PACKET_SIZE check doesn't take the retry token in initial packet headers into
+/// account, thus it doesn't properly decide to not coalesce.
+///
+/// To fix this, we properly advance the space_id when coalescing packets.
 #[test]
 fn regression_initial_coalescing_large_cid() {
     let _guard = subscribe();
@@ -4643,6 +4647,8 @@ fn regression_initial_coalescing_large_cid() {
     pair.drive_client();
     pair.drive_server();
 
+    // Trigger loss probes, thus re-sending packets from the Initial space by moving forward
+    // in time a bit:
     pair.time = pair.time + Duration::from_secs(5);
-    pair.drive_client();
+    pair.drive_client(); // this used to try to build a packet without enough datagram space
 }


### PR DESCRIPTION
## Description

- Adds a regression test that triggers the `debug_assert!(max_size >= min_size);` in `packet_builder.rs`
- Fixes the coalescing logic in `poll_transmit_path_space` to not exit the loop & function to go to the next space when coalescing.
- Adds a bunch of useful `trace!` logs to see what the server is doing in response.

## Breaking Changes

None

## Notes & open questions

A bit more on what was going on:
There are two loops for building datagrams: `poll_transmit_on_path`, which goes over `Initial`, `Handshake` and `Data`, as well as `poll_transmit_path_space`, which loops *within* the same space to produce *separate* datagrams (e.g. for producing multiple loss probes as a GSO batch).
The regression test generated a situation where two things were true at the same: The `Initial` space wants to send a small `PATH_ACK` (nothing else), and the `Handshake` space wants to send some `CRYPTO`.
Inside `poll_transmit_path_space` when we were checking for coalescing, we call `self.has_pending_packet`, which iterates through all spaces starting at `Initial`. It's false for `Initial`, but ends up being true for `Handshake`, because that has `CRYPTO` pending.
However, we then keep on looping inside `poll_transmit_path_space`, creating packets again and again in the same `space_id = Initial`, instead of exiting out of the loop to the next space.
Eventually we fill the datagram with enough packets such that the `debug_assert!(max_size >= min_size);` in `packet_builder.rs` triggers, because it doesn't take into account the retry tokens in the QUIC header for `Initial` packets (which I think it shouldn't do? because we should never be coalescing these anyways.).

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
