### PR TITLE
feat(udp): support wasm32-wasip2

### DIFF
--- a/noq-udp/build.rs
+++ b/noq-udp/build.rs
@@ -30,7 +30,7 @@ fn main() {
         apple_fast: { all(apple, feature = "fast-apple-datapath") },
         apple_slow: { all(apple, not(feature = "fast-apple-datapath")) },
         wasm_browser: { all(target_family = "wasm", target_os = "unknown") },
-        // Unix-family platforms that lack advanced socket APIs (cmsg, recvmmsg, etc.)
-        posix_minimal: { target_os = "espidf" },
+        // Platforms that lack advanced socket APIs (cmsg, recvmmsg, etc.)
+        posix_minimal: { any(target_os = "espidf", target_os = "wasi") },
     }
 }

--- a/noq-udp/src/lib.rs
+++ b/noq-udp/src/lib.rs
@@ -29,8 +29,8 @@
 
 use core::time::Duration;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
-#[cfg(unix)]
-use std::os::unix::io::AsFd;
+#[cfg(any(unix, target_os = "wasi"))]
+use std::os::fd::AsFd;
 #[cfg(windows)]
 use std::os::windows::io::AsSocket;
 #[cfg(not(wasm_browser))]
@@ -216,13 +216,13 @@ fn log_sendmsg_error(_: &Mutex<Instant>, _: impl core::fmt::Debug, _: &Transmit<
 
 /// A borrowed UDP socket
 ///
-/// On Unix, constructible via `From<T: AsFd>`. On Windows, constructible via `From<T:
+/// On Unix and WASI, constructible via `From<T: AsFd>`. On Windows, constructible via `From<T:
 /// AsSocket>`.
 // Wrapper around socket2 to avoid making it a public dependency and incurring stability risk
 #[cfg(not(wasm_browser))]
 pub struct UdpSockRef<'a>(socket2::SockRef<'a>);
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 impl<'s, S> From<&'s S> for UdpSockRef<'s>
 where
     S: AsFd,

--- a/noq-udp/src/posix_minimal.rs
+++ b/noq-udp/src/posix_minimal.rs
@@ -4,6 +4,11 @@ use std::{
     sync::Mutex,
     time::Instant,
 };
+#[cfg(target_os = "wasi")]
+use std::{
+    mem::{ManuallyDrop, MaybeUninit},
+    os::fd::{AsRawFd, FromRawFd},
+};
 
 use super::{IO_ERROR_LOG_INTERVAL, RecvMeta, Transmit, UdpSockRef, log_sendmsg_error};
 
@@ -18,6 +23,17 @@ pub struct UdpSocketState {
 
 impl UdpSocketState {
     pub fn new(socket: UdpSockRef<'_>) -> io::Result<Self> {
+        // socket2 uses `fcntl(F_SETFL, O_NONBLOCK)`, which WASI rejects; `std` uses
+        // `ioctl(FIONBIO)`, which it accepts.
+        #[cfg(target_os = "wasi")]
+        {
+            // Safety: `socket` outlives the borrow, and `ManuallyDrop` prevents a double close.
+            let borrowed = ManuallyDrop::new(unsafe {
+                std::net::UdpSocket::from_raw_fd(socket.0.as_raw_fd())
+            });
+            borrowed.set_nonblocking(true)?;
+        }
+        #[cfg(not(target_os = "wasi"))]
         socket.0.set_nonblocking(true)?;
         let now = Instant::now();
         Ok(Self {
@@ -59,14 +75,26 @@ impl UdpSocketState {
         bufs: &mut [IoSliceMut<'_>],
         meta: &mut [RecvMeta],
     ) -> io::Result<usize> {
-        // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
-        // same layout, that of `iovec`/`WSABUF`. Furthermore `recv_vectored`
-        // promises to not write uninitialised bytes to the `bufs` and pass it
-        // directly to the `recvmsg` system call, so this is safe.
-        let bufs = unsafe {
-            &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [socket2::MaybeUninitSlice<'_>])
+        // No vectored reads on WASI, and `BATCH_SIZE` is 1 regardless.
+        #[cfg(target_os = "wasi")]
+        let (len, addr) = {
+            // Safety: `MaybeUninit<u8>` shares `u8`'s layout, and `recv_from` initialises the
+            // prefix it reports as filled.
+            let buf = unsafe { &mut *(&mut *bufs[0] as *mut [u8] as *mut [MaybeUninit<u8>]) };
+            socket.0.recv_from(buf)?
         };
-        let (len, _flags, addr) = socket.0.recv_from_vectored(bufs)?;
+        #[cfg(not(target_os = "wasi"))]
+        let (len, addr) = {
+            // Safety: both `IoSliceMut` and `MaybeUninitSlice` promise to have the
+            // same layout, that of `iovec`/`WSABUF`. Furthermore `recv_vectored`
+            // promises to not write uninitialised bytes to the `bufs` and pass it
+            // directly to the `recvmsg` system call, so this is safe.
+            let bufs = unsafe {
+                &mut *(bufs as *mut [IoSliceMut<'_>] as *mut [socket2::MaybeUninitSlice<'_>])
+            };
+            let (len, _flags, addr) = socket.0.recv_from_vectored(bufs)?;
+            (len, addr)
+        };
         meta[0] = RecvMeta {
             len,
             stride: len,


### PR DESCRIPTION
## Description

Extends `posix_minimal` to `wasm32-wasip2` and makes that backend build there.

- `UdpSockRef`'s descriptor-based constructor was `cfg(unix)`; `std::os::fd::AsFd` covers
  unix and wasi alike.
- `recv` uses `recv_from`: wasi has no vectored read, and `BATCH_SIZE` is 1 regardless.
- `set_nonblocking` goes through `std`. socket2 uses `fcntl(F_SETFL, O_NONBLOCK)`, which
  WASI rejects; `std` uses `ioctl(FIONBIO)`, which it accepts.

espidf is unaffected, verified with the CI line:

``` bash
cargo check -Z build-std=std,panic_abort --target riscv32imc-esp-espidf -p noq-udp --no-default-features
```

Fixes #772.

## Breaking Changes

None.

## Notes & open questions

- The alias comment read "Unix-family platforms"; WASI is not one, so it now reads "Platforms". A separate alias or a rename may suit you better - happy to change it.
- The integration suite builds and runs on wasip2 under wasmtime: `basic`, `basic_src_ip` and `socket_buffers` pass, `gso` is ignored as it is elsewhere. That would be the first executable coverage `posix_minimal` has had, since the espidf job is `cargo check`. Not included here - it needs a blocking helper spanning unix/windows/wasi, because `set_nonblocking(false)` in the tests hits the same `fcntl` problem, plus a decision on gating the four ECN tests. Happy to open it separately.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [x] `cargo make` passes locally.
