### PR TITLE
ci(secruity): ensure locked cargo files and dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,8 @@ updates:
       github-actions:
         patterns:
           - "*"  # Group all Actions updates into a single larger pull request
-    # Supply-chain hardening: never propose a release until it has been public
-    # long enough for a compromised publish to be noticed and pulled. A typical
-    # registry compromise is live for well under a day before it is yanked.
-    #
-    # 3 days currently matches Dependabot's own default, but we set it
-    # explicitly so the value is ours and does not move if that default does.
-    #
-    # `default-days` is the only cooldown key supported for github-actions;
-    # the semver-* keys are not.
-    #
-    # Cooldown applies to *version* updates only -- Dependabot *security*
-    # updates ignore it, so real advisories are never delayed by this.
+    # Let a compromised publish be noticed before we propose it. Applies to
+    # version updates only -- security updates ignore the cooldown.
     cooldown:
       default-days: 7
     schedule:
@@ -30,10 +20,6 @@ updates:
       timezone: "America/New_York"
   - package-ecosystem: cargo
     directory: /
-    # See the note above: 3 days of public exposure on crates.io before a
-    # version is eligible for a PR.
-    # `semver-{major,minor,patch}-days` are also supported here if we ever want
-    # to hold major bumps back longer than patches.
     cooldown:
       default-days: 7
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,20 @@ updates:
       github-actions:
         patterns:
           - "*"  # Group all Actions updates into a single larger pull request
+    # Supply-chain hardening: never propose a release until it has been public
+    # long enough for a compromised publish to be noticed and pulled. A typical
+    # registry compromise is live for well under a day before it is yanked.
+    #
+    # 3 days currently matches Dependabot's own default, but we set it
+    # explicitly so the value is ours and does not move if that default does.
+    #
+    # `default-days` is the only cooldown key supported for github-actions;
+    # the semver-* keys are not.
+    #
+    # Cooldown applies to *version* updates only -- Dependabot *security*
+    # updates ignore it, so real advisories are never delayed by this.
+    cooldown:
+      default-days: 3
     schedule:
       interval: weekly
       day: "thursday"
@@ -16,6 +30,12 @@ updates:
       timezone: "America/New_York"
   - package-ecosystem: cargo
     directory: /
+    # See the note above: 3 days of public exposure on crates.io before a
+    # version is eligible for a PR.
+    # `semver-{major,minor,patch}-days` are also supported here if we ever want
+    # to hold major bumps back longer than patches.
+    cooldown:
+      default-days: 3
     schedule:
       interval: weekly
       day: "thursday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
     # Cooldown applies to *version* updates only -- Dependabot *security*
     # updates ignore it, so real advisories are never delayed by this.
     cooldown:
-      default-days: 3
+      default-days: 7
     schedule:
       interval: weekly
       day: "thursday"
@@ -35,7 +35,7 @@ updates:
     # `semver-{major,minor,patch}-days` are also supported here if we ever want
     # to hold major bumps back longer than patches.
     cooldown:
-      default-days: 3
+      default-days: 7
     schedule:
       interval: weekly
       day: "thursday"

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -12,6 +12,10 @@ concurrency:
   group: beta-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: './.github/workflows/tests.yaml'
@@ -25,14 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract test results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          printf '${{ toJSON(needs) }}\n'
-          result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
+          printf '%s\n' "$NEEDS_JSON"
+          result=$(echo "$NEEDS_JSON" | jq -r .tests.result)
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
 
       - name: Notify discord on failure
-        uses: n0-computer/discord-webhook-notify@v1
+        uses: n0-computer/discord-webhook-notify@1399c1b2d57cc05894d506d2cfdc33c5f012b993 # v1.1.1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           severity: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           components: rust-src
       - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Check noq for ESP32-C3
-        run: cargo check -Z build-std=std,panic_abort --target riscv32imc-esp-espidf -p noq -p noq-proto -p noq-udp --no-default-features
+        run: cargo check --locked -Z build-std=std,panic_abort --target riscv32imc-esp-espidf -p noq -p noq-proto -p noq-udp --no-default-features
 
   wasm_test:
     name: Build & test wasm32
@@ -213,13 +213,13 @@ jobs:
       - name: Install cargo-ndk
         run: |
           if ! cargo ndk --version 2>/dev/null | grep -q "3.5.4"; then
-            cargo install --version 3.5.4 cargo-ndk
+            cargo install --locked --version 3.5.4 cargo-ndk
           fi
 
       - name: Build
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        run: cargo ndk --target ${{ matrix.target }} build
+        run: cargo ndk --target ${{ matrix.target }} build --locked
 
   android_emulator_test:
     name: Android Emulator Tests
@@ -265,14 +265,14 @@ jobs:
       - name: Install cargo-ndk
         run: |
           if ! cargo ndk --version 2>/dev/null | grep -q "3.5.4"; then
-            cargo install --version 3.5.4 cargo-ndk
+            cargo install --locked --version 3.5.4 cargo-ndk
           fi
 
       - name: Build unit tests for Android
         env:
           RUSTC_WRAPPER: "sccache"
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        run: cargo ndk -t ${{ matrix.target }} test --no-run
+        run: cargo ndk -t ${{ matrix.target }} test --locked --no-run
 
       - name: Enable KVM group perms
         run: |
@@ -299,9 +299,16 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install --locked cargo-fuzz
+      # `cargo fuzz build` has no --locked/--offline/--frozen flag of its own,
+      # so pin the dependency set the only way it allows: fetch exactly what
+      # Cargo.lock names, then deny the build any network access at all.
+      - name: Fetch locked dependencies
+        run: cargo fetch --locked
       - name: Build fuzz targets
         run: cargo +nightly fuzz build
+        env:
+          CARGO_NET_OFFLINE: "true"
 
   check_fmt:
     timeout-minutes: 30
@@ -335,13 +342,13 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: noq docs-rs
-        run: cargo docs-rs -p noq
+        run: cargo docs-rs --locked -p noq
       - name: noq-proto docs-rs
-        run: cargo docs-rs -p noq-proto
+        run: cargo docs-rs --locked -p noq-proto
       - name: noq-udp docs-rs
-        run: cargo docs-rs -p noq-udp
+        run: cargo docs-rs --locked -p noq-udp
       - name: noq internal docs
-        run: cargo doc --workspace --no-deps --document-private-items
+        run: cargo doc --locked --workspace --no-deps --document-private-items
 
   clippy_check:
     timeout-minutes: 30
@@ -359,13 +366,13 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: clippy check (all features)
-        run: cargo clippy --workspace --exclude fuzz --all-features --all-targets --lib --bins --tests --benches --examples -- -D warnings
+        run: cargo clippy --locked --workspace --exclude fuzz --all-features --all-targets --lib --bins --tests --benches --examples -- -D warnings
 
       - name: clippy check (no features)
