### PR TITLE
chore: Run daily CI even two hours earlier

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -5,8 +5,8 @@ name: Daily CI
 
 on:
   schedule:
-    # 06:00 UTC every day
-    - cron: "0 4 * * *"
+    # 02:00 UTC every day
+    - cron: "0 2 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Description

Currently they start finishing at around 9 CEST. Let's move them 2h
earlier.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [x] `cargo make` passes locally.