### PR TITLE
fix(udp): log sendmsg errors on debug

### DIFF
--- a/noq-udp/src/lib.rs
+++ b/noq-udp/src/lib.rs
@@ -198,7 +198,7 @@ fn log_sendmsg_error(
     let last_send_error = &mut *last_send_error.lock().expect("poisend lock");
     if now.saturating_duration_since(*last_send_error) > IO_ERROR_LOG_INTERVAL {
         *last_send_error = now;
-        log::warn!(
+        log::debug!(
             "sendmsg error: {:?}, Transmit: {{ destination: {:?}, src_ip: {:?}, ecn: {:?}, len: {:?}, segment_size: {:?} }}",
             err,
             transmit.destination,


### PR DESCRIPTION
## Description

Because of dualstack hosts that can be on IPv4-only networks getting
errors is very normal. It is a bit strange to emit full on warnings
for these. Telling folks that they just shouldn't be trying to connect
to such an unreachable hosts is also a bit strange. Simply trying this
is the normal thing to do.

Fixes https://github.com/n0-computer/iroh/issues/4345

## Breaking Changes

n/a

## Notes & open questions

It feels a bit odd, but I'm like 99% sure this is the right thing to do.

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [x] `cargo make` passes locally.