-        run: cargo clippy --workspace --exclude fuzz --no-default-features --all-targets --lib --bins --tests --benches --examples -- -D warnings
+        run: cargo clippy --locked --workspace --exclude fuzz --no-default-features --all-targets --lib --bins --tests --benches --examples -- -D warnings
 
       - name: clippy check (default features)
-        run: cargo clippy --workspace --exclude fuzz --all-targets --lib --bins --tests --benches --examples -- -D warnings
+        run: cargo clippy --locked --workspace --exclude fuzz --all-targets --lib --bins --tests --benches --examples -- -D warnings
 
   msrv:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
@@ -385,7 +392,7 @@ jobs:
 
       - name: Check MSRV all features
         run: |
-          cargo +$MSRV check --workspace --exclude fuzz --all-targets
+          cargo +$MSRV check --locked --workspace --exclude fuzz --all-targets
 
   external_types:
     runs-on: ubuntu-latest
@@ -408,6 +415,10 @@ jobs:
       - uses: taiki-e/install-action@cargo-make
       - name: Install cargo-check-external-types
         run: cargo binstall cargo-check-external-types@${{ env.CARGO_CHECK_EXTERNAL_TYPES_VERSION }} --locked --no-confirm
+      # Known gap: cargo-check-external-types exposes no --locked,
+      # --offline or --frozen flag, so this step can still re-resolve.
+      # It runs a pinned tool version against a pinned nightly, and the
+      # Dependabot cooldown covers the dependency side.
       - name: Check external types
         run: cargo make check-external-types
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ env:
   MSRV: "1.88"
   SCCACHE_CACHE_SIZE: "10G"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: CI Test Suite
@@ -34,11 +38,15 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       # Go is required for FIPS builds
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "stable"
       # Prevent feature unification from selecting *ring* as the crypto provider
@@ -58,9 +66,13 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
       RUSTFLAGS: "-Dwarnings --cfg posix_minimal"
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Build and test noq-udp (posix_minimal)
         run: cargo test --locked -p noq-udp
 
@@ -87,17 +99,20 @@ jobs:
       CC_aarch64_unknown_linux_musl: musl-gcc
       CC_x86_64_unknown_linux_musl: musl-gcc
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
           target: ${{ matrix.target }}
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Install musl toolchain
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
         with:
           tool: nextest@0.9.80
       - name: Run tests
@@ -115,11 +130,18 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
+      # Pinned: nightly-2026-07-30 and later fail to build std for espidf --
+      # rust-lang/rust#158168 landed set_permissions_nofollow, which references
+      # libc::AT_FDCWD, and libc does not define it for that target.
+      # Unpin once libc catches up. Same fix as n0-computer/net-tools#202.
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly-2026-07-29
           components: rust-src
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Check noq for ESP32-C3
         run: cargo check --locked -Z build-std=std,panic_abort --target riscv32imc-esp-espidf -p noq -p noq-proto -p noq-udp --no-default-features
 
@@ -133,20 +155,24 @@ jobs:
       AR_wasm32_unknown_unknown: llvm-ar
       RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Install LLVM tools for wasm
         run: |
           sudo apt-get update
           sudo apt-get install -y llvm clang lld
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
       - run: rustup target add wasm32-unknown-unknown
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 20
-      - uses: bytecodealliance/actions/wasm-tools/setup@v1
-      - uses: cargo-bins/cargo-binstall@v1.16.3
+      - uses: bytecodealliance/actions/wasm-tools/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
+      - uses: cargo-bins/cargo-binstall@8110b3aa84cb581a90696bc57469b0656f972494 # v1.16.3
 
       - name: wasm32 test build (noq-proto)
         run: cargo test --locked -p noq-proto --target wasm32-unknown-unknown --no-run
@@ -184,27 +210,30 @@ jobs:
           - armv7-linux-androideabi
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          toolchain: stable
           target: ${{ matrix.target }}
 
       - name: Install rustup target
         run: rustup target add ${{ matrix.target }}
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
       - name: Setup Android NDK
-        uses: arqu/setup-ndk@main
+        uses: arqu/setup-ndk@4f8a02c22e2c17ff9ebba9026e599da847aa8374 # main
         id: setup-ndk
         with:
           ndk-version: r23
@@ -237,26 +266,29 @@ jobs:
       API_LEVEL: ${{ matrix.api-level }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          toolchain: stable
           target: ${{ matrix.target }}
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
 
       - name: Setup Android NDK
-        uses: arqu/setup-ndk@main
+        uses: arqu/setup-ndk@4f8a02c22e2c17ff9ebba9026e599da847aa8374 # main
         id: setup-ndk
         with:
           ndk-version: r23
@@ -284,7 +316,7 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: ${{ matrix.api-level }}
           arch: ${{ matrix.emulator-arch }}
@@ -296,8 +328,12 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly
       - name: Install cargo-fuzz
         run: cargo install --locked cargo-fuzz
       # `cargo fuzz build` has no --locked/--offline/--frozen flag of its own,
@@ -318,13 +354,21 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
           components: rustfmt
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - uses: taiki-e/install-action@cargo-make
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: cargo-make
       - run: cargo make format-check
+      - name: Lockfile must not have moved
+        # cargo make takes no --locked; assert the lockfile instead.
+        run: git diff --exit-code Cargo.lock
 
   check_docs:
     timeout-minutes: 30
@@ -335,11 +379,15 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
       RUSTDOCFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: dtolnay/install@cargo-docs-rs
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly
+      - uses: dtolnay/install@982daea0f5d846abc3c83e01a6a1d73c040047c1 # cargo-docs-rs
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: noq docs-rs
         run: cargo docs-rs --locked -p noq
@@ -358,12 +406,15 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
           components: clippy
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: clippy check (all features)
         run: cargo clippy --locked --workspace --exclude fuzz --all-features --all-targets --lib --bins --tests --benches --examples -- -D warnings
@@ -383,12 +434,14 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.MSRV }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Check MSRV all features
         run: |
@@ -399,26 +452,30 @@ jobs:
     env:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
-      # Pin to the nightly that the pinned `cargo-check-external-types`
-      # release was last tested against. Update both together.
-      CARGO_CHECK_EXTERNAL_TYPES_VERSION: "0.4.0"
-      TOOLCHAIN: "nightly-2025-10-18"
+      # Temporarily built from our fork, which adds --locked passthrough
+      # (awslabs/cargo-check-external-types#251). Revert to `cargo binstall
+      # cargo-check-external-types@<version>` once that is merged and released.
+      # The toolchain is the one the fork's rust-toolchain.toml pins; update
+      # both together.
+      CARGO_CHECK_EXTERNAL_TYPES_REV: "ebc3670edce4f62ad1be7622a5654172ce0c6ffd"
+      TOOLCHAIN: "nightly-2026-03-20"
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.TOOLCHAIN }}
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.18.1
-      - uses: taiki-e/install-action@cargo-make
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: cargo-make
       - name: Install cargo-check-external-types
