### PR TITLE
fix(udp): Disable SO_TIMESTAMPNS for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,22 +64,33 @@ jobs:
       - name: Build and test noq-udp (posix_minimal)
         run: cargo test --locked -p noq-udp
 
-  test_musl_arm64:
-    name: Test aarch64-unknown-linux-musl
+  test_musl:
+    name: Test ${{ matrix.target }}
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     timeout-minutes: 30
-    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Each target runs on a runner of its own architecture, so the tests
+          # run natively rather than under emulation.
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     env:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
-      # When cross-compiling to musl, cc-rs looks for `aarch64-linux-musl-gcc`,
+      # When cross-compiling to musl, cc-rs looks for `<arch>-linux-musl-gcc`,
       # but `musl-tools` only ships the host-native `musl-gcc`.
       CC_aarch64_unknown_linux_musl: musl-gcc
+      CC_x86_64_unknown_linux_musl: musl-gcc
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          target: aarch64-unknown-linux-musl
+          target: ${{ matrix.target }}
       - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install musl toolchain
         run: |
@@ -90,10 +101,10 @@ jobs:
         with:
           tool: nextest@0.9.80
       # The musl binaries are statically linked, so they run as-is on the
-      # aarch64 runner; no emulation or test runner needed.
+      # runner; no emulation or test runner needed.
       - name: Run tests
         run: |
-          cargo nextest run --locked --workspace --exclude fuzz --lib --bins --tests --target aarch64-unknown-linux-musl --profile ci
+          cargo nextest run --locked --workspace --exclude fuzz --lib --bins --tests --target ${{ matrix.target }} --profile ci
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Each target runs on a runner of its own architecture, so the tests
-          # run natively rather than under emulation.
+          # musl binaries are statically linked, and each target runs on a runner
+          # of its own architecture, so the tests run natively.
           - target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-musl
@@ -100,8 +100,6 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.80
-      # The musl binaries are statically linked, so they run as-is on the
-      # runner; no emulation or test runner needed.
       - name: Run tests
         run: |
           cargo nextest run --locked --workspace --exclude fuzz --lib --bins --tests --target ${{ matrix.target }} --profile ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,39 @@ jobs:
       - name: Build and test noq-udp (posix_minimal)
         run: cargo test --locked -p noq-udp
 
+  test_musl_arm64:
+    name: Test aarch64-unknown-linux-musl
+    if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04-arm
+    env:
+      RUSTC_WRAPPER: "sccache"
+      SCCACHE_GHA_ENABLED: "on"
+      # When cross-compiling to musl, cc-rs looks for `aarch64-linux-musl-gcc`,
+      # but `musl-tools` only ships the host-native `musl-gcc`.
+      CC_aarch64_unknown_linux_musl: musl-gcc
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: aarch64-unknown-linux-musl
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.80
+      # The musl binaries are statically linked, so they run as-is on the
+      # aarch64 runner; no emulation or test runner needed.
+      - name: Run tests
+        run: |
+          cargo nextest run --locked --workspace --exclude fuzz --lib --bins --tests --target aarch64-unknown-linux-musl --profile ci
+        env:
+          RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+
   esp32_check:
     name: ESP32-C3 build check (noq-udp, noq-proto, noq)
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"

--- a/noq-udp/src/unix.rs
+++ b/noq-udp/src/unix.rs
@@ -136,11 +136,12 @@ impl UdpSocketState {
                 gro_segments = NonZeroUsize::new(64).expect("known");
             }
 
-            if let Err(_err) =
-                set_socket_option(&*io, libc::SOL_SOCKET, libc::SO_TIMESTAMPNS, OPTION_ON)
-            {
-                crate::log::debug!("Ignoring error setting SO_TIMESTAMPNS on socket: {_err:?}");
-            }
+            // Disable SO_TIMESTAMPNS for now: https://github.com/n0-computer/noq/issues/774
+            // if let Err(_err) =
+            //     set_socket_option(&*io, libc::SOL_SOCKET, libc::SO_TIMESTAMPNS, OPTION_ON)
+            // {
+            //     crate::log::debug!("Ignoring error setting SO_TIMESTAMPNS on socket: {_err:?}");
+            // }
         }
         #[cfg(any(target_os = "freebsd", apple))]
         {

--- a/noq-udp/tests/tests.rs
+++ b/noq-udp/tests/tests.rs
@@ -473,25 +473,27 @@ fn test_send_recv(send: &Socket, recv: &Socket, transmit: Transmit<'_>) {
             assert_eq!(meta.ecn, transmit.ecn);
         }
 
+        // Disable SO_TIMESTAMPNS for now: https://github.com/n0-computer/noq/issues/774
+        assert!(meta.timestamp.is_none());
         // On Linux and Android, we expect the kernel to provide a receive timestamp
         // since we explicitly enabled `SO_TIMESTAMPNS`.
-        #[cfg(all(any(target_os = "linux", target_os = "android"), not(posix_minimal)))]
-        {
-            assert!(
-                meta.timestamp.is_some(),
-                "Kernel timestamp should be present on Linux/Android"
-            );
-            assert!(
-                meta.timestamp.unwrap() > std::time::Duration::ZERO,
-                "Kernel timestamp should be non-zero"
-            );
-        }
+        // #[cfg(all(any(target_os = "linux", target_os = "android"), not(posix_minimal)))]
+        // {
+        //     assert!(
+        //         meta.timestamp.is_some(),
+        //         "Kernel timestamp should be present on Linux/Android"
+        //     );
+        //     assert!(
+        //         meta.timestamp.unwrap() > std::time::Duration::ZERO,
+        //         "Kernel timestamp should be non-zero"
+        //     );
+        // }
 
-        // On other platforms, the timestamp should remain `None`.
-        #[cfg(not(any(target_os = "linux", target_os = "android", posix_minimal)))]
-        {
-            assert!(meta.timestamp.is_none());
-        }
+        // // On other platforms, the timestamp should remain `None`.
+        // #[cfg(not(any(target_os = "linux", target_os = "android", posix_minimal)))]
+        // {
+        //     assert!(meta.timestamp.is_none());
+        // }
     }
     assert_eq!(datagrams, expected_datagrams);
 }


### PR DESCRIPTION
## Description

We do not rely on this, and the implementation is broken on musl.

Fixes #774.


## Breaking Changes

n/a

## Notes & open questions

We need to run tests on musl in CI somehow.

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [x] `cargo make` passes locally.