### PR TITLE
fix(proto): ignore coalesced datagram tail for unknown path

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4160,8 +4160,13 @@ impl Connection {
         ecn: Option<EcnCodepoint>,
         data: BytesMut,
     ) {
-        self.path_data_mut(path_id)
-            .inc_total_recvd(data.len() as u64);
+        let Some(path) = self.paths.get_mut(&path_id) else {
+            // Handling the first packet of this datagram may have removed the path, so the
+            // coalesced remainder can no longer assume it exists.
+            trace!(%path_id, "discarding coalesced datagram tail for unknown path");
+            return;
+        };
+        path.data.inc_total_recvd(data.len() as u64);
         let mut remaining = Some(data);
         let cid_len = self
             .local_cid_state

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4161,8 +4161,12 @@ impl Connection {
         data: BytesMut,
     ) {
         let Some(path) = self.paths.get_mut(&path_id) else {
-            // Handling the first packet of this datagram may have removed the path, so the
-            // coalesced remainder can no longer assume it exists.
+            // An unknown path id reaches here because `early_discard_packet` does not cover
+            // it: the handshake guard needs `is_handshaking()`, and the discarded-path guard
+            // needs the id to be in `abandoned_paths`. An id that was never opened is in
+            // neither map, so the datagram proceeds. `process_decrypted_packet` then drops
+            // the first packet through its own unknown-path check, but the coalesced
+            // remainder must not assume that lookup succeeded.
             trace!(%path_id, "discarding coalesced datagram tail for unknown path");
             return;
         };

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -4161,12 +4161,6 @@ impl Connection {
         data: BytesMut,
     ) {
         let Some(path) = self.paths.get_mut(&path_id) else {
-            // An unknown path id reaches here because `early_discard_packet` does not cover
-            // it: the handshake guard needs `is_handshaking()`, and the discarded-path guard
-            // needs the id to be in `abandoned_paths`. An id that was never opened is in
-            // neither map, so the datagram proceeds. `process_decrypted_packet` then drops
-            // the first packet through its own unknown-path check, but the coalesced
-            // remainder must not assume that lookup succeeded.
             trace!(%path_id, "discarding coalesced datagram tail for unknown path");
             return;
         };

--- a/noq-proto/src/connection/state.rs
+++ b/noq-proto/src/connection/state.rs
@@ -3,7 +3,9 @@ use tracing::trace;
 
 use crate::frame::Close;
 use crate::shared::EndpointEventInner;
-use crate::{ApplicationClose, ConnectionClose, ConnectionError, TransportError, TransportErrorCode};
+use crate::{
+    ApplicationClose, ConnectionClose, ConnectionError, TransportError, TransportErrorCode,
+};
 
 #[allow(unreachable_pub)] // fuzzing only
 #[derive(Debug, Clone)]

--- a/noq-proto/src/connection/state.rs
+++ b/noq-proto/src/connection/state.rs
@@ -3,9 +3,7 @@ use tracing::trace;
 
 use crate::frame::Close;
 use crate::shared::EndpointEventInner;
-use crate::{
-    ApplicationClose, ConnectionClose, ConnectionError, TransportError, TransportErrorCode,
-};
+use crate::{ApplicationClose, ConnectionClose, ConnectionError, TransportError, TransportErrorCode};
 
 #[allow(unreachable_pub)] // fuzzing only
 #[derive(Debug, Clone)]

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -24,9 +24,9 @@ use tracing::info;
 use crate::{
     AckFrequencyConfig, ApplicationClose, ClientConfig, Connection, ConnectionClose,
     ConnectionError, ConnectionEvent, ConnectionHandle, DEFAULT_SUPPORTED_VERSIONS, Datagram,
-    DatagramEvent, Dir, Duration, Endpoint, EndpointConfig, Event, FinishError, FourTuple,
-    HashedConnectionIdGenerator, Instant, MIN_INITIAL_SIZE, PathEvent, PathId, PathStatus,
-    ReadError, ReadableError, RecvStream, SendDatagramError, ServerConfig,
+    DatagramEvent, Dir, Duration, EcnCodepoint, Endpoint, EndpointConfig, Event, FinishError,
+    FourTuple, HashedConnectionIdGenerator, Instant, MIN_INITIAL_SIZE, PathEvent, PathId,
+    PathStatus, ReadError, ReadableError, RecvStream, SendDatagramError, ServerConfig,
     Side::*,
     StreamEvent, Transmit, TransportConfig, TransportErrorCode, VarInt, WriteError,
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
@@ -1340,9 +1340,39 @@ fn initial_retransmit() {
     );
 }
 
-#[test]
-fn stale_coalesced_datagram_after_path_discard_is_ignored() {
-    let _guard = subscribe();
+/// A coalesced handshake datagram captured before the client finished connecting, together
+/// with the metadata needed to replay it as a [`DatagramConnectionEvent`].
+struct CoalescedDatagram {
+    first_decode: PartialDecode,
+    remaining: Option<BytesMut>,
+    ecn: Option<EcnCodepoint>,
+    remote: SocketAddr,
+    dst_ip: Option<IpAddr>,
+}
+
+impl CoalescedDatagram {
+    /// Replays the datagram on `path_id`, as if it had just arrived from the network.
+    fn replay(self, pair: &mut ConnPair, path_id: PathId) {
+        let now = pair.time;
+        pair.conn_mut(Client)
+            .handle_event(ConnectionEvent(ConnectionEventInner::Datagram(
+                DatagramConnectionEvent {
+                    now,
+                    network_path: FourTuple {
+                        remote: self.remote,
+                        local_ip: self.dst_ip,
+                    },
+                    path_id,
+                    ecn: self.ecn,
+                    first_decode: self.first_decode,
+                    remaining: self.remaining,
+                },
+            )));
+    }
+}
+
+/// Connects a multipath pair, capturing a coalesced handshake datagram on the way.
+fn connect_capturing_coalesced_datagram() -> (ConnPair, CoalescedDatagram) {
     let (mut pair, client_cfg) = ConnPair::builder().enable_multipath().build_pair();
 
     let client_ch = pair.begin_connect(client_cfg);
@@ -1351,7 +1381,7 @@ fn stale_coalesced_datagram_after_path_discard_is_ignored() {
 
     let cid_parser =
         FixedLengthConnectionIdParser::new(RandomConnectionIdGenerator::default().cid_len());
-    let (first_decode, remaining, ecn, remote, dst_ip) = pair
+    let datagram = pair
         .client
         .inbound
         .iter()
@@ -1365,13 +1395,13 @@ fn stale_coalesced_datagram_after_path_discard_is_ignored() {
                 return None;
             };
 
-            remaining.is_some().then_some((
+            remaining.is_some().then_some(CoalescedDatagram {
                 first_decode,
                 remaining,
-                inbound.ecn,
-                inbound.remote,
-                inbound.dst_ip,
-            ))
+                ecn: inbound.ecn,
+                remote: inbound.remote,
+                dst_ip: inbound.dst_ip,
+            })
         })
         .expect("server should have queued a coalesced handshake datagram for client");
 
@@ -1379,7 +1409,15 @@ fn stale_coalesced_datagram_after_path_discard_is_ignored() {
     let server_ch = pair.server.assert_accept();
     pair.finish_connect(client_ch, server_ch);
 
-    let mut pair = ConnPair::new(pair, client_ch, server_ch);
+    (ConnPair::new(pair, client_ch, server_ch), datagram)
+}
+
+
+#[test]
+fn stale_coalesced_datagram_after_path_discard_is_ignored() {
+    let _guard = subscribe();
+    let (mut pair, datagram) = connect_capturing_coalesced_datagram();
+
     let path_id = pair
         .open_path(
             Client,
@@ -1398,21 +1436,7 @@ fn stale_coalesced_datagram_after_path_discard_is_ignored() {
         "path 0 should have been discarded"
     );
 
-    let now = pair.time;
-    pair.conn_mut(Client)
-        .handle_event(ConnectionEvent(ConnectionEventInner::Datagram(
-            DatagramConnectionEvent {
-                now,
-                network_path: FourTuple {
-                    remote,
-                    local_ip: dst_ip,
-                },
-                path_id: PathId::ZERO,
-                ecn,
-                first_decode,
-                remaining,
-            },
-        )));
+    datagram.replay(&mut pair, PathId::ZERO);
 }
 
 #[test]

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1412,6 +1412,23 @@ fn connect_capturing_coalesced_datagram() -> (ConnPair, CoalescedDatagram) {
     (ConnPair::new(pair, client_ch, server_ch), datagram)
 }
 
+#[test]
+fn coalesced_datagram_for_never_opened_path_is_ignored() {
+    // A coalesced datagram whose path id is in neither `paths` nor `abandoned_paths`:
+    // `early_discard_packet` only covers the abandoned case, and while the first packet is
+    // dropped by the unknown-path guard in `process_decrypted_packet`, the coalesced
+    // remainder previously reached `path_data_mut(..).expect("known path")` and panicked.
+    let _guard = subscribe();
+    let (mut pair, datagram) = connect_capturing_coalesced_datagram();
+
+    let never_opened = PathId::from(7u32);
+    assert!(
+        !pair.paths(Client).contains(&never_opened),
+        "path 7 must not exist"
+    );
+
+    datagram.replay(&mut pair, never_opened);
+}
 
 #[test]
 fn stale_coalesced_datagram_after_path_discard_is_ignored() {

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1349,7 +1349,7 @@ struct CoalescedDatagram {
 }
 
 impl CoalescedDatagram {
-    fn to_connection_event(self, now: Instant, path_id: PathId) -> ConnectionEvent {
+    fn into_connection_event(self, now: Instant, path_id: PathId) -> ConnectionEvent {
         ConnectionEvent(ConnectionEventInner::Datagram(DatagramConnectionEvent {
             now,
             network_path: FourTuple {
@@ -1417,7 +1417,7 @@ fn coalesced_datagram_for_never_opened_path_is_ignored() {
 
     let now = pair.time;
     pair.conn_mut(Client)
-        .handle_event(datagram.to_connection_event(now, never_opened));
+        .handle_event(datagram.into_connection_event(now, never_opened));
 }
 
 #[test]
@@ -1445,7 +1445,7 @@ fn stale_coalesced_datagram_after_path_discard_is_ignored() {
 
     let now = pair.time;
     pair.conn_mut(Client)
-        .handle_event(datagram.to_connection_event(now, PathId::ZERO));
+        .handle_event(datagram.into_connection_event(now, PathId::ZERO));
 }
 
 #[test]

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1351,23 +1351,22 @@ struct CoalescedDatagram {
 }
 
 impl CoalescedDatagram {
-    /// Replays the datagram on `path_id`, as if it had just arrived from the network.
-    fn replay(self, pair: &mut ConnPair, path_id: PathId) {
-        let now = pair.time;
-        pair.conn_mut(Client)
-            .handle_event(ConnectionEvent(ConnectionEventInner::Datagram(
-                DatagramConnectionEvent {
-                    now,
-                    network_path: FourTuple {
-                        remote: self.remote,
-                        local_ip: self.dst_ip,
-                    },
-                    path_id,
-                    ecn: self.ecn,
-                    first_decode: self.first_decode,
-                    remaining: self.remaining,
-                },
-            )));
+    /// Builds the [`ConnectionEvent`] this datagram would arrive as on `path_id`.
+    ///
+    /// Deliberately does NOT call `handle_event` itself: the point of the tests below is
+    /// that a *public* API call panics, so that call stays visible in each test body.
+    fn to_connection_event(self, now: Instant, path_id: PathId) -> ConnectionEvent {
+        ConnectionEvent(ConnectionEventInner::Datagram(DatagramConnectionEvent {
+            now,
+            network_path: FourTuple {
+                remote: self.remote,
+                local_ip: self.dst_ip,
+            },
+            path_id,
+            ecn: self.ecn,
+            first_decode: self.first_decode,
+            remaining: self.remaining,
+        }))
     }
 }
 
@@ -1414,10 +1413,19 @@ fn connect_capturing_coalesced_datagram() -> (ConnPair, CoalescedDatagram) {
 
 #[test]
 fn coalesced_datagram_for_never_opened_path_is_ignored() {
-    // A coalesced datagram whose path id is in neither `paths` nor `abandoned_paths`:
-    // `early_discard_packet` only covers the abandoned case, and while the first packet is
-    // dropped by the unknown-path guard in `process_decrypted_packet`, the coalesced
-    // remainder previously reached `path_data_mut(..).expect("known path")` and panicked.
+    // A path id in NEITHER `paths` nor `abandoned_paths`.
+    //
+    // `early_discard_packet` has two guards and neither covers this: the handshake guard
+    // needs `is_handshaking()`, and the discarded-path guard needs the id to be in
+    // `abandoned_paths`. A never-opened id is in neither map, so the packet proceeds; the
+    // first packet is then dropped by the unknown-path guard in `process_decrypted_packet`,
+    // while the coalesced remainder used to reach `path_data_mut(..).expect("known path")`
+    // and panic.
+    //
+    // The receiver does not read the path id off the wire: the endpoint looks it up as
+    // `connection_ids[dst_cid]` (endpoint.rs), so which path a datagram is attributed to is
+    // local state, not something the sender chose. That is why replaying the datagram under
+    // a different id is a faithful model of the receive path rather than a fabricated input.
     let _guard = subscribe();
     let (mut pair, datagram) = connect_capturing_coalesced_datagram();
 
@@ -1427,7 +1435,9 @@ fn coalesced_datagram_for_never_opened_path_is_ignored() {
         "path 7 must not exist"
     );
 
-    datagram.replay(&mut pair, never_opened);
+    let now = pair.time;
+    pair.conn_mut(Client)
+        .handle_event(datagram.to_connection_event(now, never_opened));
 }
 
 #[test]
@@ -1453,7 +1463,9 @@ fn stale_coalesced_datagram_after_path_discard_is_ignored() {
         "path 0 should have been discarded"
     );
 
-    datagram.replay(&mut pair, PathId::ZERO);
+    let now = pair.time;
+    pair.conn_mut(Client)
+        .handle_event(datagram.to_connection_event(now, PathId::ZERO));
 }
 
 #[test]

--- a/noq-proto/src/tests/mod.rs
+++ b/noq-proto/src/tests/mod.rs
@@ -1340,8 +1340,6 @@ fn initial_retransmit() {
     );
 }
 
-/// A coalesced handshake datagram captured before the client finished connecting, together
-/// with the metadata needed to replay it as a [`DatagramConnectionEvent`].
 struct CoalescedDatagram {
     first_decode: PartialDecode,
     remaining: Option<BytesMut>,
@@ -1351,10 +1349,6 @@ struct CoalescedDatagram {
 }
 
 impl CoalescedDatagram {
-    /// Builds the [`ConnectionEvent`] this datagram would arrive as on `path_id`.
-    ///
-    /// Deliberately does NOT call `handle_event` itself: the point of the tests below is
-    /// that a *public* API call panics, so that call stays visible in each test body.
     fn to_connection_event(self, now: Instant, path_id: PathId) -> ConnectionEvent {
         ConnectionEvent(ConnectionEventInner::Datagram(DatagramConnectionEvent {
             now,
@@ -1370,7 +1364,6 @@ impl CoalescedDatagram {
     }
 }
 
-/// Connects a multipath pair, capturing a coalesced handshake datagram on the way.
 fn connect_capturing_coalesced_datagram() -> (ConnPair, CoalescedDatagram) {
     let (mut pair, client_cfg) = ConnPair::builder().enable_multipath().build_pair();
 
@@ -1413,19 +1406,6 @@ fn connect_capturing_coalesced_datagram() -> (ConnPair, CoalescedDatagram) {
 
 #[test]
 fn coalesced_datagram_for_never_opened_path_is_ignored() {
-    // A path id in NEITHER `paths` nor `abandoned_paths`.
-    //
-    // `early_discard_packet` has two guards and neither covers this: the handshake guard
-    // needs `is_handshaking()`, and the discarded-path guard needs the id to be in
-    // `abandoned_paths`. A never-opened id is in neither map, so the packet proceeds; the
-    // first packet is then dropped by the unknown-path guard in `process_decrypted_packet`,
-    // while the coalesced remainder used to reach `path_data_mut(..).expect("known path")`
-    // and panic.
-    //
-    // The receiver does not read the path id off the wire: the endpoint looks it up as
-    // `connection_ids[dst_cid]` (endpoint.rs), so which path a datagram is attributed to is
-    // local state, not something the sender chose. That is why replaying the datagram under
-    // a different id is a faithful model of the receive path rather than a fabricated input.
     let _guard = subscribe();
     let (mut pair, datagram) = connect_capturing_coalesced_datagram();
 


### PR DESCRIPTION
## Description

Fixes #781.

`handle_coalesced` accounts for the datagram with `path_data_mut(path_id)`, which panics via `expect("known path")`.

Nothing upstream of it guarantees the path exists. `early_discard_packet` only drops a datagram when the path id is in `abandoned_paths`, so a path id that is in neither `paths` nor `abandoned_paths` passes both guards. The first packet of such a datagram is then handled gracefully by the unknown-path check in `process_decrypted_packet`, but the coalesced remainder reaches `handle_coalesced` and panics.

The remainder is now discarded instead, matching that existing unknown-path handling.

The new test `coalesced_datagram_for_never_opened_path_is_ignored` covers exactly that case: it replays a captured coalesced datagram under a path id that was never opened. It panics at `mod.rs:4163` without the fix and passes with it. The existing `stale_coalesced_datagram_after_path_discard_is_ignored` covers the abandoned-path case and stays green either way, so the two tests do not overlap.

The connect-and-capture setup was inlined in the existing test, so it is extracted first (`connect_capturing_coalesced_datagram`, `CoalescedDatagram::into_connection_event`) and both tests share it.

## Breaking Changes

None.

## Change checklist

- [x] Self-review.
- [x] Tests if relevant.
- [x] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [x] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