-        run: cargo binstall cargo-check-external-types@${{ env.CARGO_CHECK_EXTERNAL_TYPES_VERSION }} --locked --no-confirm
-      # Known gap: cargo-check-external-types exposes no --locked,
-      # --offline or --frozen flag, so this step can still re-resolve.
-      # It runs a pinned tool version against a pinned nightly, and the
-      # Dependabot cooldown covers the dependency side.
+        # Pinned to a rev, not a branch -- same rule as every other ref here.
+        run: |
+          cargo install --locked --git https://github.com/dignifiedquire/cargo-check-external-types \
+            --rev ${{ env.CARGO_CHECK_EXTERNAL_TYPES_REV }} cargo-check-external-types
       - name: Check external types
         run: cargo make check-external-types
 
@@ -427,8 +484,10 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           arguments: --workspace --all-features
           command: check
@@ -438,9 +497,11 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Cache pip
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pip
           key: pip-codespell-2.4.1
@@ -453,18 +514,19 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       # Go is required for FIPS builds
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "stable"
 
       - name: Check semver
-        # uses: obi1kenobi/cargo-semver-checks-action@v2
-        uses: n0-computer/cargo-semver-checks-action@feat-baseline
+        # uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
+        uses: n0-computer/cargo-semver-checks-action@b49de9133f8849bb51cae32c6bdeb19a5c37e61f # feat-baseline
         with:
           package: noq, noq-proto, noq-udp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,8 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
-      # Pinned: nightly-2026-07-30 and later fail to build std for espidf --
-      # rust-lang/rust#158168 landed set_permissions_nofollow, which references
-      # libc::AT_FDCWD, and libc does not define it for that target.
-      # Unpin once libc catches up. Same fix as n0-computer/net-tools#202.
+      # Pinned: nightly-2026-07-30+ fails to build std for espidf, libc has no
+      # AT_FDCWD there. Unpin once libc catches up (n0-computer/net-tools#202).
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-07-29
@@ -336,9 +334,8 @@ jobs:
           toolchain: nightly
       - name: Install cargo-fuzz
         run: cargo install --locked cargo-fuzz
-      # `cargo fuzz build` has no --locked/--offline/--frozen flag of its own,
-      # so pin the dependency set the only way it allows: fetch exactly what
-      # Cargo.lock names, then deny the build any network access at all.
+      # `cargo fuzz build` takes no --locked: fetch what Cargo.lock names,
+      # then build offline.
       - name: Fetch locked dependencies
         run: cargo fetch --locked
       - name: Build fuzz targets
@@ -452,11 +449,9 @@ jobs:
     env:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
-      # Temporarily built from our fork, which adds --locked passthrough
-      # (awslabs/cargo-check-external-types#251). Revert to `cargo binstall
-      # cargo-check-external-types@<version>` once that is merged and released.
-      # The toolchain is the one the fork's rust-toolchain.toml pins; update
-      # both together.
+      # Fork adds --locked passthrough (awslabs/cargo-check-external-types#251);
+      # back to binstall once released. TOOLCHAIN mirrors the fork's
+      # rust-toolchain.toml -- bump both together.
       CARGO_CHECK_EXTERNAL_TYPES_REV: "ebc3670edce4f62ad1be7622a5654172ce0c6ffd"
       TOOLCHAIN: "nightly-2026-03-20"
     steps:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -12,6 +12,10 @@ concurrency:
   group: cleanup-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   clean_docs_branch:
     timeout-minutes: 45
@@ -21,9 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: generated-docs-preview
+          # stays on: this job pushes with a bare `git push`
+          persist-credentials: true
 
       - name: Clean docs branch
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,7 +29,7 @@ jobs:
         #       | grep -vFx -e 'default' -e 'aws-lc-rs-fips' \
         #       | paste -sd ',' -
         run: |
-          cargo llvm-cov \
+          cargo llvm-cov --locked \
             --features="arbitrary,aws-lc-rs,bloom,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-log,rustls,ring,serde,serde_json,tracing,tracing-log" \
             --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: ['main']
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   coverage:
     timeout-minutes: 5
@@ -14,9 +18,15 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: cargo-llvm-cov
       - shell: bash
         # Run llvm-cov _without_ the "aws-lc-rs-fips" feature, since
         # that has complex build requirements:
@@ -33,7 +43,7 @@ jobs:
             --features="arbitrary,aws-lc-rs,bloom,fast-apple-datapath,futures-io,json-output,lock_tracking,log,platform-verifier,qlog,ring,runtime-smol,runtime-tokio,rustls,rustls-log,rustls,ring,serde,serde_json,tracing,tracing-log" \
             --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -140,7 +140,13 @@ jobs:
         with:
           go-version: 'stable'
 
-      - run: cargo hack check --feature-powerset --depth 3 --optional-deps --no-dev-deps --ignore-private --skip "${{env.SKIP_FEATURES}}"
+      # --no-dev-deps rewrites Cargo.toml while cargo-hack runs, which makes
+      # cargo want to regenerate Cargo.lock -- so --locked is rejected here
+      # ("cannot update the lock file ... because --locked was passed").
+      # Fetch the locked dependency set first and then run offline: same
+      # guarantee in practice, since nothing new can be pulled mid-run.
+      - run: cargo fetch --locked
+      - run: cargo hack check --offline --feature-powerset --depth 3 --optional-deps --no-dev-deps --ignore-private --skip "${{env.SKIP_FEATURES}}"
 
   notify:
     timeout-minutes: 45

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -162,11 +162,8 @@ jobs:
         with:
           go-version: 'stable'
 
-      # --no-dev-deps rewrites Cargo.toml while cargo-hack runs, which makes
-      # cargo want to regenerate Cargo.lock -- so --locked is rejected here
-      # ("cannot update the lock file ... because --locked was passed").
-      # Fetch the locked dependency set first and then run offline: same
-      # guarantee in practice, since nothing new can be pulled mid-run.
+      # --no-dev-deps rewrites Cargo.toml mid-run, so cargo rejects --locked.
+      # Fetch locked first, then run offline -- same guarantee.
       - run: cargo fetch --locked
       - run: cargo hack check --offline --feature-powerset --depth 3 --optional-deps --no-dev-deps --ignore-private --skip "$SKIP_FEATURES"
 

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -17,6 +17,10 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   proptests:
     name: Extended Proptest Run
@@ -25,19 +29,25 @@ jobs:
     env:
       RUSTC_WRAPPER: "sccache"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
         with:
           tool: nextest@0.9.80
 
-      - uses: taiki-e/install-action@cargo-make
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: cargo-make
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Run proptests (10 minutes)
         run: cargo make proptests-long
@@ -49,9 +59,11 @@ jobs:
     name: test on freebsd
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: test on freebsd
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093 # v1.5.3
         with:
           usesh: true
           mem: 4096
