### PR TITLE
fix(udp): use unaligned cmsg payload access for musl

### DIFF
--- a/noq-udp/src/cmsg/mod.rs
+++ b/noq-udp/src/cmsg/mod.rs
@@ -41,9 +41,7 @@ impl<'a, M: MsgHdr> Encoder<'a, M> {
     ///
     /// # Panics
     /// - If insufficient buffer space remains.
-    /// - If `T` has stricter alignment requirements than `M::ControlMessage`
     pub(crate) fn push<T: Copy>(&mut self, level: c_int, ty: c_int, value: T) {
-        assert!(align_of::<T>() <= align_of::<M::ControlMessage>());
         let space = M::ControlMessage::cmsg_space(size_of_val(&value));
         assert!(
             self.hdr.control_len() >= self.len + space,
@@ -54,7 +52,8 @@ impl<'a, M: MsgHdr> Encoder<'a, M> {
         let cmsg = self.cmsg.take().expect("no control buffer space remaining");
         cmsg.set(level, ty, M::ControlMessage::cmsg_len(size_of_val(&value)));
         unsafe {
-            ptr::write(cmsg.cmsg_data() as *const T as *mut T, value);
+            // Unaligned: `align_of::<M::ControlMessage>()` is 4 on musl.
+            ptr::write_unaligned(cmsg.cmsg_data() as *const T as *mut T, value);
         }
         self.len += space;
         self.cmsg = unsafe { self.hdr.cmsg_nxt_hdr(cmsg).as_mut() };
@@ -78,9 +77,10 @@ impl<M: MsgHdr> Drop for Encoder<'_, M> {
 ///
 /// `cmsg` must refer to a native cmsg containing a payload of type `T`
 pub(crate) unsafe fn decode<T: Copy, C: CMsgHdr>(cmsg: &impl CMsgHdr) -> T {
-    assert!(align_of::<T>() <= align_of::<C>());
     debug_assert_eq!(cmsg.len(), C::cmsg_len(size_of::<T>()));
-    unsafe { ptr::read(cmsg.cmsg_data() as *const T) }
+    // Unaligned: `align_of::<libc::cmsghdr>()` is 4 on musl, but payloads such as
+    // `libc::timespec` (SCM_TIMESTAMPNS) need 8.
+    unsafe { ptr::read_unaligned(cmsg.cmsg_data() as *const T) }
 }
 
 pub(crate) struct Iter<'a, M: MsgHdr> {


### PR DESCRIPTION
## Description
Fixes #774.

Drops the two alignment asserts in `cmsg/mod.rs` and uses unaligned access:
- [`decode()`](https://github.com/n0-computer/noq/blob/5cf07f4830270ca2262e6e2f0c190dab54936c5a/noq-udp/src/cmsg/mod.rs#L80-L84) `ptr::read` → `ptr::read_unaligned`. This is the reachable bug.
- [`Encoder::push()`](https://github.com/n0-computer/noq/blob/5cf07f4830270ca2262e6e2f0c190dab54936c5a/noq-udp/src/cmsg/mod.rs#L46) `ptr::write` → `ptr::write_unaligned`, same assert removed.

On x86-64 and aarch64 these lower to the same instructions when the address is aligned, so there is no cost.

Verified on `aarch64-unknown-linux-musl`.
Before: `0 passed / 9 failed`
After: `9 passed / 0 failed`.

## Breaking Changes
None.

## Notes & open questions
- `Encoder::push` is **latent, not reachable today** - every pushed type is align ≤ 4, so its assert never fires. Fixed for symmetry. Happy to drop it if you would rather keep the diff to the live bug.
- Alternative fix: keep an assert but compare against the 8-byte alignment `Aligned<T>` actually enforces, rather than `align_of::<C>()`. I went with `read_unaligned` since it stops depending on that invariant, but I am happy to switch.
- Should CI gain a musl target? Note a `cargo check` job would **not** catch this, because it is a runtime panic. It needs `cargo test --target x86_64-unknown-linux-musl`, which runs natively on the Ubuntu runners with `musl-tools` installed. Glad to add it here or as a follow-up.

## Change checklist
- [X] Self-review.
- [X] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [X] Tests if relevant.
- [X] All breaking changes documented.
- [X] This PR was created by a human that thought critically about the proposed change and wrote an as clear and concise description as they could.
- [X] This PR isn't slop, and is carefully crafted to do have the intented effect.
- [X] `cargo make` passes locally.
