### PR TITLE
[wip/draft] feat(proto): emit PathEvent::Suspect/Recovered for dying paths

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2656,6 +2656,7 @@ impl Connection {
         stats.rtt = path.data.rtt.get();
         stats.cwnd = path.data.congestion.window();
         stats.current_mtu = path.data.mtud.current_mtu();
+        stats.suspect = path.data.suspect_since_pn.is_some();
         Some(stats)
     }
 
@@ -3033,7 +3034,22 @@ impl Connection {
         // exponential backoff from the PTO timer and would result in too many tail-loss
         // probes being sent.
         if self.peer_completed_handshake_address_validation() {
-            self.path_data_mut(path).pto_count = 0;
+            let path_data = self.path_data_mut(path);
+            path_data.pto_count = 0;
+            // A coalesced ACK can confirm packets sent well before the path went
+            // suspect (see `PathData::suspect_since_pn`); only treat this as
+            // recovery if it also covers something sent since then.
+            if let Some(since) = path_data.suspect_since_pn
+                && newly_acked
+                    .max()
+                    .expect("newly_acked checked non-empty above")
+                    >= since
+            {
+                path_data.suspect_since_pn = None;
+                debug!(%path, "path recovered: ACK received on suspect path");
+                self.events
+                    .push_back(Event::Path(PathEvent::Recovered { id: path }));
+            }
         }
 
         // Explicit congestion notification
@@ -3238,8 +3254,36 @@ impl Connection {
         };
         let pns = self.spaces[space].for_path(path_id);
         pns.loss_probes = pns.loss_probes.saturating_add(count);
-        let path_data = self.path_data_mut(path_id);
-        path_data.pto_count = path_data.pto_count.saturating_add(1);
+        // Handshake-time PTOs include anti-deadlock probes that do not expect
+        // ACKs, and a path that never validated fails via its validation
+        // timeout instead. Only a validated path on an established connection
+        // can become suspect.
+        let established = self.state.is_established();
+        let (validated, pto_count, currently_suspect) = {
+            let path_data = self.path_data_mut(path_id);
+            path_data.pto_count = path_data.pto_count.saturating_add(1);
+            (
+                path_data.validated,
+                path_data.pto_count,
+                path_data.suspect_since_pn.is_some(),
+            )
+        };
+        let became_suspect = established
+            && validated
+            && pto_count >= paths::SUSPECT_PTO_THRESHOLD
+            && !currently_suspect;
+        if became_suspect {
+            // Only an ACK for a packet sent from here on counts as recovery; see
+            // `PathData::suspect_since_pn`.
+            let next_pn = self.spaces[SpaceId::Data]
+                .for_path(path_id)
+                .next_packet_number;
+            let path_data = self.path_data_mut(path_id);
+            path_data.suspect_since_pn = Some(next_pn);
+            debug!(%path_id, "path suspect: consecutive PTOs without an ACK");
+            self.events
+                .push_back(Event::Path(PathEvent::Suspect { id: path_id }));
+        }
         self.set_loss_detection_timer(now, path_id);
     }
 

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3258,18 +3258,29 @@ impl Connection {
         // ACKs, and a path that never validated fails via its validation
         // timeout instead. Only a validated path on an established connection
         // can become suspect.
+        //
+        // Also gated on the path currently being Available: a Backup path
+        // that stops carrying new data (e.g. once a better path takes over)
+        // can still have older in-flight packets whose PTOs keep firing with
+        // nothing sent since to compare against, and keep-alive only covers
+        // gaps going forward from when it's armed, not data already inflight
+        // at the moment the path became idle. None of that reflects the
+        // path's own health, so it must not affect a path we are not
+        // currently relying on.
         let established = self.state.is_established();
-        let (validated, pto_count, currently_suspect) = {
+        let (validated, pto_count, currently_suspect, is_available) = {
             let path_data = self.path_data_mut(path_id);
             path_data.pto_count = path_data.pto_count.saturating_add(1);
             (
                 path_data.validated,
                 path_data.pto_count,
                 path_data.suspect_since_pn.is_some(),
+                path_data.local_status() == PathStatus::Available,
             )
         };
         let became_suspect = established
             && validated
+            && is_available
             && pto_count >= paths::SUSPECT_PTO_THRESHOLD
             && !currently_suspect;
         if became_suspect {

--- a/noq-proto/src/connection/paths.rs
+++ b/noq-proto/src/connection/paths.rs
@@ -239,6 +239,22 @@ pub(super) struct PathData {
     ///
     /// [`LossDetection`]: super::timer::PathTimer::LossDetection
     pub(super) pto_count: u32,
+    /// The Data-space packet number that was about to be sent when this path became
+    /// suspected dead, or `None` when it is not suspect.
+    ///
+    /// Set when [`Self::pto_count`] reaches [`SUSPECT_PTO_THRESHOLD`] and cleared when
+    /// an acknowledgement arrives again, so [`PathEvent::Suspect`] and
+    /// [`PathEvent::Recovered`] are emitted once per transition.
+    ///
+    /// Multipath QUIC lets an ACK for one path be coalesced onto any other path's
+    /// outgoing packet (`PathAck` names the path explicitly, independent of the
+    /// path that carries the frame). A path that has genuinely gone dead can still
+    /// have older, honestly-delivered packets whose ACK was pending and only goes
+    /// out once some other path becomes available. Without this watermark such a
+    /// late, pre-suspect ACK would clear suspect status on a path that will never
+    /// carry anything again. Only an ACK covering a packet sent at or after this
+    /// watermark counts as evidence the path is actually working again.
+    pub(super) suspect_since_pn: Option<u64>,
 
     //
     // Per-path idle & keep alive
@@ -339,6 +355,7 @@ impl PathData {
             status: Default::default(),
             first_packet: None,
             pto_count: 0,
+            suspect_since_pn: None,
             idle_timeout: config.default_path_max_idle_timeout,
             keep_alive: config.default_path_keep_alive_interval,
             permit_idle_reset: true,
@@ -387,6 +404,7 @@ impl PathData {
             status: prev.status.clone(),
             first_packet: None,
             pto_count: 0,
+            suspect_since_pn: None,
             idle_timeout: prev.idle_timeout,
             keep_alive: prev.keep_alive,
             permit_idle_reset: true,
@@ -1040,6 +1058,12 @@ pub enum PathStatus {
     Backup,
 }
 
+/// Number of consecutive PTOs without an acknowledgement after which a path is suspect.
+///
+/// PTO durations back off exponentially, so this reports a dead path within a few
+/// round trips while tolerating a single lost tail-loss probe.
+pub(super) const SUSPECT_PTO_THRESHOLD: u32 = 2;
+
 /// Application events about paths
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1048,6 +1072,26 @@ pub enum PathEvent {
     #[non_exhaustive]
     Established {
         /// The path which can now be used for application data.
+        id: PathId,
+    },
+    /// The path stopped acknowledging data and is suspected dead.
+    ///
+    /// Emitted when [`SUSPECT_PTO_THRESHOLD`] consecutive PTOs fire on the path without
+    /// an acknowledgement. The path is not abandoned: it either recovers (followed by
+    /// [`Self::Recovered`]) or runs into its idle timeout (followed by
+    /// [`Self::Abandoned`]). Applications can use this to steer traffic away from the
+    /// path early and to start looking for alternatives.
+    #[non_exhaustive]
+    Suspect {
+        /// The path that stopped acknowledging data.
+        id: PathId,
+    },
+    /// A suspect path acknowledged data again.
+    ///
+    /// Only emitted after [`Self::Suspect`].
+    #[non_exhaustive]
+    Recovered {
+        /// The path that recovered.
         id: PathId,
     },
     /// A path was abandoned and is no longer usable.

--- a/noq-proto/src/connection/stats.rs
+++ b/noq-proto/src/connection/stats.rs
@@ -248,6 +248,13 @@ pub struct PathStats {
     pub black_holes_detected: u64,
     /// Largest UDP payload size the path currently supports.
     pub current_mtu: u16,
+    /// Whether the path is currently suspected dead.
+    ///
+    /// Set after consecutive PTOs without an acknowledgement, cleared when the path
+    /// acknowledges data again. See [`PathEvent::Suspect`].
+    ///
+    /// [`PathEvent::Suspect`]: crate::PathEvent::Suspect
+    pub suspect: bool,
 }
 
 /// Connection statistics.
@@ -283,6 +290,7 @@ impl std::ops::Add<PathStats> for ConnectionStats {
         // rtt, cwnd and current_mtu fields.
         let PathStats {
             rtt: _,
+            suspect: _,
             udp_tx,
             udp_rx,
             frame_tx,
@@ -316,6 +324,7 @@ impl std::ops::AddAssign<PathStats> for ConnectionStats {
         // rtt, cwnd and current_mtu fields.
         let PathStats {
             rtt: _,
+            suspect: _,
             udp_tx: path_udp_tx,
             udp_rx: path_udp_rx,
             frame_tx: path_frame_tx,

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -869,8 +869,17 @@ fn test_zero_rtt_incoming_limit<F: FnOnce(&mut ServerConfig)>(configure_server: 
         pair.server_conn_mut(server_ch).poll(),
         Some(Event::Connected)
     );
+    // The deferred accept and the buffering limit leave data unacknowledged
+    // for long stretches, so the path oscillates between suspect and
+    // recovered; those events are not what is under test here.
+    let event = loop {
+        match pair.server_conn_mut(server_ch).poll() {
+            Some(Event::Path(PathEvent::Suspect { .. } | PathEvent::Recovered { .. })) => continue,
+            event => break event,
+        }
+    };
     assert_matches!(
-        pair.server_conn_mut(server_ch).poll(),
+        event,
         Some(Event::Stream(StreamEvent::Opened { dir: Dir::Uni }))
     );
 
@@ -1526,6 +1535,12 @@ fn idle_timeout() {
     }
 
     assert!(pair.time - start < Duration::from_millis(2 * IDLE_TIMEOUT));
+    // The ping went unacknowledged, so the path goes suspect before the
+    // connection times out.
+    assert_matches!(
+        pair.client_conn_mut(client_ch).poll(),
+        Some(Event::Path(PathEvent::Suspect { .. }))
+    );
     assert_matches!(
         pair.client_conn_mut(client_ch).poll(),
         Some(Event::ConnectionLost {

--- a/noq/src/connection.rs
+++ b/noq/src/connection.rs
@@ -1710,6 +1710,9 @@ impl State {
                 Path(evt @ PathEvent::RemoteStatus { .. }) => {
                     self.path_events.send(evt).ok();
                 }
+                Path(evt @ (PathEvent::Suspect { .. } | PathEvent::Recovered { .. })) => {
+                    self.path_events.send(evt).ok();
+                }
                 NatTraversal(update) => {
                     self.nat_traversal_updates.send(update).ok();
                 }


### PR DESCRIPTION
## Description

A path that stops acknowledging data currently just keeps accumulating PTOs with no signal to the application or path selector, so a dying path can keep winning path selection on stale RTT samples. This adds a new `PathEvent::Suspect` after it did not receive acks for two consecutive PTOs. The event is not used in noq-proto or noq, but emitted to applications. They can use it for trying to find or establish alternative paths.

This is a draft to explore how iroh can react to a dying relay path if it is the only path left. It uses the new event to trigger address lookup, which might yield a new relay URL, and then can try to open this path.

Waiting for `PATH_ABANDON` does not work here, because if it is the last and only path, the connection dies with it.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the -->
<!-- PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [ ] `cargo make` passes locally.