@@ -74,9 +86,11 @@ jobs:
     name: build on solaris
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: build on Solaris
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@315163f088b66e55bbcc45928bd224d4973b2312 # v1.3.8
         with:
           release: "11.4-gcc"
           usesh: true
@@ -99,10 +113,12 @@ jobs:
     name: test on illumos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: test on Illumos
         # pinned: v1 tag moves and builder v2.0.3+ ships a VM with broken DNS
-        uses: vmactions/omnios-vm@4f4fcbf0847b079a6e0eafe6ff06b3d15510f0b0
+        uses: vmactions/omnios-vm@4f4fcbf0847b079a6e0eafe6ff06b3d15510f0b0 # v1.1.5
         with:
           usesh: true
           mem: 4096
@@ -131,12 +147,18 @@ jobs:
       # skip FIPS features outside of Linux
       SKIP_FEATURES: ${{ matrix.os != 'linux' && 'aws-lc-rs-fips,aws-lc-fips-sys,__rustls-post-quantum-test' || '' }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-hack
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: cargo-hack
       - name: Setup Go (required for aws-lc-rs FIPS)
         if: matrix.os == 'linux'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: 'stable'
 
@@ -146,7 +168,7 @@ jobs:
       # Fetch the locked dependency set first and then run offline: same
       # guarantee in practice, since nothing new can be pulled mid-run.
       - run: cargo fetch --locked
-      - run: cargo hack check --offline --feature-powerset --depth 3 --optional-deps --no-dev-deps --ignore-private --skip "${{env.SKIP_FEATURES}}"
+      - run: cargo hack check --offline --feature-powerset --depth 3 --optional-deps --no-dev-deps --ignore-private --skip "$SKIP_FEATURES"
 
   notify:
     timeout-minutes: 45
@@ -155,14 +177,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract test results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          printf '${{ toJSON(needs) }}\n'
+          printf '%s\n' "$NEEDS_JSON"
 
-          proptests_result=$(echo '${{ toJSON(needs) }}' | jq -r '.proptests.result')
-          freebsd_result=$(echo '${{ toJSON(needs) }}' | jq -r '.["test-freebsd"].result')
-          solaris_result=$(echo '${{ toJSON(needs) }}' | jq -r '.["build-solaris"].result')
-          illumos_result=$(echo '${{ toJSON(needs) }}' | jq -r '.["test-illumos"].result')
-          features_result=$(echo '${{ toJSON(needs) }}' | jq -r '.features.result')
+          proptests_result=$(echo "$NEEDS_JSON" | jq -r '.proptests.result')
+          freebsd_result=$(echo "$NEEDS_JSON" | jq -r '.["test-freebsd"].result')
+          solaris_result=$(echo "$NEEDS_JSON" | jq -r '.["build-solaris"].result')
+          illumos_result=$(echo "$NEEDS_JSON" | jq -r '.["test-illumos"].result')
+          features_result=$(echo "$NEEDS_JSON" | jq -r '.features.result')
 
           # Check if any failed
           if [ "$proptests_result" = "failure" ] || [ "$freebsd_result" = "failure" ] || [ "$solaris_result" = "failure" ] || [ "$illumos_result" = "failure" ] || [ "$features_result" = "failure" ]; then
@@ -184,7 +208,7 @@ jobs:
           echo "EOF" >>"$GITHUB_ENV"
 
       - name: Notify discord on failure
-        uses: n0-computer/discord-webhook-notify@v1
+        uses: n0-computer/discord-webhook-notify@1399c1b2d57cc05894d506d2cfdc33c5f012b993 # v1.1.1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           text: "Daily CI failures in **${{ github.repository }}**"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,9 +12,15 @@ on:
 concurrency:
   group: ci-docs-preview
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   preview_docs:
-    permissions: write-all
+    permissions:
+      contents: write        # peaceiris/actions-gh-pages pushes the preview
+      pull-requests: write   # find-comment / create-or-update-comment
     timeout-minutes: 30
     name: Docs preview
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -26,12 +32,14 @@ jobs:
       PREVIEW_PATH: pr/${{ github.event.pull_request.number || inputs.pr_number }}/docs
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@master
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: nightly-2025-10-09
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
+      uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
     - name: Generate Docs
       run: cargo doc --locked --workspace --all-features --no-deps
@@ -39,7 +47,7 @@ jobs:
         RUSTDOCFLAGS: --cfg docsrs
 
     - name: Deploy Docs to Preview Branch
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/doc/
@@ -47,7 +55,7 @@ jobs:
         publish_branch: generated-docs-preview
 
     - name: Find Docs Comment
-      uses: peter-evans/find-comment@v4
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number || inputs.pr_number }}
@@ -59,7 +67,7 @@ jobs:
       run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
     - name: Create or Update Docs Comment
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ github.event.pull_request.number || inputs.pr_number }}
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -34,7 +34,7 @@ jobs:
       uses: mozilla-actions/sccache-action@v0.0.9
 
     - name: Generate Docs
-      run: cargo doc --workspace --all-features --no-deps
+      run: cargo doc --locked --workspace --all-features --no-deps
       env:
         RUSTDOCFLAGS: --cfg docsrs
 

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -95,10 +95,8 @@ jobs:
           sed -i -E "/^noq = \"[0-9.]+\"/s/\"[0-9.]+\"/$NOQ_VERSION/" iroh/bench/Cargo.toml
 
 
-      # No --locked in this job by design: it rewrites iroh's Cargo.toml to
-      # point [patch.crates-io] at this checkout, which necessarily
-      # regenerates iroh's lockfile. Dependency pinning here belongs to
-      # the iroh repo, not to us.
+      # No --locked: patching iroh to this checkout regenerates iroh's
+      # lockfile. Pinning there is the iroh repo's job.
       - name: Build patchbay tests
         working-directory: iroh
         run: cargo make patchbay --no-run

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -87,6 +87,10 @@ jobs:
           sed -i -E "/^noq = \"[0-9.]+\"/s/\"[0-9.]+\"/$NOQ_VERSION/" iroh/bench/Cargo.toml
 
 
+      # No --locked in this job by design: it rewrites iroh's Cargo.toml to
+      # point [patch.crates-io] at this checkout, which necessarily
+      # regenerates iroh's lockfile. Dependency pinning here belongs to
+      # the iroh repo, not to us.
       - name: Build patchbay tests
         working-directory: iroh
         run: cargo make patchbay --no-run

--- a/.github/workflows/iroh-patchbay.yml
+++ b/.github/workflows/iroh-patchbay.yml
@@ -17,6 +17,10 @@ env:
   IROH_FORCE_STAGING_RELAYS: "1"
   NEXTEST_VERSION: "0.9.80"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   iroh_patchbay:
     name: iroh patchbay
@@ -30,21 +34,25 @@ jobs:
         continue-on-error: true
 
       - name: Checkout noq
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: noq
+          persist-credentials: false
 
       - name: Checkout iroh
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: n0-computer/iroh
           ref: main
           path: iroh
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - name: Install cargo-make and cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
         with:
           tool: nextest@${{ env.NEXTEST_VERSION }},cargo-make
 
