### PR TITLE
fix(proto): canonicalize remote IP in early_discard_packet's peer check (noq#738)

### DIFF
--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2334,7 +2334,8 @@ impl Connection {
             // physical-interface-bound socket is handed to noq via an abstract socket).
             // Canonicalize both sides' IPs before comparing so this doesn't spuriously
             // trip the "unrecognized peer" discard.
-            let remote_matches = network_path.remote.port() == known_path.network_path.remote.port()
+            let remote_matches = network_path.remote.port()
+                == known_path.network_path.remote.port()
                 && network_path.remote.ip().to_canonical()
                     == known_path.network_path.remote.ip().to_canonical();
             if !remote_matches && !peer_may_probe {

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2327,7 +2327,17 @@ impl Connection {
         // forbids migration, drop the datagram. This could be relaxed to heuristically
         // permit NAT-rebinding-like migration.
         if let Some(known_path) = self.path_mut(path_id) {
-            if network_path.remote != known_path.network_path.remote && !peer_may_probe {
+            // noq#738: like the local_ip comparison below, dual-stack sockets can report
+            // the remote peer's address as an IPv4-mapped-IPv6 address (`::ffff:a.b.c.d`)
+            // on one side of this comparison and a plain IPv4 address on the other,
+            // depending on how the underlying fd was created (observed on Android when a
+            // physical-interface-bound socket is handed to noq via an abstract socket).
+            // Canonicalize both sides' IPs before comparing so this doesn't spuriously
+            // trip the "unrecognized peer" discard.
+            let remote_matches = network_path.remote.port() == known_path.network_path.remote.port()
+                && network_path.remote.ip().to_canonical()
+                    == known_path.network_path.remote.ip().to_canonical();
+            if !remote_matches && !peer_may_probe {
                 trace!(
                     %path_id,
                     %network_path,

--- a/noq-proto/src/connection/mod.rs
+++ b/noq-proto/src/connection/mod.rs
@@ -2339,7 +2339,15 @@ impl Connection {
 
             if known_path.network_path.local_ip.is_some()
                 && network_path.local_ip.is_some()
-                && known_path.network_path.local_ip != network_path.local_ip
+                && known_path
+                    .network_path
+                    .local_ip
+                    .as_ref()
+                    .map(std::net::IpAddr::to_canonical)
+                    != network_path
+                        .local_ip
+                        .as_ref()
+                        .map(std::net::IpAddr::to_canonical)
                 && !local_ip_may_migrate
             {
                 trace!(

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -2336,11 +2336,14 @@ fn open_path_with_explicit_local_ip() -> TestResult {
         addr
     };
 
-    pair.routes = ManyToManyRouting::from_routes(
-        vec![(first_client_addr, 0), (second_client_addr, 1)],
-        vec![(server_addr, 0), (server_addr, 1)],
-    )
-    .into();
+    // `ManyToManyRouting::from_routes` rejects duplicate interface addresses
+    // (added by #721, after this test was originally written), which trips on
+    // the same `server_addr` appearing twice. `add_client_route`/`add_server_route`
+    // don't have that check, so build the same routing table incrementally instead.
+    let mut routing = ManyToManyRouting::simple_symmetric([first_client_addr], [server_addr]);
+    routing.add_client_route(second_client_addr, 0);
+    routing.add_server_route(server_addr, 1);
+    pair.routes = routing.into();
 
     // Open a path with an explicit local_ip, targeting the same server as
     // the initial connection (path 0).

--- a/noq-proto/src/tests/multipath.rs
+++ b/noq-proto/src/tests/multipath.rs
@@ -1,6 +1,6 @@
 //! Tests for multipath
 
-use std::net::SocketAddr;
+use std::net::{Ipv6Addr, SocketAddr};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::time::Duration;
@@ -2290,6 +2290,77 @@ fn regression_discarded_path_stats_are_up_to_date() -> TestResult {
     // After a full handshake + MTU probing on the second path, these must be non-zero.
     assert_ne!(discarded_stats.cwnd, 0);
     assert_ne!(discarded_stats.current_mtu, 0);
+
+    Ok(())
+}
+
+/// Regression test for issue #738.
+///
+/// When a client opens a new path with an explicit `local_ip` set in the
+/// [`FourTuple`], the path should validate successfully.  On real devices the
+/// `PATH_RESPONSE` was never matched to the outstanding `PATH_CHALLENGE` on
+/// such paths, causing them to be abandoned with
+/// [`PathAbandonReason::ValidationFailed`].
+///
+/// This test sets up a routing table where the client has a second interface
+/// that can reach the *same* server address as the initial connection, and
+/// opens a path on that second interface with an explicit `local_ip`.
+///
+/// See <https://github.com/n0-computer/noq/issues/738>
+#[test]
+fn open_path_with_explicit_local_ip() -> TestResult {
+    let _guard = subscribe();
+    let mut pair = ConnPair::builder().enable_multipath().connect();
+
+    // Set up routing with a second client interface that can reach the same
+    // server as the first interface.  Both server routes point to the same
+    // server address but link to different client interfaces, so the server
+    // can respond on either client interface.
+    let first_client_addr = pair.routes.as_basic().client_addr;
+    let server_addr = pair.routes.as_basic().server_addr;
+    let second_client_addr = {
+        let mut addr = first_client_addr;
+        if let SocketAddr::V6(v6) = &mut addr {
+            let s = v6.ip().segments();
+            v6.set_ip(Ipv6Addr::new(
+                s[0],
+                s[1],
+                s[2],
+                s[3],
+                s[4],
+                s[5],
+                s[6],
+                s[7] + 1,
+            ));
+        }
+        addr
+    };
+
+    pair.routes = ManyToManyRouting::from_routes(
+        vec![(first_client_addr, 0), (second_client_addr, 1)],
+        vec![(server_addr, 0), (server_addr, 1)],
+    )
+    .into();
+
+    // Open a path with an explicit local_ip, targeting the same server as
+    // the initial connection (path 0).
+    let new_path = FourTuple {
+        local_ip: Some(second_client_addr.ip()),
+        remote: server_addr,
+    };
+    let path_id = pair.open_path(Client, new_path, PathStatus::Available)?;
+    pair.drive();
+
+    // The path should be established on both sides, not abandoned with
+    // ValidationFailed.
+    assert_matches!(
+        pair.poll(Client),
+        Some(Event::Path(crate::PathEvent::Established { id })) if id == path_id
+    );
+    assert_matches!(
+        pair.poll(Server),
+        Some(Event::Path(crate::PathEvent::Established { id })) if id == path_id
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Closes #738.

## Problem

`4bae6edd` (the hotfix posted in #738) canonicalizes the **`local_ip`**
comparison in `Connection::early_discard_packet`, to handle dual-stack
sockets that report a peer as an IPv4-mapped-IPv6 address
(`::ffff:a.b.c.d`) on one side of the comparison and a plain IPv4 address
on the other. We applied it and confirmed on a real Android device
(WiFi + cellular) that it is **not sufficient on its own** — `open_path()`
with an explicit `local_ip` still gets abandoned with `ValidationFailed`.

The **`remote`** comparison a few lines above the one `4bae6edd` touches
has the exact same problem, and is not canonicalized:

```rust
if network_path.remote != known_path.network_path.remote && !peer_may_probe {
```

An incoming datagram's reported remote `SocketAddr` can compare unequal
to the known path's remote purely due to mapped-vs-plain representation,
so `early_discard_packet` silently drops every packet on that path before
it ever reaches `PATH_RESPONSE` / frame processing — same failure mode as
the `local_ip` bug, just one comparison earlier in the same function.

## Fix

Mirror the existing `local_ip` fix: canonicalize both sides of the
`remote` comparison with `IpAddr::to_canonical()` before comparing.

This is the minimal, surgical fix — one comparison site, matching the
style of `4bae6edd`. See #784 for an alternative that canonicalizes
once at `FourTuple::new()` construction time instead, which also covers
a few other latent comparison sites (`Endpoint`'s
`HashMap<FourTuple, ConnectionHandle>` routing table,
`is_probably_same_path`, PATH_CHALLENGE on-path detection, OBSERVED_ADDRESS
matching, peer migration detection) that weren't yet observed failing in
our testing but share the same root cause.

## Testing

- Includes the regression test from the `noq-738` branch
  (`noq-proto/src/tests/multipath.rs::open_path_with_explicit_local_ip`),
  adapted to build its `ManyToManyRouting` via `add_client_route`/
  `add_server_route` instead of `from_routes` — `from_routes` now rejects
  the duplicate `server_addr` this test intentionally uses (invariant
  added by #721 after the regression test was originally written).
  Fails on unpatched `main`, passes with this fix.
- `cargo test -p noq-proto`: 388 passed, 0 failed (full suite, not just
  the new test).
- Verified on a real Android device: `Secondary` (`local_ip: None`)
  established, then `PhysicalWifi`/`PhysicalCellular` (`local_ip`
  explicit) both validate on the **first** attempt instead of retrying
  3x and getting abandoned:
  ```
  opening path "physical-wifi" -> <redacted>:45823 (local_ip=Some(192.168.10.80), attempt 1/3)
  path "physical-wifi" established: id=PathId(2)
  opening path "physical-cellular" -> <redacted>:45823 (local_ip=Some(10.209.235.90), attempt 1/3)
  path "physical-cellular" established: id=PathId(3)
  ```