### PR TITLE
ci: Run daily CI jobs 2 hours earlier

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -5,7 +5,7 @@ name: Beta Rust
 on:
   schedule:
     # 06:50 UTC every Monday
-    - cron: '50 6 * * 1'
+    - cron: '50 4 * * 1'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -6,7 +6,7 @@ name: Daily CI
 on:
   schedule:
     # 06:00 UTC every day
-    - cron: "0 6 * * *"
+    - cron: "0 4 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description

We have a lot of these jobs running way to long into the Europe
day. 04:00 UTC is 23:00 in the latest dev timezone so should be fine.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [x] `cargo make` passes locally.