@@ -106,7 +114,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: iroh-patchbay-testdir-${{ github.sha }}
           path: |

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -63,7 +63,7 @@ jobs:
             https://github.com/quinn-rs/quinn.git /tmp/upstream-quinn
 
       - name: Build perf binary
-        run: cargo build --release -p perf --features json-output
+        run: cargo build --locked --release -p perf --features json-output
         working-directory: ${{ matrix.impl == 'upstream-quinn' && '/tmp/upstream-quinn' || '.' }}
 
       - name: Upload binary

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -26,6 +26,10 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ matrix.impl }} perf
@@ -40,12 +44,16 @@ jobs:
           - impl: upstream-quinn
             artifact: quinn-perf-upstream
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         if: matrix.impl == 'noq'
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Get latest quinn release tag
         if: matrix.impl == 'upstream-quinn'
@@ -59,15 +67,17 @@ jobs:
         if: matrix.impl == 'upstream-quinn'
         run: |
           rm -rf /tmp/upstream-quinn
-          git clone --depth 1 --branch ${{ steps.quinn-release.outputs.tag }} \
+          git clone --depth 1 --branch ${STEPS_QUINN_RELEASE_OUTPUTS_TAG} \
             https://github.com/quinn-rs/quinn.git /tmp/upstream-quinn
+        env:
+          STEPS_QUINN_RELEASE_OUTPUTS_TAG: ${{ steps.quinn-release.outputs.tag }}
 
       - name: Build perf binary
         run: cargo build --locked --release -p perf --features json-output
         working-directory: ${{ matrix.impl == 'upstream-quinn' && '/tmp/upstream-quinn' || '.' }}
 
       - name: Upload binary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.impl == 'upstream-quinn' && '/tmp/upstream-quinn/target/release/quinn-perf' || 'target/release/noq-perf' }}
@@ -88,9 +98,11 @@ jobs:
           - impl: upstream-quinn
             artifact: quinn-perf-upstream
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ${{ matrix.artifact }}
           path: ./bin
@@ -101,7 +113,7 @@ jobs:
           chmod +x "$PERF_BIN"
           ./.github/scripts/run_perf.sh "$PERF_BIN" results/${{ matrix.impl }}
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: raw-results-${{ matrix.impl }}
           path: results/
@@ -122,9 +134,11 @@ jobs:
           - impl: upstream-quinn
             artifact: quinn-perf-upstream
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: ${{ matrix.artifact }}
           path: ./bin
