### PR TITLE
fix(proto): correctly set per path idle timer

### DIFF
--- a/noq-proto/src/config/transport.rs
+++ b/noq-proto/src/config/transport.rs
@@ -398,7 +398,7 @@ impl TransportConfig {
         self
     }
 
-    /// Sets a default per-path maximum idle timeout
+    /// Sets a default per-path maximum idle timeout.
     ///
     /// If the path is idle for this long the path will be abandoned. Bear in mind this will
     /// interact with the [`TransportConfig::max_idle_timeout`], if the last path is
@@ -406,6 +406,9 @@ impl TransportConfig {
     ///
     /// You can also change this using [`Connection::set_path_max_idle_timeout`] for
     /// existing paths.
+    ///
+    /// The idle timeout will only apply to paths of a multipath-negotiated connection. Before
+    /// multipath is negotiated, only the connection-wide max idle timeout is in effect.   
     ///
     /// [`Connection::set_path_max_idle_timeout`]: crate::Connection::set_path_max_idle_timeout
     pub fn default_path_max_idle_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -848,8 +848,10 @@ impl Connection {
 
     /// Sets the max_idle_timeout for a specific path.
     ///
-    /// The PathIdle timer is immediately re-armed accounting for already-elapsed
-    /// idle time. Setting `None` disables the timeout and stops the timer.
+    /// The path idle timer is immediately re-armed. If there was a timer previously set, re-arming
+    /// will account for elapsed idle time.
+    ///
+    /// Setting `None` disables the timeout and stops the timer.
     ///
     /// See [`TransportConfig::default_path_max_idle_timeout`] for details.
     ///

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -873,7 +873,7 @@ impl Connection {
         // it's likely that the computed value was in the future, and instead of accounting for
         // elapsed idle time, it further extended the timer. Then, for consistency, we simply choose
         // to compute the timer expiration in the same way as if the path had been immediately used.
-        self.sync_path_max_idle_timer(now, self.highest_space, path_id);
+        self.rearm_path_max_idle_timer(now, self.highest_space, path_id);
 
         Ok(prev_timeout)
     }
@@ -885,7 +885,7 @@ impl Connection {
     /// applying the guidance of RFC9000 §10.1 to multipaths.
     ///
     /// The timer only applies for non-closed, multiplath-negotiated connections.
-    fn sync_path_max_idle_timer(&mut self, now: Instant, space: SpaceKind, path_id: PathId) {
+    fn rearm_path_max_idle_timer(&mut self, now: Instant, space: SpaceKind, path_id: PathId) {
         let timer = Timer::PerPath(path_id, PathTimer::PathIdle);
 
         if self.state.is_closed() || !self.is_multipath_negotiated() {
@@ -3854,7 +3854,7 @@ impl Connection {
         }
 
         // Now handle the per-path state.
-        self.sync_path_max_idle_timer(now, space, path_id);
+        self.rearm_path_max_idle_timer(now, space, path_id);
     }
 
     /// Resets both the [`ConnTimer::KeepAlive`] and [`PathTimer::PathKeepAlive`] timers
@@ -4724,7 +4724,7 @@ impl Connection {
                 // Multipath can only be enabled after the state has reached Established.
                 // So this can not happen any earlier.
                 self.issue_first_path_cids(now);
-                self.sync_path_max_idle_timer(now, self.highest_space, path_id);
+                self.rearm_path_max_idle_timer(now, self.highest_space, path_id);
                 Ok(())
             }
             Header::Initial(InitialHeader {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -848,10 +848,8 @@ impl Connection {
 
     /// Sets the max_idle_timeout for a specific path.
     ///
-    /// The path idle timer is immediately re-armed. If there was a timer previously set, re-arming
-    /// will account for elapsed idle time.
-    ///
-    /// Setting `None` disables the timeout and stops the timer.
+    /// If `Some`, the path idle timer is immediately re-armed. Setting `None` disables the timeout
+    /// and stops the timer.
     ///
     /// See [`TransportConfig::default_path_max_idle_timeout`] for details.
     ///
@@ -866,29 +864,30 @@ impl Connection {
             .paths
             .get_mut(&path_id)
             .ok_or(ClosedPath { _private: () })?;
-        let prev = mem::replace(&mut path.data.idle_timeout, timeout);
+        let prev_timeout = mem::replace(&mut path.data.idle_timeout, timeout);
 
-        // Adjust the PathIdle timer, accounting for already-elapsed idle time.
-        if !self.state.is_closed() {
-            if let Some(new_timeout) = timeout {
-                let timer = Timer::PerPath(path_id, PathTimer::PathIdle);
-                let deadline = match (prev, self.timers.get(timer)) {
-                    (Some(old_timeout), Some(old_deadline)) => {
-                        let last_activity = old_deadline.checked_sub(old_timeout).unwrap_or(now);
-                        last_activity + new_timeout
-                    }
-                    _ => now + new_timeout,
-                };
-                self.timers.set(timer, deadline, self.qlog.with_time(now));
-            } else {
-                self.timers.stop(
-                    Timer::PerPath(path_id, PathTimer::PathIdle),
-                    self.qlog.with_time(now),
-                );
-            }
+        self.sync_path_max_idle_timer(now, self.highest_space, path_id);
+
+        Ok(prev_timeout)
+    }
+
+    /// Rearms or stops the state of the [`PathTimer::PathIdle`] based on the configured value in
+    /// [`PathData::idle_timeout`].
+    ///
+    /// The timer only applies for non-closed, multiplath-negotiated connections.
+    fn sync_path_max_idle_timer(&mut self, now: Instant, space: SpaceKind, path_id: PathId) {
+        let timer = Timer::PerPath(path_id, PathTimer::PathIdle);
+
+        if self.state.is_closed() || !self.is_multipath_negotiated() {
+            return self.timers.stop(timer, self.qlog.with_time(now));
         }
 
-        Ok(prev)
+        if let Some(timeout) = self.path_data(path_id).idle_timeout {
+            let dt = cmp::max(timeout, 3 * self.pto(space, path_id));
+            self.timers.set(timer, now + dt, self.qlog.with_time(now));
+        } else {
+            self.timers.stop(timer, self.qlog.with_time(now));
+        }
     }
 
     /// Sets the keep_alive_interval for a specific path
@@ -3824,7 +3823,7 @@ impl Connection {
         }
     }
 
-    /// Resets the idle timeout timers
+    /// Resets the idle timeout timers.
     ///
     /// Without multipath there is only the connection-wide idle timeout. When multipath is
     /// enabled there is an additional per-path idle timeout.
@@ -3844,22 +3843,8 @@ impl Connection {
             }
         }
 
-        // Now handle the per-path state
-        if let Some(timeout) = self.path_data(path_id).idle_timeout {
-            if self.state.is_closed() {
-                self.timers.stop(
-                    Timer::PerPath(path_id, PathTimer::PathIdle),
-                    self.qlog.with_time(now),
-                );
-            } else {
-                let dt = cmp::max(timeout, 3 * self.pto(space, path_id));
-                self.timers.set(
-                    Timer::PerPath(path_id, PathTimer::PathIdle),
-                    now + dt,
-                    self.qlog.with_time(now),
-                );
-            }
-        }
+        // Now handle the per-path state.
+        self.sync_path_max_idle_timer(now, space, path_id);
     }
 
     /// Resets both the [`ConnTimer::KeepAlive`] and [`PathTimer::PathKeepAlive`] timers
@@ -3995,7 +3980,7 @@ impl Connection {
                         initial_max_path_id: None,
                         ..params
                     };
-                    self.set_peer_params(params);
+                    self.set_peer_params(now, params);
                     self.qlog.emit_peer_transport_params_restored(self, now);
                 }
                 Err(e) => {
@@ -6632,13 +6617,13 @@ impl Connection {
             ));
         }
 
-        self.set_peer_params(params);
+        self.set_peer_params(now, params);
         self.qlog.emit_peer_transport_params_received(self, now);
 
         Ok(())
     }
 
-    fn set_peer_params(&mut self, params: TransportParameters) {
+    fn set_peer_params(&mut self, now: Instant, params: TransportParameters) {
         self.streams.set_params(&params);
         self.idle_timeout =
             negotiate_max_idle_timeout(self.config.max_idle_timeout, Some(params.max_idle_timeout));
@@ -6708,6 +6693,7 @@ impl Connection {
         path.pending.observed_address = address_discovery_negotiated;
         path.mtud
             .on_peer_max_udp_payload_size_received(peer_max_udp_payload_size);
+        self.sync_path_max_idle_timer(now, self.highest_space, PathId::ZERO);
     }
 
     /// Decrypts a packet, returning the packet number on success

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -3980,7 +3980,7 @@ impl Connection {
                         initial_max_path_id: None,
                         ..params
                     };
-                    self.set_peer_params(now, params);
+                    self.set_peer_params(params);
                     self.qlog.emit_peer_transport_params_restored(self, now);
                 }
                 Err(e) => {
@@ -4714,6 +4714,7 @@ impl Connection {
                 // Multipath can only be enabled after the state has reached Established.
                 // So this can not happen any earlier.
                 self.issue_first_path_cids(now);
+                self.sync_path_max_idle_timer(now, self.highest_space, path_id);
                 Ok(())
             }
             Header::Initial(InitialHeader {
@@ -6617,13 +6618,13 @@ impl Connection {
             ));
         }
 
-        self.set_peer_params(now, params);
+        self.set_peer_params(params);
         self.qlog.emit_peer_transport_params_received(self, now);
 
         Ok(())
     }
 
-    fn set_peer_params(&mut self, now: Instant, params: TransportParameters) {
+    fn set_peer_params(&mut self, params: TransportParameters) {
         self.streams.set_params(&params);
         self.idle_timeout =
             negotiate_max_idle_timeout(self.config.max_idle_timeout, Some(params.max_idle_timeout));
@@ -6693,7 +6694,6 @@ impl Connection {
         path.pending.observed_address = address_discovery_negotiated;
         path.mtud
             .on_peer_max_udp_payload_size_received(peer_max_udp_payload_size);
-        self.sync_path_max_idle_timer(now, self.highest_space, PathId::ZERO);
     }
 
     /// Decrypts a packet, returning the packet number on success

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -866,6 +866,13 @@ impl Connection {
             .ok_or(ClosedPath { _private: () })?;
         let prev_timeout = mem::replace(&mut path.data.idle_timeout, timeout);
 
+        // The expiration instant of the timer should generally be computed from the last time the
+        // path was active. This reference instance is, however, not possible to be recovered.
+        // Previous attempts used the expiration instant and previous setting to get a "last
+        // activity" instant. Since the timer is extended to 3*PTO to prevent very small timeouts,
+        // it's likely that the computed value was in the future, and instead of accounting for
+        // elapsed idle time, it further extended the timer. Then, for consistency, we simply choose
+        // to compute the timer expiration in the same way as if the path had been immediately used.
         self.sync_path_max_idle_timer(now, self.highest_space, path_id);
 
         Ok(prev_timeout)
@@ -873,6 +880,9 @@ impl Connection {
 
     /// Rearms or stops the state of the [`PathTimer::PathIdle`] based on the configured value in
     /// [`PathData::idle_timeout`].
+    ///
+    /// The timer is extended to 3*PTO if such value is greater than the configured timeout,
+    /// applying the guidance of RFC9000 §10.1 to multipaths.
     ///
     /// The timer only applies for non-closed, multiplath-negotiated connections.
     fn sync_path_max_idle_timer(&mut self, now: Instant, space: SpaceKind, path_id: PathId) {

--- a/noq-proto/src/connection/timer.rs
+++ b/noq-proto/src/connection/timer.rs
@@ -294,6 +294,7 @@ impl TimerTable {
         qlog.emit_timer_set(timer, time);
     }
 
+    #[allow(unused)]
     pub(super) fn get(&self, timer: Timer) -> Option<Instant> {
         match timer {
             Timer::Conn(timer) => self.generic[timer as usize],


### PR DESCRIPTION
## Description

This PR fixes a couple bugs: setting per path idle timers before multipath is negotiated, inconsistent calculation of the timer, and misleading docs based on wrong assumptions.

The timer arm/stop logic from `set_path_max_idle_timeout` and `reset_idle_timeout` is moved into a single shared helper, `rearm_path_max_idle_timer`, which now also enforces that the per-path idle timer only applies once multipath has been negotiated. The previous logic that re-armed the timer by accounting for already-elapsed idle time based on the old deadline/timeout is also removed. This assumed the timer had been set to `now + timeout`, which is very likely not true. The real instant in which the timer was set, and the path was thus last used is irrecoverable. Docs are adjusted to account for the changes.

`TimerTable::get` is marked `#[allow(unused)]` since it's no longer in use. We might want to remove it later if it remains dead code.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist
<!-- Remove any that are not relevant. -->
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intended effect.
- [x] `cargo make` passes locally.