@@ -165,7 +179,7 @@ jobs:
           cp /tmp/chuck/netsim/report/*.json results/${{ matrix.impl }}/ 2>/dev/null || true
           cp /tmp/chuck/netsim/logs/*.log results/${{ matrix.impl }}/ 2>/dev/null || true
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         if: always()
         with:
           name: netsim-results-${{ matrix.impl }}
@@ -179,28 +193,33 @@ jobs:
           ./cleanup.sh || true
 
   compare:
+    permissions:
+      contents: read
+      pull-requests: write   # posts the comparison comment
     name: Compare results
     needs: [raw-perf, netsim-perf]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: raw-results-*
           merge-multiple: true
           path: raw-results/
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           pattern: netsim-results-*
           merge-multiple: true
           path: netsim-results/
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -226,7 +245,7 @@ jobs:
           cat metro.json
 
       - name: Upload comparison report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: perf-comparison-report
           path: |
@@ -249,7 +268,7 @@ jobs:
 
       - name: Find existing comment
         if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find-comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -258,7 +277,7 @@ jobs:
 
       - name: Create new PR comment
         if: github.event_name == 'pull_request' && steps.find-comment.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -274,7 +293,7 @@ jobs:
 
       - name: Update existing PR comment
         if: github.event_name == 'pull_request' && steps.find-comment.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           edit-mode: append

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,24 +100,24 @@ jobs:
           do
             echo "Checking $i $FEATURES"
             targets="--lib --bins"
-            echo cargo check -p $i $FEATURES $targets
-            cargo check -p $i $FEATURES $targets
+            echo cargo check --locked -p $i $FEATURES $targets
+            cargo check --locked -p $i $FEATURES $targets
           done
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
       - name: build tests
         run: |
-          cargo nextest run --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --no-run
+          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --no-run
 
       - name: list ignored tests
         run: |
-          cargo nextest list --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
+          cargo nextest list --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
 
       - name: run tests
         run: |
           mkdir -p output
-          cargo nextest run --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} ${{ inputs.flaky && '--verbose' || '' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} ${{ inputs.flaky && '--verbose' || '' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
           NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
@@ -136,7 +136,7 @@ jobs:
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         run: |
-          cargo test --workspace --all-features --doc
+          cargo test --locked --workspace --all-features --doc
 
       - name: Check doctest features
         if: ${{ ! inputs.flaky }}
@@ -146,8 +146,8 @@ jobs:
           for i in ${CRATES_LIST//,/ }
           do
             echo "Checking $i doctest $FEATURES"
-            echo cargo test -p $i --doc $FEATURES
-            cargo test -p $i --doc $FEATURES
+            echo cargo test --locked -p $i --doc $FEATURES
+            cargo test --locked -p $i --doc $FEATURES
           done
 
       - uses: taiki-e/install-action@cargo-make
@@ -287,16 +287,16 @@ jobs:
 
       - name: build tests
         run: |
-          cargo nextest run --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
 
       - name: list ignored tests
         run: |
-          cargo nextest list --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+          cargo nextest list --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
 
       - name: tests
         run: |
           mkdir -p output
-          cargo nextest run --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
           NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
@@ -352,6 +352,15 @@ jobs:
           go-version: "stable"
           cache: false
       - name: cargo check
+        # Deliberately NOT --locked: this job deletes Cargo.lock so that
+        # -Z minimal-versions can re-resolve every dependency down to its
+        # lowest semver-compatible version. That full re-resolution is the
+        # whole point of the job -- and it is also why this is the one job in
+        # the repo that can select a crates.io version the committed lockfile
+        # has never seen. A yank-storm that removes every version satisfying a
+        # range leaves the attacker's release as the only selectable one, so
+        # "minimal" does not imply "old". Rely on the Dependabot cooldown and
+        # on cargo-deny for this job, not on the lockfile.
         run: |
           rm -f Cargo.lock
           cargo +nightly check -Z minimal-versions --workspace --exclude fuzz --all-features --lib --bins
@@ -451,6 +460,15 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: cargo check
+        # Deliberately NOT --locked: this job deletes Cargo.lock so that
+        # -Z minimal-versions can re-resolve every dependency down to its
+        # lowest semver-compatible version. That full re-resolution is the
+        # whole point of the job -- and it is also why this is the one job in
+        # the repo that can select a crates.io version the committed lockfile
+        # has never seen. A yank-storm that removes every version satisfying a
+        # range leaves the attacker's release as the only selectable one, so
+        # "minimal" does not imply "old". Rely on the Dependabot cooldown and
+        # on cargo-deny for this job, not on the lockfile.
         run: |
           rm -Force Cargo.lock
           cargo +nightly check -Z minimal-versions --workspace --exclude fuzz --all-features --lib --bins

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,10 @@ env:
   CRATES_LIST: "noq,noq-proto,noq-udp"
   NEXTEST_VERSION: "0.9.80"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   build_and_test_nix:
     timeout-minutes: 30
@@ -54,26 +58,27 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.git-ref }}
+          persist-credentials: false
 
       - name: Install ${{ matrix.rust }} rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ matrix.rust }}
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
         with:
           tool: nextest@${{ env.NEXTEST_VERSION }}
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       # Go is required for FIPS builds (aws-lc-rs-fips feature)
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "stable"
 
@@ -108,23 +113,27 @@ jobs:
 
       - name: build tests
         run: |
-          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --no-run
+          cargo nextest run --locked --workspace --exclude fuzz $FEATURES --lib --bins --tests --no-run
 
       - name: list ignored tests
         run: |
-          cargo nextest list --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
+          cargo nextest list --locked --workspace --exclude fuzz $FEATURES --lib --bins --tests --run-ignored ignored-only
 
       - name: run tests
         run: |
           mkdir -p output
-          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} ${{ inputs.flaky && '--verbose' || '' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+          cargo nextest run --locked --workspace --exclude fuzz $FEATURES --lib --bins --tests --profile ci --run-ignored "$RUN_IGNORED" $VERBOSE --no-fail-fast --message-format "$MSG_FORMAT" > "output/${OUT_NAME}.json"
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
           NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+          RUN_IGNORED: ${{ inputs.flaky && 'all' || 'default' }}
+          VERBOSE: ${{ inputs.flaky && '--verbose' || '' }}
+          MSG_FORMAT: ${{ inputs.flaky && 'libtest-json' || 'human' }}
+          OUT_NAME: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}
 
       - name: upload results
         if: ${{ failure() && inputs.flaky }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
           path: output
@@ -150,7 +159,9 @@ jobs:
             cargo test --locked -p $i --doc $FEATURES
           done
 
-      - uses: taiki-e/install-action@cargo-make
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: cargo-make
 
       - name: run proptests (1 minute minimum)
         if: ${{ ! inputs.flaky }}
@@ -180,20 +191,24 @@ jobs:
       BINDGEN_EXTRA_CLANG_ARGS: "--target=x86_64-pc-windows-msvc"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.git-ref }}
+          persist-credentials: false
 
       - name: Install ${{ matrix.rust }}
+        env:
+          RUST_TOOLCHAIN: ${{ matrix.rust }}
+          RUST_TARGET: ${{ matrix.target }}
         run: |
-          rustup toolchain install ${{ matrix.rust }}
-          rustup toolchain default ${{ matrix.rust }}
-          rustup target add ${{ matrix.target }}
-          rustup set default-host ${{ matrix.target }}
+          rustup toolchain install $env:RUST_TOOLCHAIN
+          rustup toolchain default $env:RUST_TOOLCHAIN
+          rustup target add $env:RUST_TARGET
+          rustup set default-host $env:RUST_TARGET
 
       - name: Cache cargo-nextest
         id: cache-nextest
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin/cargo-nextest.exe
           key: nextest-windows-${{ env.NEXTEST_VERSION }}
@@ -226,24 +241,24 @@ jobs:
           }
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           release: false
 
       # FIPS dependencies for Windows
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "stable"
 
       - name: Install NASM
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
 
       - name: Cache Strawberry Perl
         id: cache-perl
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: C:\Strawberry
           key: strawberry-perl-5.38.2.2
@@ -260,12 +275,12 @@ jobs:
           echo "C:\Strawberry\c\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install cmake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
 
       # Install LLVM for libclang (required by bindgen for aws-lc-fips-sys)
       - name: Cache LLVM
         id: cache-llvm
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: C:\Program Files\LLVM
           key: llvm-17.0.6-windows
@@ -283,27 +298,38 @@ jobs:
           echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Setup MSVC dev environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: build tests
+        env:
+          RUST_TARGET: ${{ matrix.target }}
         run: |
-          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+          $feat = if ($env:FEATURES) { $env:FEATURES -split '\s+' } else { @() }
+          cargo nextest run --locked --workspace --exclude fuzz @feat --lib --bins --tests --target $env:RUST_TARGET --no-run
 
       - name: list ignored tests
+        env:
+          RUST_TARGET: ${{ matrix.target }}
         run: |
-          cargo nextest list --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+          $feat = if ($env:FEATURES) { $env:FEATURES -split '\s+' } else { @() }
+          cargo nextest list --locked --workspace --exclude fuzz @feat --lib --bins --tests --target $env:RUST_TARGET --run-ignored ignored-only
 
       - name: tests
         run: |
           mkdir -p output
-          cargo nextest run --locked --workspace --exclude fuzz ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+          $feat = if ($env:FEATURES) { $env:FEATURES -split '\s+' } else { @() }
+          cargo nextest run --locked --workspace --exclude fuzz @feat --lib --bins --tests --profile ci --target $env:RUST_TARGET --run-ignored $env:RUN_IGNORED --no-fail-fast --message-format $env:MSG_FORMAT > "output/$($env:OUT_NAME).json"
         env:
           RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
           NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
+          RUST_TARGET: ${{ matrix.target }}
+          RUN_IGNORED: ${{ inputs.flaky && 'all' || 'default' }}
+          MSG_FORMAT: ${{ inputs.flaky && 'libtest-json' || 'human' }}
+          OUT_NAME: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}
 
       - name: upload results
         if: ${{ failure() && inputs.flaky }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
           path: output
@@ -312,7 +338,7 @@ jobs:
 
       - name: Cache cargo-make
         id: cache-cargo-make
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin/cargo-make.exe
           key: cargo-make-windows-0.37.24
@@ -327,7 +353,10 @@ jobs:
 
   minimal-crates:
     timeout-minutes: 45
+    # Ephemeral only: this job runs build scripts from unvetted versions.
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -337,38 +366,45 @@ jobs:
             os: ubuntu-latest
             release-os: linux
             release-arch: amd64
-            runner: [self-hosted, linux, X64]
+            runner: ubuntu-latest
           - name: macOS-arm-latest
             os: macOS-latest
             release-os: darwin
             release-arch: aarch64
-            runner: [self-hosted, macOS, ARM64]
+            runner: macos-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # Keep the token out of .git/config, readable by any build script.
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly
       - name: Install Go (required for aws-lc-rs FIPS)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "stable"
           cache: false
       - name: cargo check
-        # Deliberately NOT --locked: this job deletes Cargo.lock so that
-        # -Z minimal-versions can re-resolve every dependency down to its
-        # lowest semver-compatible version. That full re-resolution is the
-        # whole point of the job -- and it is also why this is the one job in
-        # the repo that can select a crates.io version the committed lockfile
-        # has never seen. A yank-storm that removes every version satisfying a
-        # range leaves the attacker's release as the only selectable one, so
-        # "minimal" does not imply "old". Rely on the Dependabot cooldown and
-        # on cargo-deny for this job, not on the lockfile.
+        # No --locked: re-resolving is the point, which makes this the one job
+        # that can pick a version the lockfile has never seen. -Z min-publish-age
+        # covers that, refusing versions younger than the window. Inline flag
+        # only -- the config.toml form is silently ignored on stable.
+        # (A Dependabot cooldown gates PRs, not CI resolution.)
         run: |
           rm -f Cargo.lock
-          cargo +nightly check -Z minimal-versions --workspace --exclude fuzz --all-features --lib --bins
+          cargo +nightly check -Z minimal-versions -Z min-publish-age \
+            --config 'registry.global-min-publish-age="3 days"' \
+            --workspace --exclude fuzz --all-features --lib --bins
 
   minimal-crates-windows:
     timeout-minutes: 30
     name: "Minimal Crates (Windows)"
+    # Still self-hosted; moving to windows-latest needs sccache switched to
+    # SCCACHE_GHA_ENABLED. Follow-up.
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -388,9 +424,10 @@ jobs:
       BINDGEN_EXTRA_CLANG_ARGS: "--target=x86_64-pc-windows-msvc"
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ inputs.git-ref }}
+          persist-credentials: false
 
       - name: Install Rust nightly
         run: |
@@ -399,21 +436,21 @@ jobs:
           rustup set default-host ${{ matrix.target }}
 
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
         with:
           release: false
 
       - name: Install cmake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
 
       - name: Install NASM
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
 
       - name: Cache Strawberry Perl
         id: cache-perl
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: C:\Strawberry
           key: strawberry-perl-5.38.2.2
@@ -430,7 +467,7 @@ jobs:
           echo "C:\Strawberry\c\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Go (required for aws-lc-rs FIPS)
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "stable"
           cache: false
@@ -438,7 +475,7 @@ jobs:
       # Install LLVM for libclang (required by bindgen for aws-lc-fips-sys)
       - name: Cache LLVM
         id: cache-llvm
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: C:\Program Files\LLVM
           key: llvm-17.0.6-windows
@@ -457,18 +494,16 @@ jobs:
 
       # Set up MSVC environment to ensure clang/bindgen uses MSVC headers instead of mingw
       - name: Setup MSVC dev environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: cargo check
-        # Deliberately NOT --locked: this job deletes Cargo.lock so that
-        # -Z minimal-versions can re-resolve every dependency down to its
-        # lowest semver-compatible version. That full re-resolution is the
-        # whole point of the job -- and it is also why this is the one job in
-        # the repo that can select a crates.io version the committed lockfile
-        # has never seen. A yank-storm that removes every version satisfying a
-        # range leaves the attacker's release as the only selectable one, so
-        # "minimal" does not imply "old". Rely on the Dependabot cooldown and
-        # on cargo-deny for this job, not on the lockfile.
+        # No --locked: re-resolving is the point, which makes this the one job
+        # that can pick a version the lockfile has never seen. -Z min-publish-age
+        # covers that, refusing versions younger than the window. Inline flag
+        # only -- the config.toml form is silently ignored on stable.
+        # (A Dependabot cooldown gates PRs, not CI resolution.)
         run: |
           rm -Force Cargo.lock
-          cargo +nightly check -Z minimal-versions --workspace --exclude fuzz --all-features --lib --bins
+          cargo +nightly check -Z minimal-versions -Z min-publish-age `
+            --config 'registry.global-min-publish-age="3 days"' `
+            --workspace --exclude fuzz --all-features --lib --bins

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -386,11 +386,9 @@ jobs:
           go-version: "stable"
           cache: false
       - name: cargo check
-        # No --locked: re-resolving is the point, which makes this the one job
-        # that can pick a version the lockfile has never seen. -Z min-publish-age
-        # covers that, refusing versions younger than the window. Inline flag
-        # only -- the config.toml form is silently ignored on stable.
-        # (A Dependabot cooldown gates PRs, not CI resolution.)
+        # No --locked: re-resolving is the point, so -Z min-publish-age guards
+        # the versions the lockfile has never seen. Inline flag only, the
+        # config.toml form is ignored on stable.
         run: |
           rm -f Cargo.lock
           cargo +nightly check -Z minimal-versions -Z min-publish-age \
@@ -497,11 +495,9 @@ jobs:
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: cargo check
-        # No --locked: re-resolving is the point, which makes this the one job
-        # that can pick a version the lockfile has never seen. -Z min-publish-age
-        # covers that, refusing versions younger than the window. Inline flag
-        # only -- the config.toml form is silently ignored on stable.
-        # (A Dependabot cooldown gates PRs, not CI resolution.)
+        # No --locked: re-resolving is the point, so -Z min-publish-age guards
+        # the versions the lockfile has never seen. Inline flag only, the
+        # config.toml form is ignored on stable.
         run: |
           rm -Force Cargo.lock
           cargo +nightly check -Z minimal-versions -Z min-publish-age `

--- a/.github/workflows/wine.yaml
+++ b/.github/workflows/wine.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build tests
         # Release mode required - debug builds exceed mingw's export ordinal limit (~65k symbols)
-        run: cargo build --target x86_64-pc-windows-gnu --tests --release
+        run: cargo build --locked --target x86_64-pc-windows-gnu --tests --release
 
       - name: List available tests
         run: |

--- a/.github/workflows/wine.yaml
+++ b/.github/workflows/wine.yaml
@@ -15,12 +15,18 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   wine_test:
     name: Wine Sanity Check
     runs-on: [self-hosted, linux, X64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Install Wine
         run: |
@@ -35,8 +41,9 @@ jobs:
           WINEARCH=win64 wineboot --init
 
       - name: Install Rust + mingw target
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          toolchain: stable
           targets: x86_64-pc-windows-gnu
 
       - name: Install mingw-w64

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -28,17 +28,16 @@ jobs:
       - run: zizmor --offline .
 
   pinact:
-    # Fails if a pinned SHA no longer matches its version comment, or if a pin
-    # is younger than the cooldown in .pinact.yaml.
+    # Fails if a pinned SHA drifts from its version comment, or is younger
+    # than the cooldown in .pinact.yaml.
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
-      # Installed from the release tarball with a checksum check rather than
-      # via pinact-action, which is built to push commits and wants
-      # contents:write. This job only reads.
+      # Release tarball + checksum instead of pinact-action, which wants
+      # contents:write to push commits. This job only reads.
       - name: Install pinact
         env:
           PINACT_VERSION: "4.1.1"

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,55 @@
+# Static analysis of our own workflows. The tree is clean, so this gates on
+# every finding, not just High.
+name: workflow lint
+
+on:
+  pull_request:
+    paths: ['.github/workflows/**']
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
+        with:
+          tool: zizmor
+      # whole repo, not just workflows/ -- dependabot.yml is audited too
+      - run: zizmor --offline .
+
+  pinact:
+    # Fails if a pinned SHA no longer matches its version comment, or if a pin
+    # is younger than the cooldown in .pinact.yaml.
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+      # Installed from the release tarball with a checksum check rather than
+      # via pinact-action, which is built to push commits and wants
+      # contents:write. This job only reads.
+      - name: Install pinact
+        env:
+          PINACT_VERSION: "4.1.1"
+        run: |
+          set -euo pipefail
+          base="https://github.com/suzuki-shunsuke/pinact/releases/download/v${PINACT_VERSION}"
+          curl -fsSL -O "$base/pinact_linux_amd64.tar.gz"
+          curl -fsSL -O "$base/pinact_${PINACT_VERSION}_checksums.txt"
+          grep ' pinact_linux_amd64.tar.gz$' "pinact_${PINACT_VERSION}_checksums.txt" | sha256sum -c -
+          tar xzf pinact_linux_amd64.tar.gz pinact
+          install -m755 pinact /usr/local/bin/pinact
+      - run: pinact run --check --verify-comment --verify-min-age
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+version: 3
+
+min_age:
+  value: 7 # days, matches the dependabot cooldown
+
+# These three have no semver tag upstream to pin against, so the comment cannot
+# be verified against a release. Each is a fork or a tool-named tag; revisit
+# rather than leave indefinitely.
+rules:
+  - ignore: true
+    conditions:
+      # fork of nttld/setup-ndk, 1 commit ahead since 2024-07 ("allow other
+      # hosts"). Upstream has v1.6.0 -- upstream the patch and switch.
+      - expr: |
+          ActionName == "arqu/setup-ndk"
+  - ignore: true
+    conditions:
+      # every tag in dtolnay/install is a tool name, none semver.
+      - expr: |
+          ActionName == "dtolnay/install"
+  - ignore: true
+    conditions:
+      # fork of obi1kenobi/cargo-semver-checks-action, which is now at v2.9.
+      # Check whether the baseline feature landed upstream.
+      - expr: |
+          ActionName == "n0-computer/cargo-semver-checks-action"

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -4,24 +4,23 @@ version: 3
 min_age:
   value: 7 # days, matches the dependabot cooldown
 
-# These three have no semver tag upstream to pin against, so the comment cannot
-# be verified against a release. Each is a fork or a tool-named tag; revisit
-# rather than leave indefinitely.
+# No semver tag upstream to verify the version comment against. Forks and
+# tool-named tags; revisit rather than leave indefinitely.
 rules:
   - ignore: true
     conditions:
-      # fork of nttld/setup-ndk, 1 commit ahead since 2024-07 ("allow other
-      # hosts"). Upstream has v1.6.0 -- upstream the patch and switch.
+      # fork of nttld/setup-ndk, 1 commit ahead ("allow other hosts").
+      # Upstream the patch and switch to v1.6.0.
       - expr: |
           ActionName == "arqu/setup-ndk"
   - ignore: true
     conditions:
-      # every tag in dtolnay/install is a tool name, none semver.
+      # dtolnay/install tags are tool names, not semver.
       - expr: |
           ActionName == "dtolnay/install"
   - ignore: true
     conditions:
-      # fork of obi1kenobi/cargo-semver-checks-action, which is now at v2.9.
-      # Check whether the baseline feature landed upstream.
+      # fork of obi1kenobi/cargo-semver-checks-action (now v2.9); check if the
+      # baseline feature landed upstream.
       - expr: |
           ActionName == "n0-computer/cargo-semver-checks-action"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,9 +1263,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -113,6 +113,6 @@ args = ["nextest", "run", "--package=noq-proto", "-P", "proptests", "--no-fail-f
 [tasks.check-external-types]
 description = "Run cargo check-external-types on workspace crates"
 workspace = true
-toolchain = "${TOOLCHAIN:nightly-2025-10-18}"
+toolchain = "${TOOLCHAIN:nightly-2026-03-20}"
 command = "cargo"
-args = ["check-external-types", "--features", "__all_without_fips"]
+args = ["check-external-types", "--locked", "--features", "__all_without_fips"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -96,13 +96,13 @@ args = [
 [tasks.proptests-long]
 description = "Run proptests with high case count (runs for ~10 minutes)"
 command = "cargo"
-args = ["nextest", "run", "--package=noq-proto", "-P", "proptests", "--cargo-profile=proptests", "--no-fail-fast", "${@}"]
+args = ["nextest", "run", "--locked", "--package=noq-proto", "-P", "proptests", "--cargo-profile=proptests", "--no-fail-fast", "${@}"]
 env = { "PROPTEST_CASES" = "100000" }
 
 [tasks.proptests-light]
 description = "Run proptests for CI (~1 minute)"
 command = "cargo"
-args = ["nextest", "run", "--package=noq-proto", "-P", "proptests", "--cargo-profile=proptests", "--no-fail-fast", "${@}"]
+args = ["nextest", "run", "--locked", "--package=noq-proto", "-P", "proptests", "--cargo-profile=proptests", "--no-fail-fast", "${@}"]
 env = { "PROPTEST_CASES" = "10000" }
 
 [tasks.proptests-extralight]

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,8 @@
 [advisories]
+# A yanked dependency is how the 2026-08-20 arrayref attack was staged: yank
+# the versions satisfying a range so the malicious upload is the only one left.
+# Fail on it rather than warn.
+yanked = "deny"
 ignore = [
     # gcc is only included as a minimal-versions workaround, not actually used
     "RUSTSEC-2025-0121",

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,6 @@
 [advisories]
-# A yanked dependency is how the 2026-08-20 arrayref attack was staged: yank
-# the versions satisfying a range so the malicious upload is the only one left.
-# Fail on it rather than warn.
+# Yanking is how the 2026-08-20 arrayref attack was staged: yank every version
+# satisfying a range so the malicious upload is the only one left.
 yanked = "deny"
 ignore = [
     # gcc is only included as a minimal-versions workaround, not actually used


### PR DESCRIPTION
## Description

- Uses `--locked` to ensure we only use deps from the lock file
- Adds cooldown period to dependabot
- pins actions versions
- introduces zizimor and pinact

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the -->
<!-- PR. -->

## Change checklist
<!-- Remove any that are not relevant. -->
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
- [ ] This PR was created by a human that thought critically about the
      proposed change and wrote an as clear and concise description as
      they could.
- [ ] This PR isn't slop, and is carefully crafted to do have the
      intented effect.
- [ ] `cargo make` passes locally.
